### PR TITLE
Fix deletion of rb/js/opal extension in Opal::Builder

### DIFF
--- a/lib/opal/builder.rb
+++ b/lib/opal/builder.rb
@@ -101,7 +101,7 @@ module Opal
     end
 
     def process_require(filename, options)
-      filename.gsub(/\.(rb|js|opal)$/, '')
+      filename.gsub!(/\.(rb|js|opal)$/, '')
       return if prerequired.include?(filename)
       return if already_processed.include?(filename)
       already_processed << filename


### PR DESCRIPTION
Well, I was having a look at the latest commits and I noticed that we `gsub` gaining no effect. So let's `gsub!`.

Also, just saying, at the moment machines running OSX 10.10.3 cannot `bundle` because of [this](http://stackoverflow.com/questions/29529455/missing-c-header-debug-after-updating-osx-command-line-tools-6-3).