### PR TITLE
Included modules as ancestors 🔗

### DIFF
--- a/benchmarks/class_boundaries.coffee
+++ b/benchmarks/class_boundaries.coffee
@@ -1,0 +1,38 @@
+
+rb_create_class = (name, superclass = null) ->
+  class TopProto
+  class BottomProto extends TopProto
+
+  rb_klass = {
+    top_proto: TopProto
+    bottom_proto: BottomProto
+    superclass: null
+    included_modules: []
+  }
+
+  rb_update_inheritance_chain(rb_klass)
+
+  return rb_klass
+
+
+rb_include = (klass, module) ->
+  klass.included_modules.push module
+  klass.update_modules
+
+rb_update_inheritance_chain(klass)
+  module_copies_list = [klass.top_proto]
+  klass.included_modules.each (module)->
+    module_copy = duplicate_module(module)
+    set_super_prototype(base: module_copy, parent: module_copies_list.last())
+  set_super_prototype(base: klass.bottom_proto, parent: module_copies_list.last())
+
+set_super_prototype(kwargs)
+  base = kwargs.base
+  parent = kwargs.parent
+  base.prototype
+
+duplicate_module(module)->
+  module_copy = {}
+  for method in module
+    module_copy[method] = module[method]
+  module_copy

--- a/opal/corelib/class.rb
+++ b/opal/corelib/class.rb
@@ -8,9 +8,9 @@ class Class
       }
 
       function AnonClass(){};
-      var klass       = Opal.boot(sup, AnonClass)
-      klass.$$name     = nil;
-      klass.$$parent  = sup;
+      var klass      = Opal.boot(sup, AnonClass)
+      klass.$$name   = nil;
+      klass.$$parent = sup;
 
       // inherit scope from parent
       $opal.create_scope(sup.$$scope, klass);

--- a/opal/corelib/module.rb
+++ b/opal/corelib/module.rb
@@ -77,56 +77,8 @@ class Module
   end
 
   def append_features(klass)
-    %x{
-      var module   = self,
-          included = klass.$$inc;
-
-      // check if this module is already included in the klass
-      for (var i = 0, length = included.length; i < length; i++) {
-        if (included[i] === module) {
-          return;
-        }
-      }
-
-      included.push(module);
-      module.$$dep.push(klass);
-
-      // iclass
-      var iclass = {
-        name: module.$$name,
-
-        $$proto:   module.$$proto,
-        $$parent: klass.$$parent,
-        __iclass: true
-      };
-
-      klass.$$parent = iclass;
-
-      var donator   = module.$$proto,
-          prototype = klass.$$proto,
-          methods   = module.$$methods;
-
-      for (var i = 0, length = methods.length; i < length; i++) {
-        var method = methods[i];
-
-        if (prototype.hasOwnProperty(method) && !prototype[method].$$donated) {
-          // if the target class already has a method of the same name defined
-          // and that method was NOT donated, then it must be a method defined
-          // by the class so we do not want to override it
-        }
-        else {
-          prototype[method] = donator[method];
-          prototype[method].$$donated = true;
-        }
-      }
-
-      if (klass.$$dep) {
-        $opal.donate(klass, methods.slice(), true);
-      }
-
-      $opal.donate_constants(module, klass);
-    }
-
+    raise TypeError unless Class === klass
+    `$opal.rb_include_module(klass, self)`
     self
   end
 


### PR DESCRIPTION
## WIP: do not merge

### This PR is here for everyone to review or suggest stuff

The idea is to inject the a copy of the module in the ancestor chain of a class each time the module is included.
The copy is named "iclass" as included class and has as prototype the previous parent prototype of the class (the superclass or another module).
