### PR TITLE
Use `["new"]` instead of `.new` because `new` is a reserved keyword on IE < 9

### DIFF
--- a/spec/opal/stdlib/native/native_class_spec.rb
+++ b/spec/opal/stdlib/native/native_class_spec.rb
@@ -13,6 +13,6 @@ describe "Class#native_class" do
 
   it 'aliases Class#new to the unprefixed new method in JS world' do
     SomeClass.native_class
-    `Opal.global.SomeClass.new()`.is_a?(SomeClass).should == true
+    `Opal.global.SomeClass["new"]()`.is_a?(SomeClass).should == true
   end
 end

--- a/stdlib/native.rb
+++ b/stdlib/native.rb
@@ -550,7 +550,7 @@ class Class
 
   def native_class
     native_module
-    `self.new = self.$new;`
+    `self["new"] = self.$new;`
   end
 end
 


### PR DESCRIPTION
This takes care of the initial roadblock trying to run rubyspec on IE. Next up, dealing with invalid regexp flags per https://github.com/opal/opal/issues/740#issuecomment-78251397 which is not an IE-specific issue.