### PR TITLE
Fix underscore stripping regex in Kernel#Integer and Kernel#Float

### DIFF
--- a/opal/corelib/kernel.rb
+++ b/opal/corelib/kernel.rb
@@ -478,7 +478,7 @@ module Kernel
 
       str = value.toLowerCase();
 
-      str = str.replace(/(\d)_(\d)/g, '$1$2');
+      str = str.replace(/(\d)_(?=\d)/g, '$1');
 
       str = str.replace(/^(\s*[+-]?)(0[bodx]?)/, function (_, head, flag) {
         switch (flag) {
@@ -536,7 +536,7 @@ module Kernel
       if (value.$$is_string) {
         str = value.toString();
 
-        str = str.replace(/(\d)_(\d)/g, '$1$2');
+        str = str.replace(/(\d)_(?=\d)/g, '$1');
 
         if (!/^\s*[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?\s*$/.test(str)) {
           #{raise ArgumentError, "invalid value for Float(): \"#{value}\""}


### PR DESCRIPTION
The original regex `/(\d)_(\d)/g` did not handle some cases correctly (it did look so cute though!)

E.g. `"10_1_0.5_5_5"` became `"101_0.55_5"` instead of the expected `"1010.555"`. This issue was not caught by any of the rubyspec code for `Kernel#Integer` and `Kernel#Float`, but surfaced when testing `Kernel#format`. Changing the regex to `/(\d)_(?=\d)/g` fixed the issue.