### PR TITLE
Kernel#Float accepts hex strings as a special case

### DIFF
--- a/opal/corelib/kernel.rb
+++ b/opal/corelib/kernel.rb
@@ -538,6 +538,11 @@ module Kernel
 
         str = str.replace(/(\d)_(?=\d)/g, '$1');
 
+        //Special case for hex strings only:
+        if (/^\s*[-+]?0[xX][0-9a-fA-F]+\s*$/.test(str)) {
+          return #{Integer(`str`)};
+        }
+
         if (!/^\s*[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?\s*$/.test(str)) {
           #{raise ArgumentError, "invalid value for Float(): \"#{value}\""}
         }


### PR DESCRIPTION
This behavior is not specified in rubyspec for `Kernel#Float`, but it
is tested in `Kernel#format`.

Surprisingly, `Kernel#Float` accepts hexadecimal strings, but no other
integer notation that is accepted by `Kernel#Integer`. I.e. `0x10` is
ok, but `0b10`, `0d10`, `0o10` are not acceptable. Looks like a bug to
me. I guess this PR makes Opal’s `Kernel#Float` a bug-for-bug
implementation of MRI’s `Kernel#Float` :)

```
$ pry
[1] pry(main)> Float("010")
=> 10.0
[2] pry(main)> Float("0o10")
ArgumentError: invalid value for Float(): "0o10"
from (pry):2:in `Float'
[3] pry(main)> Float("0b10")
ArgumentError: invalid value for Float(): "0b10"
from (pry):3:in `Float'
[4] pry(main)> Float("0d10")
ArgumentError: invalid value for Float(): "0d10"
from (pry):4:in `Float'
[5] pry(main)> Float("0x10")
=> 16.0
```