### PR TITLE
Fix issue #666

### DIFF
--- a/opal/corelib/string.rb
+++ b/opal/corelib/string.rb
@@ -516,7 +516,7 @@ class String
 
   def match(pattern, pos = undefined, &block)
     if String === pattern || pattern.respond_to?(:to_str)
-      pattern = /#{Regexp.escape(pattern.to_str)}/
+      pattern = Regexp.new(pattern.to_str)
     end
 
     unless Regexp === pattern


### PR DESCRIPTION
Note that it says “…without escaping” in the spec:
```ruby
describe "String#match" do
  #…
  it "converts string patterns to regexps without escaping" do
    'hello'.match('(.)\1')[0].should == 'll'
  end
end
```