### PR TITLE
Utility to run a block in context of `this`

### DIFF
--- a/stdlib/native.rb
+++ b/stdlib/native.rb
@@ -178,6 +178,11 @@ module Kernel
       a.map! {|x| Native(`x`)}
       instance = Native(`this`)
       %x{
+        // if window is current scope, run the block in the scope it was defined
+        if(this.toString() === '[object Window]') {
+          return block.apply(self, a);
+        }
+        // otherwise run the block in the current scope
         return (function() {
           var s = block.$$s;
           block.$$s = null;


### PR DESCRIPTION
When passing a block it will run in the context it was defined, normally.
This method wraps the block into a proc that when called will run the block in context of incoming `this`

https://gist.github.com/sleewoo/8d785061fc0cfbe5675d
