### PR TITLE
RFC: String#casecmp fully compliant with rubyspec

### DIFF
--- a/opal/corelib/string.rb
+++ b/opal/corelib/string.rb
@@ -210,8 +210,14 @@ class String
 
   def casecmp(other)
     other = Opal.coerce_to(other, String, :to_str).to_s
-
-    `self.toLowerCase()` <=> `other.toLowerCase()`
+    %x{
+      var ascii_only = /^[\x00-\x7F]*$/;
+      if (ascii_only.test(self) && ascii_only.test(other)) {
+        self = self.toLowerCase();
+        other = other.toLowerCase();
+      }
+    }
+    self <=> other
   end
 
   def center(width, padstr = ' ')

--- a/spec/filters/bugs/string.rb
+++ b/spec/filters/bugs/string.rb
@@ -136,9 +136,6 @@ opal_filter "String" do
   fails "String#sub with pattern and Hash taints the result if the original string is tainted"
   fails "String#sub with pattern and Hash taints the result if a hash value is tainted"
 
-  fails "String#casecmp independent of case for non-ASCII characters returns -1 when numerically less than other"
-  fails "String#casecmp independent of case for non-ASCII characters returns 1 when numerically greater than other"
-
   fails "String#byteslice returns the character code of the character at the given index"
   fails "String#byteslice returns nil if index is outside of self"
   fails "String#byteslice calls to_int on the given index"


### PR DESCRIPTION
Not sure about this one, need your feedback.

It looks like strings that contain non-ascii characters should not be lower-cased per rubyspec.

1. Does the above statement make sense?
2. Does my code for determining that a string is ascii-only make sense?

Thanks!