### PR TITLE
Fixing failing RubySpec Singleton dump_spec

### DIFF
--- a/spec/filters/bugs/singleton.rb
+++ b/spec/filters/bugs/singleton.rb
@@ -1,6 +1,4 @@
 opal_filter "Singleton" do
-  fails "Singleton#_dump returns an empty string"
-  fails "Singleton#_dump returns an empty string from a singleton subclass"
   fails "Singleton.instance returns an instance of the singleton's clone"
   fails "Singleton.instance returns the same instance for multiple class to instance on clones"
 end

--- a/stdlib/singleton.rb
+++ b/stdlib/singleton.rb
@@ -7,6 +7,10 @@ module Singleton
     raise TypeError, "can't dup instance of singleton #{self.class}"
   end
 
+  def _dump
+    ""
+  end
+
   module SingletonClassMethods
 
     def clone


### PR DESCRIPTION
Singleton#_dump returns an empty string
Singleton#_dump returns an empty string from a singleton subclass