### PR TITLE
Making shifts with negative counts reverse the shift direction

### DIFF
--- a/opal/corelib/numeric.rb
+++ b/opal/corelib/numeric.rb
@@ -188,11 +188,15 @@ class Numeric
   end
 
   def <<(count)
-    `self << #{count.to_int}`
+    count = Opal.coerce_to! count, Integer, :to_int
+
+    `#{count} > 0 ? self << #{count} : self >> -#{count}`
   end
 
   def >>(count)
-    `self >> #{count.to_int}`
+    count = Opal.coerce_to! count, Integer, :to_int
+
+    `#{count} > 0 ? self >> #{count} : self << -#{count}`
   end
 
   def [](bit)

--- a/spec/opal/filters/bugs/numeric.rb
+++ b/spec/opal/filters/bugs/numeric.rb
@@ -6,14 +6,15 @@ opal_filter "Fixnum bugs" do
   fails "Fixnum#zero? returns true if self is 0"
 end
 
-opal_filter "Fixnum#<< doesn't handle non-integers" do
-  fails "Fixnum#<< with n << m raises a TypeError when passed a String"
-  fails "Fixnum#<< with n << m raises a TypeError when passed nil"
-  fails "Fixnum#<< with n << m raises a TypeError when #to_int does not return an Integer"
+opal_filter "Fixnum#<< doesn't handle Bignum and large number checks" do
   fails "Fixnum#<< with n << m returns a Bignum == fixnum_min() * 2 when fixnum_min() << 1 and n < 0"
   fails "Fixnum#<< with n << m returns a Bignum == fixnum_max() * 2 when fixnum_max() << 1 and n > 0"
   fails "Fixnum#<< with n << m returns 0 when m < 0 and m is a Bignum"
   fails "Fixnum#<< with n << m returns 0 when m < 0 and m == p where 2**p > n >= 2**(p-1)"
-  fails "Fixnum#<< with n << m returns n shifted right m bits when n < 0, m < 0"
-  fails "Fixnum#<< with n << m returns n shifted right m bits when n > 0, m < 0"
+end
+
+opal_filter "Fixnum#>> doesn't handle Bignum" do
+  fails "Fixnum#>> with n >> m returns a Bignum == fixnum_max() * 2 when fixnum_max() >> -1 and n > 0"
+  fails "Fixnum#>> with n >> m returns a Bignum == fixnum_min() * 2 when fixnum_min() >> -1 and n < 0"
+  fails "Fixnum#>> with n >> m returns 0 when m is a Bignum"
 end

--- a/spec/opal/rubyspecs
+++ b/spec/opal/rubyspecs
@@ -23,6 +23,7 @@ core/fixnum/even_spec
 core/fixnum/gt_spec
 core/fixnum/gte_spec
 core/fixnum/left_shift_spec
+core/fixnum/right_shift_spec
 core/fixnum/lt_spec
 core/fixnum/lte_spec
 core/fixnum/magnitude_spec


### PR DESCRIPTION
This is very [sane and well defined](http://www.ruby-doc.org/core-2.1.0/Fixnum.html#method-i-3C-3C) in Ruby, but JavaScript's behaviour is a bit more chaotic(*), so I introduced a comparison that "manually" reverts the direction.

New specs came from the rubyspec files with the same name for `Fixnum` (which seems to be the source for the specs that were already there). Inserted at the same position, so the files keep comparable.

(*) I found that Firefox and Chrome seem to strictly follow [ECMA-262 11.7.1](http://www.ecma-international.org/ecma-262/5.1/#sec-11.7.1) item 7, meaning they will turn negative shift counts (in two's complement) into positive - in most cases, positive numbers that are large enough to make the final result zero, regardless of the original "shifted" number.
