### PR TITLE
Fix Util module to work on Windows

### DIFF
--- a/lib/opal/util.rb
+++ b/lib/opal/util.rb
@@ -2,26 +2,34 @@ module Opal
   module Util
     extend self
 
+    def null
+      if (/mswin|mingw/ =~ RUBY_PLATFORM).nil?
+        '/dev/null'
+      else
+        'nul'
+      end
+    end
+
     # Used for uglifying source to minify
     def uglify(str)
-      IO.popen('uglifyjs 2> /dev/null', 'r+') do |i|
+      IO.popen('uglifyjs 2> ' + null, 'r+') do |i|
         i.puts str
         i.close_write
         return i.read
       end
-    rescue Errno::ENOENT, Errno::EPIPE
+    rescue Errno::ENOENT, Errno::EPIPE, Errno::EINVAL
       $stderr.puts '"uglifyjs" command not found (install with: "npm install -g uglify-js")'
       nil
     end
 
     # Gzip code to check file size
     def gzip(str)
-      IO.popen('gzip -f 2> /dev/null', 'r+') do |i|
+      IO.popen('gzip -f 2> ' + null, 'r+') do |i|
         i.puts str
         i.close_write
         return i.read
       end
-    rescue Errno::ENOENT, Errno::EPIPE
+    rescue Errno::ENOENT, Errno::EPIPE, Errno::EINVAL
       $stderr.puts '"gzip" command not found, it is required to produce the .gz version'
       nil
     end


### PR DESCRIPTION
Basically there's no `/dev/null` on Windows but instead it's just `nul` and also when command isn't found "Invalid argument" is thrown so we catch `Errno::EINVAL` too
