### PR TITLE
Fix failing RubySpec: Array#clone copies singleton methods

### DIFF
--- a/opal/corelib/array.rb
+++ b/opal/corelib/array.rb
@@ -522,6 +522,15 @@ class Array
 
   def clone
     copy = []
+    %x{
+      for (var key in self) {
+        if (key[0] == "$" && typeof(self[key]) === "function") {
+          if (self.hasOwnProperty(key) && self[key].$$stub === undefined) {
+            copy[key] = self[key];
+          }
+        }
+      }
+    }
     copy.initialize_clone(self)
     copy
   end
@@ -694,8 +703,6 @@ class Array
       return self.slice(number);
     }
   end
-
-  alias dup clone
 
   def each(&block)
     return enum_for :each unless block_given?

--- a/spec/filters/bugs/array.rb
+++ b/spec/filters/bugs/array.rb
@@ -1,5 +1,4 @@
 opal_filter "Array" do
-  fails "Array#clone copies singleton methods"
 
   fails "Array#combination generates from a defensive copy, ignoring mutations"
   fails "Array#combination yields a partition consisting of only singletons"


### PR DESCRIPTION
`Array#clone` must copy singleton methods over. `Array#dup` should not.