### PR TITLE
Fix Numeric comparison operator

### DIFF
--- a/corelib/numeric.rb
+++ b/corelib/numeric.rb
@@ -85,7 +85,7 @@ class Numeric
 
   def <=>(other)
     %x{
-      if (typeof(other) !== 'number') {
+      if (typeof(other) !== 'number' && typeof(other) !== 'Numeric') {
         return nil;
       }
 


### PR DESCRIPTION
This PR fixes the comparison operator (`<=>`) allowing it to also accept the `Numeric` type.
