### PR TITLE
use regexp-safe string operations in String#chomp

### DIFF
--- a/opal/opal/string.rb
+++ b/opal/opal/string.rb
@@ -175,13 +175,30 @@ class String < `String`
 
   def chomp(separator = $/)
     %x{
-      if (separator === "\\n") {
-        return #{self}.replace(/(\\n|\\r|\\r\\n)$/, '');
+      var strlen = #{self}.length;
+      var seplen = separator.length;
+      if (strlen > 0) {
+        if (separator === "\\n") {
+          var last = #{self}.charAt(strlen - 1);
+          if (last === "\\n" || last == "\\r") {
+            var result = #{self}.substr(0, strlen - 1);
+            if (strlen > 1 && #{self}.charAt(strlen - 2) === "\\r") {
+              result = #{self}.substr(0, strlen - 2);
+            } 
+            return result;
+          }
+        }
+        else if (separator === "") {
+          return #{self}.replace(/(?:\\n|\\r\\n)+$/, '');
+        }
+        else if (strlen >= seplen) {
+          var tail = #{self}.substr(-1 * seplen);
+          if (tail === separator) {
+            return #{self}.substr(0, strlen - seplen);
+          }
+        }
       }
-      else if (separator === "") {
-        return #{self}.replace(/(\\n|\\r\\n)+$/, '');
-      }
-      return #{self}.replace(new RegExp(separator + '$'), '');
+      return #{self}
     }
   end
 

--- a/spec/rubyspec/core/string/chomp_spec.rb
+++ b/spec/rubyspec/core/string/chomp_spec.rb
@@ -30,6 +30,11 @@ describe "String#chomp with separator" do
     "hello\n\r\n".chomp("\r\n").should == "hello\n"
   end
 
+  it "removes separator character" do
+    "hello)".chomp(")").should == "hello"
+    "hello*)".chomp("*)").should == "hello"
+  end
+
   it "returns self if the separator is nil" do
     "hello\n\n".chomp(nil).should == "hello\n\n"
   end


### PR DESCRIPTION
String#chomp was previously choking on:

```
"hello)".chomp(")")
```
