### PR TITLE
String#split ignores leading and continuous whitespace

### DIFF
--- a/opal/corelib/string.rb
+++ b/opal/corelib/string.rb
@@ -622,7 +622,10 @@ class String
             }
           }
 
-          while ((cursor = #{self}.indexOf(splat, start)) > -1 && cursor < #{self}.length) {
+          string = (splat == ' ') ? #{self}.replace(/[\\r\\n\\t\\v]\\s+/g, ' ')
+                                  : #{self};
+
+          while ((cursor = string.indexOf(splat, start)) > -1 && cursor < string.length) {
             if (splitted + 1 == lim) {
               break;
             }
@@ -632,18 +635,18 @@ class String
               continue;
             }
 
-            result.push(#{self}.substr(start, splat.length ? cursor - start : 1));
+            result.push(string.substr(start, splat.length ? cursor - start : 1));
             splitted++;
 
             start = cursor + (splat.length ? splat.length : 1);
           }
 
-          if (#{self}.length > 0 && (limit || lim < 0 || #{self}.length > start)) {
-            if (#{self}.length == start) {
+          if (string.length > 0 && (limit || lim < 0 || string.length > start)) {
+            if (string.length == start) {
               result.push('');
             }
             else {
-              result.push(#{self}.substr(start, #{self}.length));
+              result.push(string.substr(start, string.length));
             }
           }
 

--- a/spec/opal/filters/bugs/string.rb
+++ b/spec/opal/filters/bugs/string.rb
@@ -166,7 +166,6 @@ opal_filter "String" do
   fails "String#slice with String returns a subclass instance when given a subclass instance"
   fails "String#slice with Regexp, group"
 
-  fails "String#split with String ignores leading and continuous whitespace when string is a single space"
   fails "String#split with String returns subclass instances based on self"
   fails "String#split with Regexp divides self on regexp matches"
   fails "String#split with Regexp treats negative limits as no limit"


### PR DESCRIPTION
This fix was made possible by https://github.com/opal/opal/commit/03fda15aa01393af9179998c9439a6040b69721c
