### PR TITLE
fixed opal command without options

### DIFF
--- a/bin/opal
+++ b/bin/opal
@@ -7,7 +7,7 @@ options.parse!
 require 'opal/cli'
 
 if ARGV.empty? and !options.options[:evals]
-  p options
+  puts options
 else
   cli = Opal::CLI.new options.options.merge(:filename => ARGV.first)
   begin


### PR DESCRIPTION
`opal` without options used to print representation of CLIOptions instance. `puts`, unlike `p`, returns `nil`, which fixed the issue.
