### PR TITLE
Make `rake mspec_node` runnable on Windows

### DIFF
--- a/lib/opal/path_reader.rb
+++ b/lib/opal/path_reader.rb
@@ -9,7 +9,7 @@ module Opal
     def read(path)
       full_path = expand(path)
       return nil if full_path.nil?
-      File.read(full_path)
+      File.open(full_path, 'rb:UTF-8'){|f| f.read}
     end
 
     def expand(path)

--- a/tasks/testing.rake
+++ b/tasks/testing.rake
@@ -50,14 +50,13 @@ task :mspec_node do
   mkdir_p File.dirname(filename)
   File.write filename, <<-RUBY
     require 'spec_helper'
-    #{requires.join("    \n")}
+    #{requires.join("\n    ")}
     OSpecRunner.main.did_finish
   RUBY
 
-  stubs = " -smspec/helpers/tmp -smspec/helpers/environment -smspec/guards/block_device -smspec/guards/endian"
+  stubs = '-smspec/helpers/tmp -smspec/helpers/environment -smspec/guards/block_device -smspec/guards/endian'
 
-  sh 'RUBYOPT="-rbundler/setup -rmspec/opal/special_calls" '\
-     "bin/opal -Ispec -Ilib -gmspec #{stubs} -rnodejs -Dwarning -A #{filename}"
+  sh "ruby -rbundler/setup -rmspec/opal/special_calls bin/opal -Ispec -Ilib -gmspec #{stubs} -rnodejs -Dwarning -A #{filename}"
 end
 
 task :cruby_tests do


### PR DESCRIPTION
With a little care, the same Ruby code can run on Unix and on Windows.