### PR TITLE
Pass "Struct anonymous class instance methods includes Enumerable"

### DIFF
--- a/opal/corelib/module.rb
+++ b/opal/corelib/module.rb
@@ -334,7 +334,7 @@ class Module
 
   def include?(mod)
     %x{
-      for (var cls = self; cls; cls = cls.parent) {
+      for (var cls = self; cls; cls = cls.$$super) {
         for (var i = 0; i != cls.$$inc.length; i++) {
           var mod2 = cls.$$inc[i];
           if (mod === mod2) {

--- a/opal/corelib/struct.rb
+++ b/opal/corelib/struct.rb
@@ -1,4 +1,8 @@
+require 'corelib/enumerable'
+
 class Struct
+  include Enumerable
+
   def self.new(name = undefined, *args, &block)
     return super unless self == Struct
 
@@ -34,11 +38,10 @@ class Struct
   end
 
   def self.inherited(klass)
-    return if self == Struct
-
     members = @members
 
     klass.instance_eval {
+      include Enumerable
       @members = members
     }
   end
@@ -46,8 +49,6 @@ class Struct
   class << self
     alias [] new
   end
-
-  include Enumerable
 
   def initialize(*args)
     members.each_with_index {|name, index|

--- a/opal/corelib/struct.rb
+++ b/opal/corelib/struct.rb
@@ -41,7 +41,6 @@ class Struct
     members = @members
 
     klass.instance_eval {
-      include Enumerable
       @members = members
     }
   end

--- a/spec/filters/bugs/module.rb
+++ b/spec/filters/bugs/module.rb
@@ -38,4 +38,15 @@ opal_filter "Module" do
   fails "Module#module_function as a toggle (no arguments) in a Module body does not affect module_evaled method definitions also if outside the eval itself"
   fails "Module#module_function as a toggle (no arguments) in a Module body has no effect if inside a module_eval if the definitions are outside of it"
   fails "Module#module_function with specific method names creates an independent copy of the method, not a redirect"
+
+  fails "Module#include adds all ancestor modules when a previously included module is included again"
+  fails "Module#include raises a TypeError when the argument is not a Module"
+  fails "Module#include imports instance methods to modules and classes"
+  fails "Module#include doesn't include module if it is included in a super class"
+  fails "Module#include recursively includes new mixins"
+  fails "Module#include preserves ancestor order"
+  fails "Module#include detects cyclic includes"
+  fails "Module#include ignores modules it has already included via module mutual inclusion"
+  fails "Module#include? returns true if the given module is included by self or one of it's ancestors"
+  fails "Module#include? raises a TypeError when no module was given"
 end

--- a/spec/filters/bugs/struct.rb
+++ b/spec/filters/bugs/struct.rb
@@ -1,7 +1,4 @@
 opal_filter "Struct" do
-  fails "Struct includes Enumerable"
-  fails "Struct anonymous class instance methods includes Enumerable"
-
   fails "Struct#[] fails when it does not know about the requested attribute"
   fails "Struct#[] fails if not passed a string, symbol, or integer"
 

--- a/spec/rubyspecs
+++ b/spec/rubyspecs
@@ -73,6 +73,7 @@ corelib/core/module/class_variable_get_spec
 corelib/core/module/class_variable_set_spec
 corelib/core/module/module_function_spec
 corelib/core/module/const_get_spec
+corelib/core/module/include_spec
 
 corelib/core/range/begin_spec
 corelib/core/range/case_compare_spec


### PR DESCRIPTION
@meh, I need your help with this one - I don't know what I'm doing :) You [fixed Struct inheritance back in 2013](https://github.com/opal/opal/commit/9677ea31a2630b3690507b9722b5730f7d0ea544), and you have this guard clause in your code: `return if self == Struct`. I removed it and all tests pass, but I'm worried I'm missing something here.

Also, I'm doing `include Enumerable` in the `self.inherited` hook even though `Struct` already has `include Enumerable` at the class level. If I don't do that, `StructClasses::Car.include?(Enumerable).should == true` fails. `StructClasses::Car` is defined as follows:
```ruby
module StructClasses
  Car = Struct.new(:make, :model, :year)
end
```
So, is including `Enumerable` inside `self.inherited` the right way to go, or am I brute-forcing something that is really a bug to be fixed elsewhere?