### PR TITLE
Symbol#[] isn't available for 1.8.7

### DIFF
--- a/lib/opal.rb
+++ b/lib/opal.rb
@@ -1,3 +1,11 @@
+unless Symbol.instance_methods.include? :[]
+  class Symbol
+    def []key
+      to_s[key]
+    end
+  end
+end
+
 require 'opal/parser'
 require 'opal/builder'
 require 'opal/version'

--- a/lib/opal/parser.rb
+++ b/lib/opal/parser.rb
@@ -7,14 +7,6 @@ class Array
   attr_accessor :end_line
 end
 
-unless Symbol.instance_methods.include? :[]
-  class Symbol
-    def []key
-      to_s[key]
-    end
-  end
-end
-
 module Opal
   class OpalParseError < Exception; end
 


### PR DESCRIPTION
Avoiding the `#[]` addition would cost a major effort with no guarantee of success
(the previous version of this pull was an attempt in that way and failed).

**PS** Did you set up travis-ci for opal? you want me to do that?
