### PR TITLE
Fix incorrect MatchData#pre_match and #post_match behavior

### DIFF
--- a/opal/corelib/match_data.rb
+++ b/opal/corelib/match_data.rb
@@ -6,8 +6,8 @@ class MatchData
     @regexp     = regexp
     @begin      = `match_groups.index`
     @string     = `match_groups.input`
-    @pre_match  = `#@string.substr(0, regexp.lastIndex - match_groups[0].length)`
-    @post_match = `#@string.substr(regexp.lastIndex)`
+    @pre_match  = `match_groups.input.slice(0, match_groups.index)`
+    @post_match = `match_groups.input.slice(match_groups.index + match_groups[0].length)`
     @matches    = []
 
     %x{


### PR DESCRIPTION
Despite passing rubyspec, the behavior of these methods does not match MRI:

MRI:
```
$ ruby -e "'hello'.sub(/ll/, ''); p $~.pre_match, $~.post_match"
"he"
"o"
```
Opal before the fix:
```
$ bundle exec opal -e "'hello'.sub(/ll/, ''); p $~.pre_match, $~.post_match"
""
"hello"
```
Opal after the fix:
```
$ bundle exec opal -e "'hello'.sub(/ll/, ''); p $~.pre_match, $~.post_match"
"he"
"o"
```
