### PR TITLE
Add String#concat

### DIFF
--- a/opal/core/string.rb
+++ b/opal/core/string.rb
@@ -49,6 +49,14 @@ class String
     `self + #{other.to_s}`
   end
 
+  def concat(other)
+    other = Opal.coerce_to other, String, :to_str
+
+    `self.concat(#{other.to_s})`
+  end
+
+  alias << concat
+
   def <=>(other)
     if other.respond_to? :to_str
       other = other.to_str.to_s

--- a/spec/corelib/string/concat_spec.rb
+++ b/spec/corelib/string/concat_spec.rb
@@ -1,0 +1,11 @@
+describe "String#concat" do
+  it "concatinate original string with other string" do
+    "hello ".concat("world").should == "hello world"
+  end
+
+  it "concatinate original string with incompatible object" do
+    class A; end
+
+    lambda { "hello ".concat(A.new) }.should raise_error TypeError
+  end
+end


### PR DESCRIPTION
1. I don't know about how fast `String#concat` vs `String#+=`, but i think first is more semantic
2. I don't know how i can add `Numeric#to_str` ... if i do something like this, it make specs red in `Array`

``` ruby
  def to_s(base = 10)
    if base < 2 || base > 36
      raise ArgumentError, 'base must be between 2 and 36'
    end

    `self.toString(base)`
  end

  alias inspect to_s
  alias to_str to_s
```

This article http://www.sitepoint.com/javascript-fast-string-concatenation/ says that challenge in `String#concat` vs `Array.join` mode, not in `String#concat` vs `String#+=`
