### PR TITLE
Change indexOf call on Array to if statement so we're compatible with IE 8

### DIFF
--- a/opal/opal/array.rb
+++ b/opal/opal/array.rb
@@ -907,7 +907,7 @@ class Array
           if (result['$<=>'] && typeof(result['$<=>']) == "function") {
             result = result['$<=>'](0);
           }
-          if ([-1, 0, 1].indexOf(result) == -1) {
+          if (result !== -1 && result !== 0 && result !== 1) {
             t_arg_error = true;
           }
           return result;


### PR DESCRIPTION
After testing the new release of Opal (0.3.44) in IE 8, I came across an error of a `indexOf` function call on `Array`, which is not supported in IE 8.

This PR replaces the `indexOf` function call with an if statement, making it compatible with IE 8 and possibly other older JavaScript implementations.
