### PR TITLE
String#intern and String#to_sym fully compliant with rubyspec

### DIFF
--- a/spec/filters/bugs/string.rb
+++ b/spec/filters/bugs/string.rb
@@ -57,9 +57,6 @@ opal_filter "String" do
 
   fails "String#index raises a TypeError if passed a Symbol"
 
-  # fails "String#intern does not special case certain operators"
-  # fails "String#intern special cases +(binary) and -(binary)"
-
   fails "String#lines accepts a string separator"
   fails "String#lines should split on the default record separator and return enumerator if not block is given"
   fails "String#lines splits using default newline separator when none is specified"
@@ -139,9 +136,6 @@ opal_filter "String" do
   fails "String#sum returns sum of the bytes in self if n less or equal to zero"
 
   fails "String#to_str returns a new instance of String when called on a subclass"
-
-  # fails "String#to_sym does not special case certain operators"
-  # fails "String#to_sym special cases +(binary) and -(binary)"
 
   fails "String#tr raises an ArgumentError a descending range in the replacement as containing just the start character"
   fails "String#tr raises an ArgumentError a descending range in the source as empty"

--- a/spec/filters/bugs/string.rb
+++ b/spec/filters/bugs/string.rb
@@ -57,8 +57,8 @@ opal_filter "String" do
 
   fails "String#index raises a TypeError if passed a Symbol"
 
-  fails "String#intern does not special case certain operators"
-  fails "String#intern special cases +(binary) and -(binary)"
+  # fails "String#intern does not special case certain operators"
+  # fails "String#intern special cases +(binary) and -(binary)"
 
   fails "String#lines accepts a string separator"
   fails "String#lines should split on the default record separator and return enumerator if not block is given"
@@ -140,8 +140,8 @@ opal_filter "String" do
 
   fails "String#to_str returns a new instance of String when called on a subclass"
 
-  fails "String#to_sym does not special case certain operators"
-  fails "String#to_sym special cases +(binary) and -(binary)"
+  # fails "String#to_sym does not special case certain operators"
+  # fails "String#to_sym special cases +(binary) and -(binary)"
 
   fails "String#tr raises an ArgumentError a descending range in the replacement as containing just the start character"
   fails "String#tr raises an ArgumentError a descending range in the source as empty"


### PR DESCRIPTION
Special-casing of +(binary) and -(binary) [has been removed from Ruby](https://www.ruby-forum.com/topic/4418067).

These specs originally failed for me on Windows, but the reason turned out to have nothing to do with Windows, but rather with the version of Ruby I had installed on that Windows machine, which was `ruby 2.0.0p247 (2013-06-27) [i386-mingw32]`. After updating to `ruby 2.0.0p643 (2015-02-25) [i386-mingw32]`, the specs passed.