### PR TITLE
core: fix Module#=== and Object.=== to not fail

### DIFF
--- a/core/object.rb
+++ b/core/object.rb
@@ -1,8 +1,4 @@
 class Object
-  def self.===(other)
-    `other != null && other.o$klass`
-  end
-
   include Kernel
 
   # FIXME


### PR DESCRIPTION
Probably you won't like it, but it's really how it should work.
