### PR TITLE
Fix Range#each to never include a value out of bounds.

### DIFF
--- a/corelib/range.rb
+++ b/corelib/range.rb
@@ -58,7 +58,7 @@ class Range
       current = current.succ
     end
 
-    yield current unless `#{self}.exclude`
+    yield current if `!#{self}.exclude` && current == last
 
     self
   end


### PR DESCRIPTION
Wrong:

``` ruby
(0..2.4).to_a #=> [0, 1, 2, 3]
```

Right:

``` ruby
(0..2.4).to_a #=> [0, 1, 2]
```
