### PR TITLE
preserve trailing separator for String#lines

### DIFF
--- a/opal/opal/string.rb
+++ b/opal/opal/string.rb
@@ -230,10 +230,31 @@ class String < `String`
     return self.split(separator).each unless block_given?
 
     %x{
-      var splitted = #{self}.split(separator);
+      var chomped = #{self.chomp};
+      var trailing_separator = #{self}.length != chomped.length
+      var splitted = chomped.split(separator);
+
+      if (!#{block_given?}) {
+        result = []
+        for (var i = 0, length = splitted.length; i < length; i++) {
+          if (i < length - 1 || trailing_separator) {
+            result.push(splitted[i] + separator);
+          }
+          else {
+            result.push(splitted[i]);
+          }
+        }
+
+        return #{`result`.each};
+      }
 
       for (var i = 0, length = splitted.length; i < length; i++) {
-        #{yield `splitted[i] + separator`}
+        if (i < length - 1 || trailing_separator) {
+          #{yield `splitted[i] + separator`}
+        }
+        else {
+          #{yield `splitted[i]`}
+        }
       }
     }
   end

--- a/spec/rubyspec/core/string/lines_spec.rb
+++ b/spec/rubyspec/core/string/lines_spec.rb
@@ -3,6 +3,7 @@ describe "String#lines" do
     "first\nsecond\nthird".lines.class.should == Enumerator
     "first\nsecond\nthird".lines.entries.class.should == Array
     "first\nsecond\nthird".lines.entries.size.should == 3
-    "first\nsecond\nthird".lines.entries.should == ["first", "second", "third"]
+    "first\nsecond\nthird".lines.entries.should == ["first\n", "second\n", "third"]
+    "first\nsecond\nthird\n".lines.entries.should == ["first\n", "second\n", "third\n"]
   end
 end


### PR DESCRIPTION
I made a slight mistake when implementing String#lines w/o block given. I forgot to preserve the separator.

I also added a fix to not restore the separator on the last entry if it wasn't present in the original string. This behavior is consistent w/ the behavior of Ruby as I deduced from comparing outputs.
