### PR TITLE
Sprockets 3.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'thin', platform: :mri
 
 # Uncomment to try with sprockets 3.0:
 #
-#   gem 'sprockets', github: 'sstephenson/sprockets', branch: 'master'
+#   gem 'sprockets', '~> 3.0.0.beta'
 
 group :repl do
   gem 'therubyracer', :platform => :mri, :require => 'v8'

--- a/opal.gemspec
+++ b/opal.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   required_ruby_version = '>= 1.9.3'
 
   s.add_dependency 'sourcemap', '~> 0.1.0'
-  s.add_dependency 'sprockets', '~> 2.12.1'
+  s.add_dependency 'sprockets', '>= 2.12.1', '< 4.0.0'
   s.add_dependency 'hike', '~> 1.2'
   s.add_dependency 'tilt', '~> 1.4'
 


### PR DESCRIPTION
Hey @elia!

Looks like things are passing on Opal on Sprockets 3.x beta. I updated the Gemfile comment and allowed 3.x versions.

Everything should be API compatible on going forward on 3.x. Until you make the leap to only support 3.x and 4.x, I'd say you're best of allowing the current Opal to run on Sprockets 2/3.

wdyt?

Thanks!
