### PR TITLE
Implement String#[] with a string argument

### DIFF
--- a/opal/corelib/string.rb
+++ b/opal/corelib/string.rb
@@ -98,7 +98,6 @@ class String
     when String
       return self.include?(index) ? index : nil
     when Regexp
-      #WTF - not implemented yet, but somehow the tests are passing
       #TODO implement by testing the regexp, then setting index and
       #length accordingly to let the code below do the rest of work
     when Range, Numeric

--- a/opal/corelib/string.rb
+++ b/opal/corelib/string.rb
@@ -95,6 +95,10 @@ class String
 
   def [](index, length = undefined)
     %x{
+      if (typeof index === 'string') {
+        return self.indexOf(index) === -1 ? nil : index;
+      }
+
       var size = self.length;
 
       if (index.$$is_range) {

--- a/opal/corelib/string.rb
+++ b/opal/corelib/string.rb
@@ -94,11 +94,19 @@ class String
   end
 
   def [](index, length = undefined)
+    case index
+    when String
+      return self.include?(index) ? index : nil
+    when Regexp
+      #WTF - not implemented yet, but somehow the tests are passing
+      #TODO implement by testing the regexp, then setting index and
+      #length accordingly to let the code below do the rest of work
+    when Range, Numeric
+      #implemented in JS below
+    else
+      raise TypeError, "type mismatch: #{index.class} given"
+    end
     %x{
-      if (typeof index === 'string') {
-        return self.indexOf(index) === -1 ? nil : index;
-      }
-
       var size = self.length;
 
       if (index.$$is_range) {

--- a/opal/corelib/string.rb
+++ b/opal/corelib/string.rb
@@ -94,17 +94,6 @@ class String
   end
 
   def [](index, length = undefined)
-    case index
-    when String
-      return self.include?(index) ? index : nil
-    when Regexp
-      #TODO implement by testing the regexp, then setting index and
-      #length accordingly to let the code below do the rest of work
-    when Range, Numeric
-      #implemented in JS below
-    else
-      raise TypeError, "type mismatch: #{index.class} given"
-    end
     %x{
       var size = self.length;
 
@@ -138,24 +127,39 @@ class String
         return self.substr(index, length);
       }
 
-      if (index < 0) {
-        index += self.length;
-      }
 
-      if (length == null) {
-        if (index >= self.length || index < 0) {
+      if (index.$$is_number) {
+        if (index < 0) {
+          index += size;
+        }
+
+        if (length == null) {
+          if (index >= size || index < 0) {
+            return nil;
+          }
+
+          return self.substr(index, 1);
+        }
+
+        if (index > size || index < 0) {
           return nil;
         }
 
-        return self.substr(index, 1);
+        return self.substr(index, length);
       }
 
-      if (index > self.length || index < 0) {
-        return nil;
+
+      if (index.$$is_string) {
+        return self.indexOf(index) !== -1 ? index : nil
       }
 
-      return self.substr(index, length);
+
+      if (index.$$is_regexp) {
+        #{raise NotImplementedError}
+      }
     }
+
+    raise TypeError, "type mismatch: #{index.class} given"
   end
 
   def capitalize

--- a/opal/corelib/string/inheritance.rb
+++ b/opal/corelib/string/inheritance.rb
@@ -15,6 +15,8 @@ class String
 end
 
 class String::Wrapper
+  `def.$$is_string = true`
+
   def self.allocate(string = "")
     obj = super()
     `obj.literal = string`

--- a/spec/filters/bugs/string.rb
+++ b/spec/filters/bugs/string.rb
@@ -30,8 +30,6 @@ opal_filter "String" do
   fails "String#[] with Regexp, index raises a TypeError when the given index can't be converted to Integer"
   fails "String#[] with Regexp, index raises a TypeError when the given index is nil"
   fails "String#[] with Regexp, index sets $~ to MatchData when there is a match and nil when there's none"
-  fails "String#[] with String doesn't call to_str on its argument"
-  fails "String#[] with String returns a subclass instance when given a subclass instance"
 
   fails "String#dup does not copy constants defined in the singleton class"
   fails "String#dup does not modify the original string when changing dupped string"

--- a/spec/filters/bugs/string.rb
+++ b/spec/filters/bugs/string.rb
@@ -156,10 +156,6 @@ opal_filter "String" do
   fails "String#slice with Regexp, index raises a TypeError when the given index can't be converted to Integer"
   fails "String#slice with Regexp, index raises a TypeError when the given index is nil"
   fails "String#slice with Regexp, index sets $~ to MatchData when there is a match and nil when there's none"
-  fails "String#slice with String returns other_str if it occurs in self"
-  fails "String#slice with String returns nil if there is no match"
-  fails "String#slice with String doesn't call to_str on its argument"
-  fails "String#slice with String returns a subclass instance when given a subclass instance"
   fails "String#slice with Regexp, group"
 
   fails "String#split with String returns subclass instances based on self"

--- a/spec/filters/bugs/string.rb
+++ b/spec/filters/bugs/string.rb
@@ -30,8 +30,6 @@ opal_filter "String" do
   fails "String#[] with Regexp, index raises a TypeError when the given index can't be converted to Integer"
   fails "String#[] with Regexp, index raises a TypeError when the given index is nil"
   fails "String#[] with Regexp, index sets $~ to MatchData when there is a match and nil when there's none"
-  fails "String#[] with String returns other_str if it occurs in self"
-  fails "String#[] with String returns nil if there is no match"
   fails "String#[] with String doesn't call to_str on its argument"
   fails "String#[] with String returns a subclass instance when given a subclass instance"
 

--- a/spec/filters/bugs/string.rb
+++ b/spec/filters/bugs/string.rb
@@ -30,6 +30,8 @@ opal_filter "String" do
   fails "String#[] with Regexp, index raises a TypeError when the given index can't be converted to Integer"
   fails "String#[] with Regexp, index raises a TypeError when the given index is nil"
   fails "String#[] with Regexp, index sets $~ to MatchData when there is a match and nil when there's none"
+  fails "String#[] with Regexp returns subclass instances"
+  fails "String#[] with Regexp, index returns subclass instances"
 
   fails "String#dup does not copy constants defined in the singleton class"
   fails "String#dup does not modify the original string when changing dupped string"
@@ -157,6 +159,8 @@ opal_filter "String" do
   fails "String#slice with Regexp, index raises a TypeError when the given index is nil"
   fails "String#slice with Regexp, index sets $~ to MatchData when there is a match and nil when there's none"
   fails "String#slice with Regexp, group"
+  fails "String#slice with Regexp returns subclass instances"
+  fails "String#slice with Regexp, index returns subclass instances"
 
   fails "String#split with String returns subclass instances based on self"
   fails "String#split with Regexp respects $KCODE when splitting between characters"

--- a/spec/rubyspecs
+++ b/spec/rubyspecs
@@ -107,7 +107,7 @@ corelib/core/string/each_byte_spec
 corelib/core/string/each_char_spec
 corelib/core/string/each_codepoint_spec
 corelib/core/string/each_line_spec
-# corelib/core/string/element_reference_spec - fails to find a shared group - "String#[] with Regexp"
+corelib/core/string/element_reference_spec
 corelib/core/string/element_set_spec
 corelib/core/string/empty_spec
 corelib/core/string/encode_spec
@@ -149,7 +149,7 @@ corelib/core/string/rstrip_spec
 # corelib/core/string/scan_spec - infinite loop on parsing
 corelib/core/string/setbyte_spec
 corelib/core/string/size_spec
-# corelib/core/string/slice_spec - fails to find a shared thing (same as element_reference_spec)
+corelib/core/string/slice_spec
 corelib/core/string/split_spec
 corelib/core/string/squeeze_spec
 corelib/core/string/start_with_spec


### PR DESCRIPTION
DONE:
pass "String#[] with String returns other_str if it occurs in self"
pass "String#[] with String returns nil if there is no match"

TODO:
still fails "String#[] with String doesn't call to_str on its argument"
still fails "String#[] with String returns a subclass instance when
given a subclass instance”