### PR TITLE
implement String#lines behavior when no block is given

### DIFF
--- a/opal/opal/string.rb
+++ b/opal/opal/string.rb
@@ -221,6 +221,8 @@ class String < `String`
   alias each_char chars
 
   def each_line (separator = $/)
+    return self.split(separator).each unless block_given?
+
     %x{
       var splitted = #{self}.split(separator);
 

--- a/spec/rubyspec/core/string/lines_spec.rb
+++ b/spec/rubyspec/core/string/lines_spec.rb
@@ -1,0 +1,8 @@
+describe "String#lines" do
+  it "should split on the default record separator and return enumerator if not block is given" do
+    "first\nsecond\nthird".lines.class.should == Enumerator
+    "first\nsecond\nthird".lines.entries.class.should == Array
+    "first\nsecond\nthird".lines.entries.size.should == 3
+    "first\nsecond\nthird".lines.entries.should == ["first", "second", "third"]
+  end
+end


### PR DESCRIPTION
Implements the behavior of String#lines when no block is given, which is to return an Enumerator. This allows the following invocation:

```
str = "one\ntwo\nthree"
lines = str.lines.entries
```

This form is often used when processing file data.
