### PR TITLE
fix rescue’s default behavior

### DIFF
--- a/lib/opal/nodes/rescue.rb
+++ b/lib/opal/nodes/rescue.rb
@@ -98,8 +98,10 @@ module Opal
       def compile
         push "if ("
         if rescue_exprs.empty?
-          # if no expressions are given, then catch all errors
-          push "true"
+          # if no expressions are given, then catch StandardError only
+          push "Opal.rescue($err, ["
+          push expr(Sexp.new([:const, :StandardError]))
+          push "])"
         else
           push "Opal.rescue($err, ["
           rescue_exprs.each_with_index do |rexpr, idx|

--- a/lib/opal/nodes/rescue.rb
+++ b/lib/opal/nodes/rescue.rb
@@ -96,21 +96,17 @@ module Opal
       children :args, :body
 
       def compile
-        push "if ("
+        push "if (Opal.rescue($err, ["
         if rescue_exprs.empty?
           # if no expressions are given, then catch StandardError only
-          push "Opal.rescue($err, ["
           push expr(Sexp.new([:const, :StandardError]))
-          push "])"
         else
-          push "Opal.rescue($err, ["
           rescue_exprs.each_with_index do |rexpr, idx|
             push ', ' unless idx == 0
             push expr(rexpr)
           end
-          push "])"
         end
-        push ") {"
+        push "])) {"
 
         if variable = rescue_variable
           variable[2] = s(:js_tmp, '$err')

--- a/lib/opal/nodes/rescue.rb
+++ b/lib/opal/nodes/rescue.rb
@@ -16,7 +16,11 @@ module Opal
       end
 
       def compile
-        push "try {", expr(body), " } catch ($err) { ", expr(rescue_val), " }"
+        push "try {", expr(body), " } catch ($err) { "
+        push "if (Opal.rescue($err, ["
+        push expr(Sexp.new([:const, :StandardError]))
+        push "])) {", expr(rescue_val), "}"
+        push "else { throw $err; } }"
 
         wrap '(function() {', '})()' unless stmt?
       end

--- a/spec/opal/core/runtime/rescue_spec.rb
+++ b/spec/opal/core/runtime/rescue_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 class RescueReturningSpec
   def single
     begin
@@ -35,4 +33,10 @@ describe "The rescue keyword" do
   it "returns nil if no expr given in rescue body" do
     RescueReturningSpec.new.empty_rescue.should be_nil
   end
+
+  it "by default, catch StandardError, not all Exception" do
+    lambda { begin;raise Exception.new;rescue;end }.should raise_error
+    lambda { begin;raise "err";rescue;end }.should_not raise_error
+  end
+
 end

--- a/spec/opal/core/runtime/rescue_spec.rb
+++ b/spec/opal/core/runtime/rescue_spec.rb
@@ -37,6 +37,12 @@ describe "The rescue keyword" do
   it "by default, catch StandardError, not all Exception" do
     lambda { begin;raise Exception.new;rescue;end }.should raise_error
     lambda { begin;raise "err";rescue;end }.should_not raise_error
+
+    # one line rescue
+    lambda { raise Exception rescue nil }.should raise_error(Exception)
+    lambda { raise "err" rescue nil }.should_not raise_error
+    (raise "err" rescue "foo").should == "foo"
+    ("err" rescue "foo").should == "err"
   end
 
 end


### PR DESCRIPTION
When no type is given, “rescue” should catch StandardError by default,
*NOT* all types of Exceptions.

I am surprised `rubyspec`'s `corelib/language/rescue_spec.rb` did not test this.