### PR TITLE
Enable benchmarking of rubyspecs

### DIFF
--- a/stdlib/nodejs/file.rb
+++ b/stdlib/nodejs/file.rb
@@ -84,7 +84,7 @@ class File < IO
   attr_reader :path
 
   def write string
-    `__fs__.writeSync(#{@fd}, #{string}, null, #{string}.length)`
+    `__fs__.writeSync(#{@fd}, #{string})`
   end
 
   def flush

--- a/tasks/testing.rake
+++ b/tasks/testing.rake
@@ -49,11 +49,12 @@ task :mspec_node do
   requires = specs.map{|s| "require '#{s.sub(/^spec\//,'')}'"}
   filename = 'tmp/mspec_node.rb'
   mkdir_p File.dirname(filename)
+  enter_benchmarking_mode = ENV['BM'] && "OSpecRunner.main.bm!(#{Integer(ENV['BM'])})"
   File.write filename, <<-RUBY
     # Node v0.12 showed to need more tolerance, rubyspec default is  0.00003
     TOLERANCE = 0.00004
     require 'spec_helper'
-    #{ENV['BM'] && "OSpecRunner.main.bm! #{Integer(ENV['BM'])}"}
+    #{enter_benchmarking_mode}
     #{requires.join("\n    ")}
     OSpecRunner.main.did_finish
   RUBY

--- a/tasks/testing.rake
+++ b/tasks/testing.rake
@@ -53,6 +53,7 @@ task :mspec_node do
     # Node v0.12 showed to need more tolerance, rubyspec default is  0.00003
     TOLERANCE = 0.00004
     require 'spec_helper'
+    #{ENV['BM'] && "OSpecRunner.main.bm! #{Integer(ENV['BM'])}"}
     #{requires.join("\n    ")}
     OSpecRunner.main.did_finish
   RUBY


### PR DESCRIPTION
Re https://github.com/opal/opal/issues/736

This is the first phase of the project: just getting the raw performance data.

The way it works is you run the spec suite as you normally would, but set the `BM` environment variable to the number of iterations you want MSpec to perform on each `it` block. If this environment variable is present, Opal MSpec runner will record the number of milliseconds taken for each spec (across all iterations) and, at the end of the run, dump a JSON object with spec names for keys and milliseconds for values into a time-stamped file in the `tmp` directory.
```
$ bundle exec rake mspec_node PATTERN=spec/corelib/core/string/index_spec.rb BM=100
...
Finished
2000 examples, 0 failures (time taken: 2.8919999599456787)
```
Notice the `BM=100` above, and how it affects the number of examples: it's `2000 examples` instead of the normal `20 examples` for this spec file. It is actually 20 examples executed 100 times each, so don't be confused by that output.
```
$ cat tmp/bm_2015-05-03_15-53-48-662.json 
{
  "String#index raises a TypeError if passed nil": 45,
  "String#index raises a TypeError if passed a boolean": 41,
  "String#index calls #to_str to convert the first argument": 74,
  "String#index calls #to_int to convert the second argument": 72,
  "String#index raises a TypeError if passed a Fixnum": 29,
  "String#index with String behaves the same as String#index(char) for one-character strings": 340,
  "String#index with String returns the index of the first occurrence of the given substring": 50,
  "String#index with String doesn't set $~": 23,
  "String#index with String ignores string subclasses": 36,
  "String#index with String starts the search at the given offset": 110,
  "String#index with String starts the search at offset + self.length if offset is negative": 239,
  "String#index with String returns nil if the substring isn't found": 33,
  "String#index with Regexp behaves the same as String#index(string) for escaped string regexps": 1244,
  "String#index with Regexp returns the index of the first match of regexp": 51,
  "String#index with Regexp sets $~ to MatchData of match and nil when there's none": 25,
  "String#index with Regexp starts the search at the given offset": 73,
  "String#index with Regexp starts the search at offset + self.length if offset is negative": 238,
  "String#index with Regexp returns nil if the substring isn't found": 36,
  "String#index with Regexp returns nil if the Regexp matches the empty string and the offset is out of range": 23,
  "String#index with Regexp converts start_offset to an integer via to_int": 56
}
```
Phase 2 would be to create a rake task that can analyze data files from two or more runs. "Analyze" is a very open-ended proposition, I would appreciate feedback from the community on this one. What should the rake workflow be? What should the results of the analysis look like?

Phase 3 would be the ability to push (from a rake task as well?) the analysis results to a web app (hosted on Heroku?) for the purpose of tracking how Opal is doing vis-a-vis performance over time. Maybe integrate with GitHub too?

Phase 2 is fuzzy to me. Phase 3 is even fuzzier. Maybe the analysis in Phase 2 should not be done locally at all, and instead upload the files to a web app directly? In which case Phase 2 and 3 are the same thing?

So, any ideas are very much welcome, and code is even more welcome!