### PR TITLE
Use case insensitive search when finding Encodings

### DIFF
--- a/stdlib/encoding.rb
+++ b/stdlib/encoding.rb
@@ -12,12 +12,13 @@ class Encoding
   end
 
   def self.find(name)
-    return name if self === name
+    upcase_name = name.upcase
+    return upcase_name if self === upcase_name
 
     constants.each {|const|
       encoding = const_get(const)
 
-      if encoding.name == name || encoding.names.include?(name)
+      if encoding.name == upcase_name || encoding.names.include?(upcase_name)
         return encoding
       end
     }


### PR DESCRIPTION
Other rubies allow both `Encoding.find('binary')` and
`Encoding.find('BINARY')`. Opal was only allowing the uppercase version.
This change permits the lowercase search string as well.