### PR TITLE
fix behaviour of puts on arrays to be closer to Ruby's

### DIFF
--- a/core/kernel.rb
+++ b/core/kernel.rb
@@ -218,7 +218,7 @@ module Kernel
 
   def p(*args)
     `console.log.apply(console, args);`
-    args
+    args.length <= 1 ? args[0] : args
   end
 
   alias print puts

--- a/spec/core/kernel/p_spec.rb
+++ b/spec/core/kernel/p_spec.rb
@@ -1,0 +1,13 @@
+describe "Kernel#p" do
+  it "returns nil if called with no arguments" do
+    p.should == nil
+  end
+  
+  it "returns its argument if called with one argument" do
+    p(123).should == 123
+  end
+  
+  it "returns all arguments as an Array if called with multiple arguments" do
+    p(1,2,3).should == [1,2,3]
+  end
+end


### PR DESCRIPTION
This code:

``` ruby
puts [[1, 2], 3], 4
```

outputs this on Ruby:

```
1
2
3
4
```

and this on Opal:

```
[[1, 2], 3], 4
```

This commit fixes that
