### PR TITLE
Fixing array expansion when triggered by attribution indexed by range

### DIFF
--- a/opal/corelib/array.rb
+++ b/opal/corelib/array.rb
@@ -326,7 +326,7 @@ class Array
         }
 
         if (from > size) {
-          for (var i = size; i < index; i++) {
+          for (var i = size; i < from; i++) {
             self[i] = nil;
           }
         }

--- a/spec/opal/core/array/set_range_to_array_spec.rb
+++ b/spec/opal/core/array/set_range_to_array_spec.rb
@@ -1,0 +1,7 @@
+describe "Array#[]=" do
+  it 'expands the array when assigning another array to a range' do
+    a = ['a']
+    a[3..4] = ['b', 'c']
+    a.should == ['a', nil, nil, 'b', 'c']
+  end
+end


### PR DESCRIPTION
The [Array#[]= documentation](http://www.ruby-doc.org/core-2.1.0/Array.html#method-i-5B-5D-3D) says you can replace multiple elements of an array by using a range. Their example, highlighted below, works fine:

``` ruby
a = Array.new
a[4] = "4";                 #=> [nil, nil, nil, nil, "4"]
a[0, 3] = [ 'a', 'b', 'c' ] #=> ["a", "b", "c", nil, "4"]
a[1..2] = [ 1, 2 ]          #=> ["a", 1, 2, nil, "4"]
```

It also states that "If indices are greater than the current capacity of the array, the array grows automatically", which happens in Opal overall.

However, if an expansion happens during such an attribution, Opal is not "fillling the blanks", but merely adding the elements at the end.

Added the spec because I could not find anything covering that on rubyspecs.

Looking at the code that is supposed to do that, it checks if the JavaScript array needs growth before `splice`-ing it, but it grows up to `index`, which is a `Range`. It seemed to be a trivial fix, which broke no previous test (and also worked for [my original code that revealed the issue](https://github.com/chesterbr/ruby2600/blob/master/spec/lib/ruby2600/cpu_spec.rb#L703))
