### PR TITLE
Kernel#methods should not return method_missing stubs

### DIFF
--- a/opal/corelib/kernel.rb
+++ b/opal/corelib/kernel.rb
@@ -44,8 +44,9 @@ module Kernel
               continue;
             }
           }
-
-          methods.push(key.substr(1));
+          if (self[key].rb_stub === undefined) {
+            methods.push(key.substr(1));
+          }
         }
       }
 

--- a/spec/opal/core/kernel/methods_spec.rb
+++ b/spec/opal/core/kernel/methods_spec.rb
@@ -1,11 +1,25 @@
+module MethodsSpecs
+  class Issue < Object
+    def unique_method_name
+    end
+  end
+
+  # Trigger stub generation
+  Issue.new.unique_method_name
+end
+
 describe "Kernel#methods" do
   it "lists methods available on an object" do
     Object.new.methods.include?("puts").should == true
   end
-  
+
   it "lists only singleton methods if false is passed" do
     o = Object.new
     def o.foo; 123; end
     o.methods(false).should == ["foo"]
+  end
+
+  it "ignores stub methods" do
+    Object.methods.include?(:unique_method_name).should be_false
   end
 end


### PR DESCRIPTION
Closes #529
