### PR TITLE
def and define_method return the method name.

### DIFF
--- a/lib/opal/nodes/def.rb
+++ b/lib/opal/nodes/def.rb
@@ -114,7 +114,7 @@ module Opal
           unshift "def#{jsid} = "
         end
 
-        wrap '(', ', nil)' if expr?
+        wrap '(', ", nil) && '#{mid}'" if expr?
       end
 
       # Returns code used in debug mode to check arity of method call

--- a/opal/corelib/module.rb
+++ b/opal/corelib/module.rb
@@ -271,7 +271,7 @@ class Module
       self._proto[jsid] = block;
       $opal.donate(self, [jsid]);
 
-      return null;
+      return name;
     }
   end
 


### PR DESCRIPTION
This is a Ruby 2.1 change, but as we previously returned nil, this is unlikely to be a compatibility issue.
