### PR TITLE
Fix Hash#has_key? to only return true for properties of its own.

### DIFF
--- a/corelib/hash.rb
+++ b/corelib/hash.rb
@@ -351,7 +351,7 @@ class Hash
   end
 
   def has_key?(key)
-    `#{self}.map[key] != null`
+    `$hasOwn.call(#{self}.map, key)`
   end
 
   def has_value?(value)


### PR DESCRIPTION
Wrong:

``` ruby
x = { foo: "bar" }
x.has_key?("toString") #=> true
```

Right:

``` ruby
x = { foo: "bar" }
x.has_key?("toString") #=> false
```
