### PR TITLE
Clean up spec/filters/bugs/kernel.rb

### DIFF
--- a/opal/corelib/kernel.rb
+++ b/opal/corelib/kernel.rb
@@ -13,7 +13,9 @@ module Kernel
 
   def <=>(other)
     %x{
-      if (#{self == other}) {
+      var x = #{self == other};
+
+      if (x && x !== nil) {
         return 0;
       }
 

--- a/spec/filters/bugs/kernel.rb
+++ b/spec/filters/bugs/kernel.rb
@@ -1,10 +1,3 @@
 opal_filter "Kernel" do
-  fails "Kernel.rand returns a float if no argument is passed"
-  fails "Kernel.rand returns an integer for an integer argument"
-
-  fails "Kernel#<=> returns 0 if self is == to the argument"
-  fails "Kernel#<=> returns nil if self is eql? but not == to the argument"
-  fails "Kernel#<=> returns nil if self.==(arg) returns nil"
-
   fails "Kernel#equal? returns true only if obj and other are the same object"
 end


### PR DESCRIPTION
The only remaining `fail` in that file cannot be made to pass until https://github.com/opal/opal/issues/729 is addressed.