### PR TITLE
Use require_paths from spec

### DIFF
--- a/lib/opal/paths.rb
+++ b/lib/opal/paths.rb
@@ -26,7 +26,9 @@ module Opal
       use_gem dependency.name
     end if include_dependecies
 
-    Opal.append_path File.join(spec.gem_dir, 'lib')
+    spec.require_paths.each do |path|
+      Opal.append_path File.join(spec.gem_dir, path)
+    end
   end
 
   # Private, don't add to these directly (use .append_path instead).


### PR DESCRIPTION
Some gems don't use lib or use more than one require path. _why's metaid library is a good example. This commit updates Opal.use_gem to append all require paths a gem declares. 
