### PR TITLE
Enable inline_operators by default

### DIFF
--- a/lib/opal/compiler.rb
+++ b/lib/opal/compiler.rb
@@ -102,7 +102,7 @@ module Opal
     # @!method inline_operators?
     #
     # are operators compiled inline
-    compiler_option :inline_operators, false, :as => :inline_operators?
+    compiler_option :inline_operators, true, :as => :inline_operators?
 
     # @return [String] The compiled ruby code
     attr_reader :result

--- a/lib/opal/sprockets/processor.rb
+++ b/lib/opal/sprockets/processor.rb
@@ -63,7 +63,7 @@ module Opal
     self.dynamic_require_severity    = :error # :error, :warning or :ignore
     self.source_map_enabled          = true
     self.irb_enabled                 = false
-    self.inline_operators_enabled    = false
+    self.inline_operators_enabled    = true
 
 
     def evaluate(context, locals, &block)

--- a/opal/corelib/array/inheritance.rb
+++ b/opal/corelib/array/inheritance.rb
@@ -116,4 +116,12 @@ class Array::Wrapper
   def flatten(level = undefined)
     self.class.allocate(@literal.flatten(level))
   end
+
+  def -(other)
+    @literal - other
+  end
+
+  def +(other)
+    @literal + other
+  end
 end

--- a/opal/corelib/string/inheritance.rb
+++ b/opal/corelib/string/inheritance.rb
@@ -75,4 +75,21 @@ class String::Wrapper
   def inspect
     @literal.inspect
   end
+
+  def +(other)
+    @literal + other
+  end
+
+  def *(other)
+    %x{
+      var result = #{@literal * other};
+
+      if (result.$$is_string) {
+        return #{self.class.allocate(`result`)}
+      }
+      else {
+        return result;
+      }
+    }
+  end
 end


### PR DESCRIPTION
Pass failing rubyspecs for String and Array inheritance