### PR TITLE
String#===, String#==, and String#eql? implementation fully compliant with rubyspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 *   `String#succ` and `String#next` implementation fully compliant with rubyspec
 
+*   `String#===`, `String#==`, and `String#eql?` implementation fully compliant with rubyspec
+
 ## 0.7.1 2015-02-14
 
 *   CLI options `-d` and `-v` now set respectively `$DEBUG` and `$VERBOSE`

--- a/opal/corelib/string.rb
+++ b/opal/corelib/string.rb
@@ -81,7 +81,16 @@ class String
   end
 
   alias eql? ==
-  alias === ==
+
+  def ===(other)
+    %x{
+      if (#{Opal.respond_to? `other`, :to_str}) {
+        return #{other == self};
+      } else {
+        return false;
+      }
+    }
+  end
 
   def =~(other)
     %x{

--- a/opal/corelib/string.rb
+++ b/opal/corelib/string.rb
@@ -75,22 +75,19 @@ class String
   end
 
   def ==(other)
-    return false unless String === other
-
-    `#{to_s} == #{other.to_s}`
+    %x{
+      if (other.$$is_string) {
+        return self.toString() === other.toString();
+      }
+      if (#{Opal.respond_to? `other`, :to_str}) {
+        return #{other == self};
+      }
+      return false;
+    }
   end
 
   alias eql? ==
-
-  def ===(other)
-    %x{
-      if (#{Opal.respond_to? `other`, :to_str}) {
-        return #{other == self};
-      } else {
-        return false;
-      }
-    }
-  end
+  alias === ==
 
   def =~(other)
     %x{

--- a/spec/filters/bugs/string.rb
+++ b/spec/filters/bugs/string.rb
@@ -1,7 +1,5 @@
 opal_filter "String" do
-  fails "String#=== returns false if obj does not respond to to_str"
-  fails "String#=== returns obj == self if obj responds to to_str"
-  fails "String#=== returns obj == self if obj responds to to_str"
+  fails "String#=== returns false if obj does not respond to to_str" #passes except for the line with symbol: fails "'hello'.send(@method, :hello).should be_false"
 
   fails "String#=~ raises a TypeError if a obj is a string"
 

--- a/spec/filters/bugs/string.rb
+++ b/spec/filters/bugs/string.rb
@@ -219,9 +219,8 @@ opal_filter "String" do
   fails "String#each_byte keeps iterating from the old position (to new string end) when self changes"
   fails "String#each_byte passes each byte in self to the given block"
 
-  fails "String#== returns obj == self if obj responds to to_str"
-  fails "String#== returns false if obj does not respond to to_str"
-  fails "String#eql? when given a non-String returns false"
+  fails "String#== returns false if obj does not respond to to_str" #passes except for the line with symbol: fails "'hello'.send(@method, :hello).should be_false"
+  fails "String#eql? when given a non-String returns false" #passes except for the line with symbol: fails "'hello'.should_not eql(:hello)"
 
   fails "String#hex treats leading characters of self as a string of hex digits"
 

--- a/spec/filters/bugs/string.rb
+++ b/spec/filters/bugs/string.rb
@@ -1,5 +1,4 @@
 opal_filter "String" do
-  fails "String#=== ignores subclass differences"
   fails "String#=== returns false if obj does not respond to to_str"
   fails "String#=== returns obj == self if obj responds to to_str"
   fails "String#=== returns obj == self if obj responds to to_str"


### PR DESCRIPTION
*"String#=== returns false if obj does not respond to to_str"* and  *"String#== returns false if obj does not respond to to_str"* actually pass, except for the one line that tests a symbol argument:
```ruby
'hello'.send(@method, :hello).should be_false
```
Same goes for *"String#eql? when given a non-String returns false"* - only the following line fails:
```ruby 
'hello'.should_not eql(:hello)
```
There is currently no way to pass these assertions because strings and symbols are identical in Opal.

I really would like to see those `fail` lines gone from filters/bugs/string.rb, and I see 3 possible courses of action (in the order from least invasive to most invasive to Opal):

1. Wrap `not_compliant_on :opal do ...` around the offending assertions in the rubyspec. 
2. Set a new additional property on the string object at compile time to indicate that is was originally meant to be a symbol. This way we can tell symbols from strings at runtime if/as needed with minimum overhead.
3. Make Symbol a subclass of String and set `$$is_symbol` flag on it? I don't like this one, but throwing it out there anyway.

What do you think?