### PR TITLE
implement String#clone, String#dup + specs

### DIFF
--- a/opal/opal/string.rb
+++ b/opal/opal/string.rb
@@ -193,6 +193,10 @@ class String < `String`
     `#{self}.charAt(0)`
   end
 
+  def clone
+    `#{self}.slice()`
+  end
+
   def count(str)
     `(#{self}.length - #{self}.replace(new RegExp(str,"g"), '').length) / str.length`
   end
@@ -215,6 +219,8 @@ class String < `String`
       return #{self};
     }
   end
+
+  alias dup clone
 
   alias_native :downcase, :toLowerCase
 

--- a/spec/rubyspec/core/string/clone_spec.rb
+++ b/spec/rubyspec/core/string/clone_spec.rb
@@ -1,0 +1,8 @@
+describe "String#clone" do
+  it "produces a copy of the original" do
+    str = "a string"
+    str_copy = str.dup
+    str_copy.should == str
+    str_copy.object_id.should_not == str.object_id
+  end
+end

--- a/spec/rubyspec/core/string/dup_spec.rb
+++ b/spec/rubyspec/core/string/dup_spec.rb
@@ -1,0 +1,8 @@
+describe "String#dup" do
+  it "produces a copy of the original" do
+    str = "a string"
+    str_copy = str.dup
+    str_copy.should == str
+    str_copy.object_id.should_not == str.object_id
+  end
+end


### PR DESCRIPTION
Implement String#clone and String#dup. Although this a somewhat meaningless operation in JavaScript since Strings are immutable, it prevents code that use them from crashing.
