### PR TITLE
Slight README correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ visit `http://localhost:9292/` in any web browser.
 [spectator][] can be used in an autotest fashion with this command
 
 ```shell
-spectator .spectator-mspec # this will run RSpec examples only
+spectator .spectator-mspec # this will run MSpec examples only
 ```
 
 


### PR DESCRIPTION
The comment for running the MSpec tests through spectator said it would run "R"Spec tests only. Small change but I thought I'd submit a PR since I noticed it :smile: 
