### PR TITLE
implement full MatchData (as is possible) + specs

### DIFF
--- a/opal/opal/regexp.rb
+++ b/opal/opal/regexp.rb
@@ -3,8 +3,8 @@ class Regexp < `RegExp`
     `string.replace(/[\\-\\[\\]\\/\\{\\}\\(\\)\\*\\+\\?\\.\\\\\^\\$\\|]/g, '\\\\$&')`
   end
 
-  def self.new(string, options = undefined)
-    `new RegExp(string, options)`
+  def self.new(regexp, options = undefined)
+    `new RegExp(regexp, options)`
   end
 
   def ==(other)
@@ -36,19 +36,35 @@ class Regexp < `RegExp`
 
   alias_native :inspect, :toString
 
-  def match(pattern, pos = undefined)
+  def match(string, pos = undefined)
     %x{
-      var result  = #{self}.exec(pattern);
+      var re = #{self};
+      if (!#{self}.global) {
+        re = new RegExp(re.source, 'g' + (#{self}.multiline ? 'm' : '') + (#{self}.ignoreCase ? 'i' : ''));
+      }
+
+      var result  = re.exec(string);
 
       if (result) {
-        result.$to_s    = match_to_s;
-        result.$inspect = match_inspect;
         result._klass = #{MatchData};
+        result.$begin = match_begin;
+        result.$captures = match_captures;
+        result.$inspect = match_inspect;
+        result._post_match = #{$' = `string.substr(re.lastIndex)`};
+        result.$post_match = match_post_match;
+        result._pre_match = #{$` = `string.substr(0, re.lastIndex - result[0].length)`};
+        result.$pre_match = match_pre_match;
+        result._regexp = #{self};
+        result.$regexp = match_regexp;
+        result.$string = match_string;
+        result.$to_a = match_to_a;
+        result.$to_s = match_to_s;
+        result.$values_at = match_values_at;
 
         return #{$~ = `result`};
       }
       else {
-        return #{$~ = nil};
+        return #{$~ = $` = $' = nil};
       }
     }
   end
@@ -58,12 +74,67 @@ class Regexp < `RegExp`
   end
 
   %x{
-    function match_to_s() {
-      return this[0];
+    function match_begin(pos) {
+      if (pos == 0 || pos == 1) {
+        return this.index;
+      }
+      else {
+        #{raise ArgumentError, 'MatchData#begin only supports 0th element'};
+      }
+    }
+
+    function match_captures() {
+      return this.slice(1);
     }
 
     function match_inspect() {
       return "<#MatchData " + this[0].$inspect() + ">";
+    }
+
+    function match_post_match() {
+      return this._post_match;
+    }
+
+    function match_pre_match() {
+      return this._pre_match;
+    }
+
+    function match_regexp() {
+      return this._regexp;
+    }
+
+    function match_string() {
+      return this.input
+    }
+
+    function match_to_a() {
+      return this.slice(0);
+    }
+
+    function match_to_s() {
+      return this[0];
+    }
+
+    function match_values_at() {
+      var vals = [];
+      var match_length = this.length;
+      for (var i = 0, length = arguments.length; i < length; i++) {
+        var pos = arguments[i];
+        if (pos >= 0) {
+          vals.push(this[pos]);
+        }
+        else {
+          pos = match_length + pos;
+          if (pos > 0) {
+            vals.push(this[pos]);
+          }
+          else {
+            vals.push(#{nil});
+          }
+        }
+      }
+
+      return vals;
     }
   }
 end

--- a/spec/rubyspec/core/regexp/match_spec.rb
+++ b/spec/rubyspec/core/regexp/match_spec.rb
@@ -17,6 +17,64 @@ describe "Regexp#match on a successful match" do
     /1/.match(nil)
     $~.should be_nil
   end
+
+  it "returns a MatchData object that exposes pre_match and post_match strings for inline regexp" do
+    re = /note: /i
+    result = re.match('preamble NOTE: This is just a test.')
+    result.pre_match.should == 'preamble '
+    result.post_match.should == 'This is just a test.'
+  end
+
+  it "returns a MatchData object that exposes pre_match and post_match strings for constructed regexp" do
+    re = Regexp.new(/note: /i)
+    result = re.match('preamble NOTE: This is just a test.')
+    result.pre_match.should == 'preamble '
+    result.post_match.should == 'This is just a test.'
+  end
+
+  it "sets $` and $' variables on match" do
+    re = /note: /i
+    re.match('preamble NOTE: This is just a test.')
+    $`.should == 'preamble '
+    $'.should == 'This is just a test.'
+  end
+
+  it "resets $` and $' when no match" do
+    re = /note: /i
+    re.match('preamble NOTE: This is just a test.')
+    $`.should_not be_nil
+    $'.should_not be_nil
+    re.match(nil)
+    $`.should be_nil
+    $'.should be_nil
+  end
+
+  it "returns a MatchData object that exposes match array" do
+    re = /(note): (.*)/i
+    result = re.match('preamble NOTE: This is just a test.')
+    result.length.should == 3
+    result.size.should == 3
+    result.captures.should == ['NOTE', 'This is just a test.']
+    result.to_a.should == ['NOTE: This is just a test.', 'NOTE', 'This is just a test.']
+    result[1].should == ['NOTE']
+    result.values_at(1, -1).should == ['NOTE', 'This is just a test.']
+    result.values_at(-3, 0).should == [nil, 'NOTE: This is just a test.']
+  end
+
+  it "returns a MatchData object that exposes regexp and string" do
+    re = /(note): (.*)/i
+    result = re.match('preamble NOTE: This is just a test.')
+    result.string.should == 'preamble NOTE: This is just a test.'
+    result.regexp.should == re
+  end
+
+  it "returns a MatchData object that provides access to offset of 0th element only" do
+    re = /(note): (.*)/i
+    result = re.match('preamble NOTE: This is just a test.')
+    result.begin(0).should == 9
+    result.begin(1).should == 9
+    lambda { result.begin(2) }.should raise_error(ArgumentError)
+  end
 end
 
 describe :regexp_match do

--- a/spec/rubyspec/core/string/match_spec.rb
+++ b/spec/rubyspec/core/string/match_spec.rb
@@ -24,4 +24,18 @@ describe "String#match" do
     'hello'.match(/X/)
     $~.should == nil
   end
+
+  it "sets $` to pre_match and $' to post_match or nil when there is no match" do
+    result = 'hello'.match(/ll/)
+    $`.should == 'he'
+    $'.should == 'o'
+    result.pre_match.should == 'he'
+    result.post_match.should == 'o'
+
+    'hello'.match(/X/)
+    $`.should == nil
+    $'.should == nil
+    result.pre_match.should == 'he'
+    result.post_match.should == 'o'
+  end
 end


### PR DESCRIPTION
- recreate RegExp, if necessary, to include global flag in match method
- populate MatchData using all information JavaScript makes available
- assign the $` and $' implicit variables
- rename argument names to correctly match what they are
