### PR TITLE
Fix parse error when newline exist right after rescue

### DIFF
--- a/lib/opal/lexer.rb
+++ b/lib/opal/lexer.rb
@@ -1271,7 +1271,10 @@ module Opal
 
           when 'rescue'
             return :IDENTIFIER, matched if [:expr_dot, :expr_fname].include? @lex_state
-            return :RESCUE, matched if @lex_state == :expr_beg
+            if @lex_state == :expr_beg
+              @lex_state = :expr_mid
+              return :RESCUE, matched
+            end
             @lex_state = :expr_beg
             return :RESCUE_MOD, matched
 

--- a/spec/grammar/begin_spec.rb
+++ b/spec/grammar/begin_spec.rb
@@ -28,6 +28,10 @@ describe "The begin keyword" do
       opal_parse('begin 1; rescue => @a; 2; end').should == [:rescue, [:lit, 1], [:resbody, [:array, [:iasgn, :@a, [:gvar, :$!]]], [:lit, 2]]]
       opal_parse('begin 1; rescue Klass => @a; 2; end').should == [:rescue, [:lit, 1], [:resbody, [:array, [:const, :Klass],[:iasgn, :@a, [:gvar, :$!]]], [:lit, 2]]]
     end
+
+    it "should parse newline right after rescue" do
+      opal_parse("begin; 1; rescue\n 2; end").should == [:rescue, [:lit, 1], [:resbody, [:array], [:lit, 2]]]
+    end
   end
 
   describe "with an 'ensure' block" do


### PR DESCRIPTION
Fixed parse error when newline exist right after rescue.

```
begin
  raise 'foo'
rescue
  puts 'error'
end
```
