### PR TITLE
Distinguish between single- and double-quoted heredoc identifiers.

### DIFF
--- a/spec/opal/core/language/string_spec.rb
+++ b/spec/opal/core/language/string_spec.rb
@@ -13,4 +13,32 @@ describe "Ruby character strings" do
     a = 1
     %[#{a}23].should == "123"
   end
+
+  it "should not process escape characters in single-quoted heredocs" do
+    s = <<'EOD'
+      hey\now\brown\cow
+    EOD
+    s.strip.should == 'hey\now\brown\cow'
+  end
+
+  it "should ignore single-quote escapes in single-quoted heredocs" do
+    s = <<'EOD'
+      they\'re greeeeaaat!
+    EOD
+    s.strip.should == 'they\\\'re greeeeaaat!'
+  end
+
+  it "should process escape characters in double quoted heredocs" do
+    s = <<"EOD"
+      hey\now\brown\cow
+    EOD
+    s.strip.should == "hey\now\brown\cow"
+  end
+
+  it "should treat bare-word heredoc identifiers as double-quoted" do
+    s = <<EOD
+      hey\now\brown\cow
+    EOD
+    s.strip.should == "hey\now\brown\cow"
+  end
 end


### PR DESCRIPTION
Single-quoted heredoc identifiers do not process the content for escape sequences.

Added tests to ensure:
- Escapes not processed in `<<'EOD'`
- Escapes are processed in `<<"EOD"`
- `<<EOD` is processed as `<<"EOD"`
