### PR TITLE
Experiment 2: define object_id for strings, numbers, and booleans

### DIFF
--- a/opal/corelib/boolean.rb
+++ b/opal/corelib/boolean.rb
@@ -1,6 +1,11 @@
 class Boolean
   `def.$$is_boolean = true`
 
+  def __id__
+    `self.valueOf() ? 2 : 0`
+  end
+  alias object_id __id__
+
   class << self
     undef_method :new
   end

--- a/opal/corelib/numeric.rb
+++ b/opal/corelib/numeric.rb
@@ -5,6 +5,11 @@ class Numeric
 
   `def.$$is_number = true`
 
+  def __id__
+    `(self * 2) + 1`
+  end
+  alias object_id __id__
+
   def coerce(other, type = :operation)
     %x{
       if (other.$$is_number) {

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -29,8 +29,12 @@
   var $hasOwn = Opal.hasOwnProperty;
   var $slice  = Opal.slice = Array.prototype.slice;
 
-  // Generates unique id for every ruby object
-  var unique_id = 4;
+  // Nil object id is always 4
+  var nil_id = 4;
+
+  // Generates even sequential numbers greater than 4
+  // (nil_id) to serve as unique ids for ruby objects
+  var unique_id = nil_id;
 
   // Return next unique id
   Opal.uid = function() {
@@ -239,7 +243,7 @@
   function setup_module_or_class_object(module, constructor, superklass, prototype) {
     // @property $$id Each class is assigned a unique `id` that helps
     //                comparation and implementation of `#object_id`
-    module.$$id = unique_id++;
+    module.$$id = Opal.uid();
 
     // @property $$proto This is the prototype on which methods will be defined
     module.$$proto = prototype;
@@ -1418,7 +1422,7 @@
   // Nil
   Opal.klass(ObjectClass, ObjectClass, 'NilClass', NilClass);
   var nil = Opal.nil = new NilClass();
-  nil.$$id = 4;
+  nil.$$id = nil_id;
   nil.call = nil.apply = function() { throw Opal.LocalJumpError.$new('no block given'); };
 
   Opal.breaker  = new Error('unexpected break');

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -30,11 +30,12 @@
   var $slice  = Opal.slice = Array.prototype.slice;
 
   // Generates unique id for every ruby object
-  var unique_id = 0;
+  var unique_id = 4;
 
   // Return next unique id
   Opal.uid = function() {
-    return unique_id++;
+    unique_id += 2;
+    return unique_id;
   };
 
   // Table holds all class variables
@@ -1415,10 +1416,9 @@
   Opal.top = new ObjectClass.$$alloc();
 
   // Nil
-  var nil_id = Opal.uid(); // nil id is traditionally 4
   Opal.klass(ObjectClass, ObjectClass, 'NilClass', NilClass);
   var nil = Opal.nil = new NilClass();
-  nil.$$id = nil_id;
+  nil.$$id = 4;
   nil.call = nil.apply = function() { throw Opal.LocalJumpError.$new('no block given'); };
 
   Opal.breaker  = new Error('unexpected break');

--- a/opal/corelib/string.rb
+++ b/opal/corelib/string.rb
@@ -5,6 +5,11 @@ class String
 
   `def.$$is_string = true`
 
+  def __id__
+    `self.toString()`
+  end
+  alias object_id __id__
+
   def self.try_convert(what)
     what.to_str
   rescue

--- a/spec/opal/core/object_id_spec.rb
+++ b/spec/opal/core/object_id_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe "Opal.uid()" do
+  it "returns even sequential numbers in increments of 2" do
+    %x{
+      var id0 = Opal.uid(),
+          id1 = Opal.uid(),
+          id2 = Opal.uid(),
+          id3 = Opal.uid(),
+          id4 = Opal.uid();
+    }
+
+    modulo = `id0` % 2
+    modulo.should == 0
+
+    `id1`.should == `id0` + 2
+    `id2`.should == `id0` + 4
+    `id3`.should == `id0` + 6
+    `id4`.should == `id0` + 8
+  end
+end
+
+describe "FalseClass#object_id" do
+  it "returns 0" do
+    false.object_id.should == 0
+  end
+end
+
+describe "TrueClass#object_id" do
+  it "returns 2" do
+    true.object_id.should == 2
+  end
+end
+
+describe "NilClass#object_id" do
+  it "returns 4" do
+    nil.object_id.should == 4
+  end
+end
+
+describe "Numeric#object_id" do
+  it "returns (self * 2) + 1" do
+    0.object_id.should == 1
+    1.object_id.should == 3
+    2.object_id.should == 5
+    420.object_id.should == 841
+    -2.object_id.should == -3
+    -1.object_id.should == -1
+  end
+end
+
+describe "String#object_id" do
+  it "returns the primitive string version of self" do
+    `#{"hello".object_id} === "hello".toString()`.should be_true
+  end
+end


### PR DESCRIPTION
Fix #729. A different approach:

For strings, object_id can be simply their string representation. For
booleans, numbers, and nil, follow the MRI scheme:

* false: 0
* true: 2
* nil: 4
* numbers: (n * 2) + 1
* heap objects: 6, 8, 10, 12, 14, 16, etc…