### PR TITLE
Pass "Kernel#equal? returns true only if obj and other are the same object"

### DIFF
--- a/spec/filters/bugs/kernel.rb
+++ b/spec/filters/bugs/kernel.rb
@@ -1,3 +1,2 @@
 opal_filter "Kernel" do
-  fails "Kernel#equal? returns true only if obj and other are the same object"
 end


### PR DESCRIPTION
With *"('stuff'.equal? 'stuff').should == false" cannot be supported on Opal* now [merged](https://github.com/opal/rubyspec/pull/2) into opal/rubyspec, the last remaining failing assertion for *"Kernel#equal? returns true only if obj and other are the same object”* is passing. The last remaining failure can safely be removed from filters/bugs/kernel now.