### PR TITLE
allow severity of dynamic require to be controlled

### DIFF
--- a/lib/opal/processor.rb
+++ b/lib/opal/processor.rb
@@ -29,12 +29,14 @@ module Opal
       attr_accessor :optimized_operators_enabled
       attr_accessor :arity_check_enabled
       attr_accessor :const_missing_enabled
+      attr_accessor :dynamic_require_severity
     end
 
     self.method_missing_enabled = true
     self.optimized_operators_enabled = true
     self.arity_check_enabled = false
     self.const_missing_enabled = true
+    self.dynamic_require_severity = :error # :error, :warning or :ignore
 
     def initialize_engine
       require_template_library 'opal'
@@ -45,11 +47,12 @@ module Opal
 
     def evaluate(context, locals, &block)
       options = {
-        :method_missing       => self.class.method_missing_enabled,
-        :optimized_operators  => self.class.optimized_operators_enabled,
-        :arity_check          => self.class.arity_check_enabled,
-        :const_missing        => self.class.const_missing_enabled,
-        :file                 => context.logical_path
+        :method_missing           => self.class.method_missing_enabled,
+        :optimized_operators      => self.class.optimized_operators_enabled,
+        :arity_check              => self.class.arity_check_enabled,
+        :const_missing            => self.class.const_missing_enabled,
+        :dynamic_require_severity => self.class.dynamic_require_severity,
+        :file                     => context.logical_path
       }
 
       parser = Opal::Parser.new


### PR DESCRIPTION
I think being able to control the severity of the validation for a dynamic require is critical for Opal adoption. There are paths in the code I've guarded against Opal getting to at runtime, but it has to be possible to tell the parser not to worry about them.
