### PR TITLE
String#index fully compliant with rubyspec

### DIFF
--- a/spec/filters/bugs/opal.rb
+++ b/spec/filters/bugs/opal.rb
@@ -5,10 +5,5 @@ opal_filter "Opal bugs" do
   fails "Array#shift passed a number n as an argument raises an ArgumentError if more arguments are passed"
   fails "Array#pop passed a number n as an argument raises an ArgumentError if more arguments are passed"
 
-  # lacking regexp conversion
-  fails "String#index with Regexp supports \\G which matches at the given start offset"
-  fails "String#index with Regexp starts the search at the given offset"
-  fails "String#index with Regexp returns the index of the first match of regexp"
-
   fails "Kernel#warn requires multiple arguments"
 end

--- a/spec/filters/unsupported/regular_expressions.rb
+++ b/spec/filters/unsupported/regular_expressions.rb
@@ -32,14 +32,16 @@ opal_filter "regular_expressions" do
 
   fails "MatchData#regexp returns the pattern used in the match"
 
-  fails "String#sub with pattern, replacement supports \\G which matches at the beginning of the string"
-
   fails "String#gsub with pattern and replacement replaces \\k named backreferences with the regexp's corresponding capture"
   fails "String#gsub with pattern and replacement doesn't freak out when replacing ^" #Only fails "Text\nFoo".gsub(/^/, ' ').should == " Text\n Foo"
   fails "String#gsub with pattern and replacement supports \\G which matches at the beginning of the remaining (non-matched) string"
   fails "String#gsub with pattern and replacement returns a copy of self with all occurrences of pattern replaced with replacement" #Only fails str.gsub(/\Ah\S+\s*/, "huh? ").should == "huh? homely world. hah!"
 
-  fails "String#scan supports \\G which matches the end of the previous match / string start for first match"
+  fails "String#index with Regexp supports \\G which matches at the given start offset"
 
   fails "String#match matches \\G at the start of the string"
+
+  fails "String#scan supports \\G which matches the end of the previous match / string start for first match"
+
+  fails "String#sub with pattern, replacement supports \\G which matches at the beginning of the string"
 end


### PR DESCRIPTION
My goal was to clean up the failures, and it turned out that modifying `String#index` implementation was not necessary to make the failures go away, but re-writing it in JS made it over 2x faster based on my very un-scientific benchmark, so I decided to keep my re-implementation of `String#index`.

Before:
```
$ bundle exec opal -e "t = Time.now; 100000.times{'hello'.index(/ll/)}; puts Time.now - t"
1.44
$ bundle exec opal -e "t = Time.now; 100000.times{'hello'.index(/ll/)}; puts Time.now - t"
1.547
$ bundle exec opal -e "t = Time.now; 100000.times{'hello'.index(/ll/)}; puts Time.now - t"
1.537
$ bundle exec opal -e "t = Time.now; 100000.times{'hello'.index(/ll/)}; puts Time.now - t"
1.416
```
After:
```
$ bundle exec opal -e "t = Time.now; 100000.times{'hello'.index(/ll/)}; puts Time.now - t"
0.614
$ bundle exec opal -e "t = Time.now; 100000.times{'hello'.index(/ll/)}; puts Time.now - t"
0.611
$ bundle exec opal -e "t = Time.now; 100000.times{'hello'.index(/ll/)}; puts Time.now - t"
0.62
```
Lesson learned over and over again - corelib must be implemented in JS. It will be fun re-writing the methods that use Ruby and watching the perf numbers improve. But first, need a way to generate perf numbers :)