### PR TITLE
Use "//#" instead of "//@" deprecated syntax for sourceMappingURL

### DIFF
--- a/lib/opal/source_map.rb
+++ b/lib/opal/source_map.rb
@@ -47,7 +47,7 @@ module Opal
     end
 
     def magic_comment map_path
-      "\n//@ sourceMappingURL=file://#{map_path}"
+      "\n//# sourceMappingURL=file://#{map_path}"
     end
   end
 end

--- a/lib/opal/sprockets/processor.rb
+++ b/lib/opal/sprockets/processor.rb
@@ -88,7 +88,7 @@ module Opal
 
       if self.class.source_map_enabled
         $OPAL_SOURCE_MAPS[context.pathname] = compiler.source_map(source_file_url(context)).to_s
-        "#{result}\n//@ sourceMappingURL=#{source_map_url(context)}\n"
+        "#{result}\n//# sourceMappingURL=#{source_map_url(context)}\n"
       else
         result
       end


### PR DESCRIPTION
Firefox keeps filling the JS console with:

```
SyntaxError: Using //@ to indicate source map URL pragmas is deprecated. Use //# instead
```

this fix the problem (not tested with other browser).
