### PR TITLE
resolve #651 escape forward slash in regexp

### DIFF
--- a/opal/corelib/regexp.rb
+++ b/opal/corelib/regexp.rb
@@ -4,7 +4,7 @@ class Regexp
   class << self
     def escape(string)
       %x{
-        return string.replace(/([-[\]/{}()*+?.^$\\| ])/g, '\\$1')
+        return string.replace(/([-[\]\/{}()*+?.^$\\| ])/g, '\\$1')
                      .replace(/[\n]/g, '\\n')
                      .replace(/[\r]/g, '\\r')
                      .replace(/[\f]/g, '\\f')


### PR DESCRIPTION
- escape forward slash in regexp for compatibility with Rhino on JDK6
