### PR TITLE
Experiment: define object_id for strings, numbers, and booleans

### DIFF
--- a/opal/corelib/boolean.rb
+++ b/opal/corelib/boolean.rb
@@ -1,6 +1,11 @@
 class Boolean
   `def.$$is_boolean = true`
 
+  def __id__
+    `"boolean#" + self`
+  end
+  alias object_id __id__
+
   class << self
     undef_method :new
   end

--- a/opal/corelib/numeric.rb
+++ b/opal/corelib/numeric.rb
@@ -5,6 +5,11 @@ class Numeric
 
   `def.$$is_number = true`
 
+  def __id__
+    `"numeric#" + self`
+  end
+  alias object_id __id__
+
   def coerce(other, type = :operation)
     %x{
       if (other.$$is_number) {

--- a/opal/corelib/string.rb
+++ b/opal/corelib/string.rb
@@ -5,6 +5,11 @@ class String
 
   `def.$$is_string = true`
 
+  def __id__
+    `"string#" + self`
+  end
+  alias object_id __id__
+
   def self.try_convert(what)
     what.to_str
   rescue


### PR DESCRIPTION
Fix #729. This is just an experiment. For strings, numbers, and
booleans, `object_id` can be simply their string representation with a
static prefix to distinguish a string “123” from a number 123 whose
`object_id` would also be “123”, from an array whose `object_id` happens to be
123 because that’s what `Opal.uid` gave it. Hope this makes sense. No
idea about the performance implications.