### PR TITLE
untaint corelib, stdlib, and "safe" requires

### DIFF
--- a/lib/opal.rb
+++ b/lib/opal.rb
@@ -19,11 +19,11 @@ module Opal
   end
 
   def self.core_dir
-    File.expand_path('../../corelib', __FILE__)
+    File.expand_path('../../corelib', __FILE__.untaint)
   end
 
   def self.std_dir
-    File.expand_path('../../stdlib', __FILE__)
+    File.expand_path('../../stdlib', __FILE__.untaint)
   end
 
   # Add a file path to opals load path. Any gem containing ruby code that Opal
@@ -40,6 +40,6 @@ module Opal
 
   # Private, don't add to these directly (use .append_path instead).
   def self.paths
-    @paths ||= [core_dir, std_dir]
+    @paths ||= [core_dir.untaint, std_dir.untaint]
   end
 end

--- a/lib/opal/builder.rb
+++ b/lib/opal/builder.rb
@@ -43,6 +43,7 @@ module Opal
     end
 
     def find_asset(path)
+      path.untaint if path =~ /\A[-\w]+\Z/
       file_types = %w[.rb .js .js.erb]
 
       @paths.each do |root|


### PR DESCRIPTION
I'm trying to run opal in a [safe](http://www.ruby-doc.org/docs/ProgrammingRuby/html/taint.html) environment, and this is the first problem I ran into.  If I run into more, I'll provide more patches.  These changes will not affect anybody who runs code in a normal ("unsafe") environment.
