### PR TITLE
Update dependencies

### DIFF
--- a/opal.gemspec
+++ b/opal.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'hike'
   s.add_dependency 'source_map'
-  s.add_dependency 'sprockets', '>= 2.0.0'
+  s.add_dependency 'sprockets', '~> 2.0'
 
   s.add_development_dependency 'mspec', '1.5.20'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
Sorry for all the pull requests - should have tested a bit better and made one pull request. Opal's embedded engine test in Slim was failing since Opal requires Hike and a version of Sprockets that supports Sprockets.register_engine, but doesn't declare that in its gemspec. This should fix that. 
