### PR TITLE
Make the Opal Tilt template work in any context.

### DIFF
--- a/lib/opal/sprockets/processor.rb
+++ b/lib/opal/sprockets/processor.rb
@@ -63,21 +63,19 @@ module Opal
 
 
     def evaluate(context, locals, &block)
-      if context.is_a? ::Sprockets::Context
-        path = context.logical_path
-        prerequired = []
+      return Opal.compile data unless context.is_a? ::Sprockets::Context
+      
+      path = context.logical_path
+      prerequired = []
 
-        builder = self.class.new_builder(context)
-        result = builder.build_str(data, path, :prerequired => prerequired)
+      builder = self.class.new_builder(context)
+      result = builder.build_str(data, path, :prerequired => prerequired)
 
-        if self.class.source_map_enabled
-          register_source_map(context.pathname, result.source_map.to_s)
-          "#{result.to_s}\n//# sourceMappingURL=#{context.logical_path}.map\n"
-        else
-          result.to_s
-        end
+      if self.class.source_map_enabled
+        register_source_map(context.pathname, result.source_map.to_s)
+        "#{result.to_s}\n//# sourceMappingURL=#{context.logical_path}.map\n"
       else
-        Opal.compile data
+        result.to_s
       end
     end
 


### PR DESCRIPTION
Opal registers Opal::Processor as a Tilt template for .opal files. That template only works if passed a Sprockets context. Even with limited functionality, it is useful to have an Opal Tilt template that runs in any context. For example, I like to embed Opal in my Slim templates for inline javascript without having to switch away from ruby. 

This pull request simply compiles the Tilt data using Opal.compile if the context passed in was anything other than a Sprockets::Context.
