### PR TITLE
Make String#to_proc return value allow arguments.

### DIFF
--- a/opal/corelib/string.rb
+++ b/opal/corelib/string.rb
@@ -880,14 +880,9 @@ class String
   end
 
   def to_proc
-    %x{
-      var name = '$' + self;
-
-      return function(arg) {
-        var meth = arg[name];
-        return meth ? meth.call(arg) : arg.$method_missing(name);
-      };
-    }
+    proc do |recv, *args|
+      recv.send(self, *args)
+    end
   end
 
   def to_s


### PR DESCRIPTION
Among other things, this allows binary operators to work:

``` ruby
  (:+).to_proc.call(1, 2)  # => 3
```

This is most commonly encountered as a result of:

``` ruby
  [1, 2, 3].reduce(&:+) # => 6
```

(Note the ampersand: not using `inject`'s special-case Symbol handling.)

I originally implemented this by extending the JS escape:

``` ruby
  def to_proc
    %x{
      return function(recv) {
        var meth = recv['$' + self];
        var rest = $slice.call(arguments, 1);
        return meth ? meth.apply(recv, rest)
                    : recv.$method_missing.apply(recv, [self].concat(rest));
      };
    }
  end
```

Then I noticed the compiler does a damn-reasonable job at this, and it doesn't require scattering another `send` and `method_missing` dispatch around.
