### PR TITLE
Add task for all files.

### DIFF
--- a/spec/ospec/main.rb.erb
+++ b/spec/ospec/main.rb.erb
@@ -9,8 +9,14 @@
 <% end %>
 
 # This file just greps for all spec files in spec/ and requires them
-<% Dir.glob("spec/#{ENV['OPAL_SPEC_DIR'] ? ENV['OPAL_SPEC_DIR'] + '/' : ''}**/*_spec.{rb,opal}").each do |s| %>
-  <% require_asset s.sub(/^spec\//, '').sub(/\.(rb|opal)$/, '') %>
+<% ENV['OPAL_SPEC'].split(',').each do |s| %>
+  <% if File.directory?(s) %>
+    <% Dir.glob(s + "/**/*_spec.{rb, opal}").each do |file| %>
+      <% require_asset file %>
+    <% end %>
+  <% else %>
+    <% require_asset s %>
+  <% end %>
 <% end %>
 
 # All specs have been run, so we notify mspec that we are done


### PR DESCRIPTION
Hi.
I add rule into `Rakefile` now you can tests one files or one dirs.
For example

```
rake spec:core #run all specs into spec/core directory
rake spec:core:array #run all specs into spec/core/array/ directory
rake spec:core:array:allocate #run only allocate_spec.rb intro spec/core/array
```

And it for all dirs into `spec` dir.

When file or dir not found, then raised error.
