### PR TITLE
Fix 'Cleanup Module#define_method' refucktor

### DIFF
--- a/opal/corelib/module.rb
+++ b/opal/corelib/module.rb
@@ -284,10 +284,10 @@ class Module
       block.$$def  = block;
 
       if (self.$$is_singleton) {
-        self.$$proto[jsid] = block;
+        self.$$proto[id] = block;
       }
       else {
-        Opal.defn(self, jsid, block);
+        Opal.defn(self, id, block);
       }
 
       return name;


### PR DESCRIPTION
After [Cleanup Module#define_method](https://github.com/opal/opal/commit/33c509101ec89e35f965ad700773fa1abdc0f5ad), this happens when trying to run the test suite:
```
$ rake mspec
[40, :filters]
[189, :shared]
[577, :rubyspecs]
mkdir -p tmp
RUBYOPT="-rbundler/setup -rmspec/opal/special_calls" bin/opal -Ispec -Ilib -gmspec  -smspec/helpers/tmp -smspec/helpers/environment -smspec/guards/block_device -smspec/guards/endian -rnodejs -Dwarning -A tmp/mspec_node.rb

/private/var/folders/pt/kr0lwm4d20jgc_jvpc5fyk1r0000gn/T/opal-nodejs-runner-20150225-3692-g51yt4:1989
        Opal.defn(self, jsid, block);
                        ^
ReferenceError: jsid is not defined
    at OpalClass.def.$define_method.TMP_2 [as $define_method] (/private/var/folders/pt/kr0lwm4d20jgc_jvpc5fyk1r0000gn/T/opal-nodejs-runner-20150225-3692-g51yt4:1989:25)
    at $a.$$p.TMP_2 (/private/var/folders/pt/kr0lwm4d20jgc_jvpc5fyk1r0000gn/T/opal-nodejs-runner-20150225-3692-g51yt4:18987:83)
    at self.$each.$$p (/private/var/folders/pt/kr0lwm4d20jgc_jvpc5fyk1r0000gn/T/opal-nodejs-runner-20150225-3692-g51yt4:4351:21)
    at Opal.yield1 (/private/var/folders/pt/kr0lwm4d20jgc_jvpc5fyk1r0000gn/T/opal-nodejs-runner-20150225-3692-g51yt4:817:14)
    at Array.def.$each.TMP_6 [as $each] (/private/var/folders/pt/kr0lwm4d20jgc_jvpc5fyk1r0000gn/T/opal-nodejs-runner-20150225-3692-g51yt4:6533:26)
    at Array.Opal.defn.TMP_14 (/private/var/folders/pt/kr0lwm4d20jgc_jvpc5fyk1r0000gn/T/opal-nodejs-runner-20150225-3692-g51yt4:4361:18)
    at OpalClass.def.$initialize.$arity [as $children] (/private/var/folders/pt/kr0lwm4d20jgc_jvpc5fyk1r0000gn/T/opal-nodejs-runner-20150225-3692-g51yt4:18987:130)
    at /private/var/folders/pt/kr0lwm4d20jgc_jvpc5fyk1r0000gn/T/opal-nodejs-runner-20150225-3692-g51yt4:19227:14
    at /private/var/folders/pt/kr0lwm4d20jgc_jvpc5fyk1r0000gn/T/opal-nodejs-runner-20150225-3692-g51yt4:19239:9
    at /private/var/folders/pt/kr0lwm4d20jgc_jvpc5fyk1r0000gn/T/opal-nodejs-runner-20150225-3692-g51yt4:19540:7
rake aborted!
Command failed with status (8): [RUBYOPT="-rbundler/setup -rmspec/opal/spec...]
```