### PR TITLE
Clean up Array#partition bug filter

### DIFF
--- a/spec/filters/bugs/array.rb
+++ b/spec/filters/bugs/array.rb
@@ -182,8 +182,6 @@ opal_filter "Array" do
   fails "Array#hash returns the same fixnum for arrays with the same content"
 
   fails "Array#partition returns in the left array values for which the block evaluates to true"
-  fails "Array#partition returns two arrays"
-  fails "Array#partition does not return subclass instances on Array subclasses"
 
   fails "Array#| acts as if using an intermediate hash to collect values"
 


### PR DESCRIPTION
Pass "Array#partition returns two arrays"
Pass "Array#partition does not return subclass instances on Array subclasses"

Still fails "Array#partition returns in the left array values for which the block evaluates to true" because of a problem with integer division in Opal (see https://github.com/opal/opal/issues/748)

E.g. `[0, 1, 2, 3, 4, 5].partition { |i| i / 3 == 0 }`
Expected: `[[0, 1, 2], [3, 4, 5]]`
Actual: `[[0], [1, 2, 3, 4, 5]]`