### PR TITLE
Support exponential part in float literals

### DIFF
--- a/lib/opal/lexer.rb
+++ b/lib/opal/lexer.rb
@@ -1146,7 +1146,7 @@ module Opal
 
         elsif scanner.check(/[0-9]/)
           @lex_state = :expr_end
-          if scanner.scan(/[\d_]+\.[\d_]+\b/)
+          if scanner.scan(/[\d_]+\.[\d_]+\b|[\d_]+(\.[\d_]+)?[eE][-+]?[\d_]+\b/)
             return [:FLOAT, scanner.matched.gsub(/_/, '').to_f]
           elsif scanner.scan(/[\d_]+\b/)
             return [:INTEGER, scanner.matched.gsub(/_/, '').to_i]

--- a/spec/parser/simple_spec.rb
+++ b/spec/parser/simple_spec.rb
@@ -1,6 +1,9 @@
 describe "Opal::Parser" do
   it "should parse simple ruby values" do
     opal_eval('3.142').should == 3.142
+    opal_eval('123e1').should == 1230.0
+    opal_eval('123E+10').should == 1230000000000.0
+    opal_eval('123e-9').should == 0.000000123
     opal_eval('false').should == false
     opal_eval('true').should == true
     opal_eval('nil').should == nil


### PR DESCRIPTION
Supported exponential part in float literals. eg.

```
123e1
123E+10
123e-9
123.45e+256
```
