### PR TITLE
Fixed `Include` Bug

### DIFF
--- a/opal/opal/class.rb
+++ b/opal/opal/class.rb
@@ -57,6 +57,14 @@ class Class
       for (var idx = 0, length = klass.$included_modules.length; idx < length; idx++) {
         if (klass.$included_modules[idx] === module) {
           return;
+        } 
+      }
+
+      if (klass._super && klass._super.$included_modules) {
+        for (var idx = 0, length = klass._super.$included_modules.length; idx < length; idx++) {
+          if (klass._super.$included_modules[idx] === module) {
+            return;
+          } 
         }
       }
 
@@ -70,11 +78,13 @@ class Class
 
       var donator   = module.prototype,
           prototype = klass.prototype,
-          methods   = module._methods;
-
+          methods   = module._methods,   
+          pmethods =  klass.$instance_methods();
+      
       for (var i = 0, length = methods.length; i < length; i++) {
         var method = methods[i];
-        prototype[method] = donator[method];
+        if (pmethods.indexOf(method.slice(1)) == -1)
+            prototype[method] = donator[method];
       }
 
       if (prototype._smethods) {

--- a/opal/opal/native.rb
+++ b/opal/opal/native.rb
@@ -1,4 +1,4 @@
-module Native
+class Native
   def initialize(native)
     %x{
       if (#{native} == null) {

--- a/spec/core/class/fixtures/classes.rb
+++ b/spec/core/class/fixtures/classes.rb
@@ -7,3 +7,25 @@ module CoreClassSpecs
     end
   end
 end
+module Include
+  module Mod
+    def a
+      'M:a'
+    end
+  end
+
+  class AClass
+    def a
+      'A:a'
+    end
+    include Mod
+  end
+
+  class BClass
+    include Mod
+  end
+
+  class CClass < AClass 
+    include Mod
+  end
+end

--- a/spec/core/class/include_spec.rb
+++ b/spec/core/class/include_spec.rb
@@ -1,0 +1,14 @@
+require File.expand_path('../fixtures/classes', __FILE__)
+describe "Class#include" do 
+  it "should have own method" do 
+    Include::AClass.new.a.should == 'A:a'
+  end
+
+  it "should have included method" do 
+    Include::BClass.new.a.should == "M:a"
+  end
+
+  it "should return own methods with inheritance" do 
+    Include::CClass.new.a.should == "A:a"
+  end
+end

--- a/spec/core_ext/native/fixtures/classes.rb
+++ b/spec/core_ext/native/fixtures/classes.rb
@@ -1,5 +1,4 @@
 require "opal/native"
 
-class NativeSpecs
-  include Native
+class NativeSpecs < Native
 end


### PR DESCRIPTION
Hi.

I fixed the error with `include` method.

Before 

``` ruby
   module M
     def a
       'M:a'
     end
   end

   class A
     include M
     def a
       'A:a'
     end
   end 
   #and
  class B
    def a
      'B:a'
    end
    include M
  end

  A.new.a #=> 'A:a' - ok
  #but
  B.new.a #=> 'M:a' - wrong
```

Also i change `Native` from `module` to `class`. 

Thanks,
