### PR TITLE
Templates with locals

### DIFF
--- a/lib/opal/builder_processors.rb
+++ b/lib/opal/builder_processors.rb
@@ -132,6 +132,14 @@ module Opal
         erb_compiler = erb_compiler_class.new(source, path)
         erb_compiler.prepared_source
       end
+
+      def compiled
+        @compiled ||= begin
+          compiler = compiler_for(@source, file: @filename, template: true)
+          compiler.compile
+          compiler
+        end
+      end
     end
 
     class ERBProcessor < Processor

--- a/lib/opal/builder_processors.rb
+++ b/lib/opal/builder_processors.rb
@@ -87,7 +87,7 @@ module Opal
 
       def compiled
         @compiled ||= begin
-          compiler = compiler_for(@source, file: @filename)
+          compiler = compiler_for(@source, default_compiler_options)
           compiler.compile
           compiler
         end
@@ -95,6 +95,10 @@ module Opal
 
       def compiler_for(source, options = {})
         compiler_class.new(source, @options.merge(options))
+      end
+
+      def default_compiler_options
+        { file: @filename }
       end
 
       def requires
@@ -133,12 +137,8 @@ module Opal
         erb_compiler.prepared_source
       end
 
-      def compiled
-        @compiled ||= begin
-          compiler = compiler_for(@source, file: @filename, template: true)
-          compiler.compile
-          compiler
-        end
+      def default_compiler_options
+        super.update({ template: true })
       end
     end
 

--- a/lib/opal/cli.rb
+++ b/lib/opal/cli.rb
@@ -148,6 +148,7 @@ module Opal
         source_map_enabled
         irb_enabled
         inline_operators
+        template
       ]
     end
 

--- a/lib/opal/cli_options.rb
+++ b/lib/opal/cli_options.rb
@@ -136,6 +136,10 @@ module Opal
         options[:irb] = true
       end
 
+      on('--template', 'Template local variables mode') do
+        options[:template] = true
+      end
+
       separator ''
     end
 

--- a/lib/opal/compiler.rb
+++ b/lib/opal/compiler.rb
@@ -86,6 +86,11 @@ module Opal
     # compile top level local vars with support for irb style vars
     compiler_option :irb, false, :as => :irb?
 
+    #@!method template?
+    #
+    # compile file with support for local variables (used by Template)
+    compiler_option :template, false, :as => :template?
+
     # @!method dynamic_require_severity
     #
     # how to handle dynamic requires (:error, :warning, :ignore)

--- a/lib/opal/erb.rb
+++ b/lib/opal/erb.rb
@@ -46,7 +46,7 @@ module Opal
       end
 
       def compile
-        Opal.compile prepared_source
+        Opal.compile prepared_source, :template => true
       end
 
       def fix_quotes(result)
@@ -77,7 +77,7 @@ module Opal
 
       def wrap_compiled(result)
         path = @file_name.sub(/\.opalerb$/, '')
-        result = "Template.new('#{path}') do |output_buffer|\noutput_buffer.append(\"#{result}\")\noutput_buffer.join\nend\n"
+        result = "Template.new('#{path}') do |output_buffer, __locals = {}|\noutput_buffer.append(\"#{result}\")\noutput_buffer.join\nend\n"
       end
     end
   end

--- a/lib/opal/erb.rb
+++ b/lib/opal/erb.rb
@@ -77,7 +77,13 @@ module Opal
 
       def wrap_compiled(result)
         path = @file_name.sub(/\.opalerb$/, '')
-        result = "Template.new('#{path}') do |output_buffer, __locals = {}|\noutput_buffer.append(\"#{result}\")\noutput_buffer.join\nend\n"
+
+        <<-RUBY
+          Template.new("#{path}") do |output_buffer, __locals = {}|
+            output_buffer.append("#{result}")
+            output_buffer.join
+          end
+        RUBY
       end
     end
   end

--- a/spec/opal/stdlib/erb/erb_spec.rb
+++ b/spec/opal/stdlib/erb/erb_spec.rb
@@ -2,12 +2,14 @@ require 'erb'
 require File.expand_path('../simple', __FILE__)
 require File.expand_path('../quoted', __FILE__)
 require File.expand_path('../inline_block', __FILE__)
+require File.expand_path('../with_locals', __FILE__)
 
 describe "ERB files" do
   before :each do
     @simple = Template['opal/stdlib/erb/simple']
     @quoted = Template['opal/stdlib/erb/quoted']
     @inline_block = Template['opal/stdlib/erb/inline_block']
+    @with_locals = Template['opal/stdlib/erb/with_locals']
   end
 
   it "should be defined by their filename on Template namespace" do
@@ -26,5 +28,12 @@ describe "ERB files" do
 
   it "should be able to handle inline blocks" do
     @inline_block.should be_kind_of(Template)
+  end
+
+  describe 'template locals' do
+    it 'can pass local variables to a template' do
+      def self.non_local; 'Ford'; end
+      @with_locals.render(self, :is_local => 'Perfect').should =~ /Ford\ Perfect/
+    end
   end
 end

--- a/spec/opal/stdlib/erb/with_locals.opalerb
+++ b/spec/opal/stdlib/erb/with_locals.opalerb
@@ -1,0 +1,1 @@
+<%= non_local %> <%= is_local %>

--- a/stdlib/template.rb
+++ b/stdlib/template.rb
@@ -23,8 +23,8 @@ class Template
     "#<Template: '#@name'>"
   end
 
-  def render(ctx = self)
-    ctx.instance_exec(OutputBuffer.new, &@body)
+  def render(ctx = self, locals = {})
+    ctx.instance_exec(OutputBuffer.new, locals, &@body)
   end
 
   class OutputBuffer


### PR DESCRIPTION
**WIP Do not merge **

This pull request supports a new compiler option, `:template`. It is off by default (the most common case), but when turned on it makes any local variable reference check if it exists against a local hash (we assume a string key, as given variable names must be a string or symbol), and uses the value given if present, otherwise resorts to a method call.

The purpose of this switch is to allow ERB and HAML templates to have a hash of local variables passed in. The ERB and HAML builder processors and compilers set the `:template` flag manually.

## Future work

Really, this should be extended out to allow any file to evaluate in the context of a hash of local variables, which would allow us to mimic a binding (very basic mimicking). Also, compiled files should have the ability to take a custom `self` attribute, so a compiled file does not always have to run in the context of `Opal.top`, the main object. This will allow `eval()` to work with a custom object context.