### PR TITLE
Support tilt integration without sprockets

### DIFF
--- a/lib/opal/sprockets/processor.rb
+++ b/lib/opal/sprockets/processor.rb
@@ -8,12 +8,17 @@ require 'opal/sprockets/source_map_server'
 $OPAL_SOURCE_MAPS = {}
 
 module Opal
-  class Processor
+  class Processor < TiltTemplate
     class << self
       attr_accessor :source_map_enabled
     end
 
     self.source_map_enabled          = true
+
+    def self.inherited(subclass)
+      super
+      subclass.source_map_enabled = source_map_enabled
+    end
 
     def evaluate(context, locals, &block)
       return super unless context.is_a? ::Sprockets::Context
@@ -171,6 +176,9 @@ module Opal
     end
   end
 end
+
+Tilt.register 'rb',   Opal::Processor
+Tilt.register 'opal', Opal::Processor
 
 Sprockets.register_engine '.rb',  Opal::Processor
 Sprockets.register_engine '.opal',  Opal::Processor

--- a/lib/opal/sprockets/processor.rb
+++ b/lib/opal/sprockets/processor.rb
@@ -8,38 +8,12 @@ require 'opal/sprockets/source_map_server'
 $OPAL_SOURCE_MAPS = {}
 
 module Opal
-  # The Processor class is used to make ruby files (with rb or opal extensions)
-  # available to any sprockets based server. Processor will then get passed any
-  # ruby source file to build. There are some options you can override globally
-  # which effect how certain ruby features are handled:
-  #
-  #   * method_missing_enabled      [true by default]
-  #   * arity_check_enabled         [false by default]
-  #   * const_missing_enabled       [true by default]
-  #   * dynamic_require_severity    [:error by default]
-  #   * source_map_enabled          [true by default]
-  #   * irb_enabled                 [false by default]
-  #   * inline_operators_enabled    [false by default]
-  #
   class Processor
     class << self
-      attr_accessor :method_missing_enabled
-      attr_accessor :arity_check_enabled
-      attr_accessor :const_missing_enabled
-      attr_accessor :dynamic_require_severity
       attr_accessor :source_map_enabled
-      attr_accessor :irb_enabled
-      attr_accessor :inline_operators_enabled
     end
 
-    self.method_missing_enabled      = true
-    self.arity_check_enabled         = false
-    self.const_missing_enabled       = true
-    self.dynamic_require_severity    = :error # :error, :warning or :ignore
     self.source_map_enabled          = true
-    self.irb_enabled                 = false
-    self.inline_operators_enabled    = true
-
 
     def evaluate(context, locals, &block)
       return super unless context.is_a? ::Sprockets::Context
@@ -82,12 +56,6 @@ module Opal
 
     def sprockets_extnames_regexp
       @sprockets_extnames_regexp ||= self.class.sprockets_extnames_regexp(@sprockets)
-    end
-
-    def compiler_options
-      # Not using self.class because otherwise would check subclasses for
-      # attr_accessors they have but are not set.
-      ::Opal::Processor.compiler_options
     end
 
     def process_requires(requires, context)
@@ -200,18 +168,6 @@ module Opal
 
     def stubbed_files
       self.class.stubbed_files
-    end
-
-    def self.compiler_options
-      {
-        :method_missing           => method_missing_enabled,
-        :arity_check              => arity_check_enabled,
-        :const_missing            => const_missing_enabled,
-        :dynamic_require_severity => dynamic_require_severity,
-        :irb                      => irb_enabled,
-        :inline_operators         => inline_operators_enabled,
-        :requirable               => true,
-      }
     end
   end
 end

--- a/lib/opal/sprockets/processor.rb
+++ b/lib/opal/sprockets/processor.rb
@@ -1,7 +1,6 @@
 require 'set'
-require 'tilt'
+require 'tilt/opal'
 require 'sprockets'
-require 'opal/version'
 require 'opal/builder'
 require 'opal/sprockets/path_reader'
 require 'opal/sprockets/source_map_server'
@@ -22,31 +21,7 @@ module Opal
   #   * irb_enabled                 [false by default]
   #   * inline_operators_enabled    [false by default]
   #
-  class Processor < Tilt::Template
-    # vvv BOILERPLATE vvv
-    self.default_mime_type = 'application/javascript'
-
-    def self.engine_initialized?
-      true
-    end
-
-    def self.version
-      ::Opal::VERSION
-    end
-
-    def initialize_engine
-      require_template_library 'opal'
-    end
-
-    def prepare
-    end
-    # ^^^ BOILERPLATE ^^^
-
-    def self.inherited(subclass)
-      subclass.default_mime_type = 'application/javascript'
-    end
-
-
+  class Processor
     class << self
       attr_accessor :method_missing_enabled
       attr_accessor :arity_check_enabled
@@ -67,7 +42,7 @@ module Opal
 
 
     def evaluate(context, locals, &block)
-      return Opal.compile data, file: file unless context.is_a? ::Sprockets::Context
+      return super unless context.is_a? ::Sprockets::Context
 
       @sprockets = sprockets = context.environment
 
@@ -241,8 +216,5 @@ module Opal
   end
 end
 
-Tilt.register 'rb',               Opal::Processor
 Sprockets.register_engine '.rb',  Opal::Processor
-
-Tilt.register 'opal',               Opal::Processor
 Sprockets.register_engine '.opal',  Opal::Processor

--- a/lib/tilt/opal.rb
+++ b/lib/tilt/opal.rb
@@ -5,8 +5,35 @@ require 'opal/version'
 $OPAL_SOURCE_MAPS = {}
 
 module Opal
+  # The Processor class is used to make ruby files (with rb or opal extensions)
+  # available to any sprockets based server. Processor will then get passed any
+  # ruby source file to build. There are some options you can override globally
+  # which effect how certain ruby features are handled:
+  #
+  #   * method_missing_enabled      [true by default]
+  #   * arity_check_enabled         [false by default]
+  #   * const_missing_enabled       [true by default]
+  #   * dynamic_require_severity    [:error by default]
+  #   * irb_enabled                 [false by default]
+  #   * inline_operators_enabled    [false by default]
+  #
   class Processor < Tilt::Template
-    # vvv BOILERPLATE vvv
+    class << self
+      attr_accessor :method_missing_enabled
+      attr_accessor :arity_check_enabled
+      attr_accessor :const_missing_enabled
+      attr_accessor :dynamic_require_severity
+      attr_accessor :irb_enabled
+      attr_accessor :inline_operators_enabled
+    end
+
+    self.method_missing_enabled      = true
+    self.arity_check_enabled         = false
+    self.const_missing_enabled       = true
+    self.dynamic_require_severity    = :error # :error, :warning or :ignore
+    self.irb_enabled                 = false
+    self.inline_operators_enabled    = true
+
     self.default_mime_type = 'application/javascript'
 
     def self.inherited(subclass)
@@ -21,6 +48,18 @@ module Opal
       ::Opal::VERSION
     end
 
+    def self.compiler_options
+      {
+        :method_missing           => method_missing_enabled,
+        :arity_check              => arity_check_enabled,
+        :const_missing            => const_missing_enabled,
+        :dynamic_require_severity => dynamic_require_severity,
+        :irb                      => irb_enabled,
+        :inline_operators         => inline_operators_enabled,
+        :requirable               => true,
+      }
+    end
+
     module InstanceMethods
       def initialize_engine
         require_template_library 'opal'
@@ -30,7 +69,15 @@ module Opal
       end
 
       def evaluate(context, locals, &block)
-        Opal.compile data, file: file
+        compiler_options = self.compiler_options.merge(file: file)
+        compiler = Compiler.new(data, compiler_options)
+        compiler.compile.to_s
+      end
+
+      def compiler_options
+        # Not using self.class because otherwise would check subclasses for
+        # attr_accessors they have but are not set.
+        ::Opal::Processor.compiler_options
       end
     end
 

--- a/lib/tilt/opal.rb
+++ b/lib/tilt/opal.rb
@@ -1,0 +1,42 @@
+require 'tilt'
+require 'opal/compiler'
+require 'opal/version'
+
+$OPAL_SOURCE_MAPS = {}
+
+module Opal
+  class Processor < Tilt::Template
+    # vvv BOILERPLATE vvv
+    self.default_mime_type = 'application/javascript'
+
+    def self.inherited(subclass)
+      subclass.default_mime_type = default_mime_type
+    end
+
+    def self.engine_initialized?
+      true
+    end
+
+    def self.version
+      ::Opal::VERSION
+    end
+
+    module InstanceMethods
+      def initialize_engine
+        require_template_library 'opal'
+      end
+
+      def prepare
+      end
+
+      def evaluate(context, locals, &block)
+        Opal.compile data, file: file
+      end
+    end
+
+    include InstanceMethods
+  end
+end
+
+Tilt.register 'rb',   Opal::Processor
+Tilt.register 'opal', Opal::Processor

--- a/spec/lib/tilt/opal_spec.rb
+++ b/spec/lib/tilt/opal_spec.rb
@@ -1,0 +1,19 @@
+require 'lib/spec_helper'
+require 'tilt/opal'
+
+describe Opal::Processor do
+  %w[rb js.rb opal js.opal].each do |ext|
+    let(:ext) { ext }
+
+    describe %Q{with extension ".#{ext}"} do
+      it "is registered for '.#{ext}' files" do
+        expect(Tilt["test.#{ext}"]).to eq(described_class)
+      end
+
+      it "compiles and evaluates the template on #render" do
+        template = described_class.new('file') { |t| "puts 'Hello, World!'\n" }
+        expect(template.render(Object.new)).to include('"Hello, World!"')
+      end
+    end
+  end
+end

--- a/spec/lib/tilt/opal_spec.rb
+++ b/spec/lib/tilt/opal_spec.rb
@@ -1,13 +1,13 @@
 require 'lib/spec_helper'
 require 'tilt/opal'
 
-describe Opal::Processor do
+describe Opal::TiltTemplate do
   %w[rb js.rb opal js.opal].each do |ext|
     let(:ext) { ext }
 
     describe %Q{with extension ".#{ext}"} do
       it "is registered for '.#{ext}' files" do
-        expect(Tilt["test.#{ext}"]).to eq(described_class)
+        expect(Tilt["test.#{ext}"]).to be <= described_class
       end
 
       it "compiles and evaluates the template on #render" do


### PR DESCRIPTION
This adds a tilt/opal.rb file that allows you to render opal templates
via Tilt without using sprockets. It changes lib/opal/sprockets/processor.rb
to load tilt/opal.rb and augment it with sprockets specific code.

This allows you to use opal with asset engines that don't use sprockets.

I'm not sure where to add specs for this, if you could point me to the appropriate place, I'll add some specs.  Ideally, these specs would load tilt/opal without loading lib/opal/sprockets/processor, to ensure that tilt/opal works standalone.  I've tested that manually, but I think there should be automated tests for it.