### PR TITLE
Opal::Config

### DIFF
--- a/lib/mspec/opal/rake_task.rb
+++ b/lib/mspec/opal/rake_task.rb
@@ -1,3 +1,4 @@
+require 'opal'
 require 'rack'
 require 'webrick'
 require 'mspec/opal/special_calls'

--- a/lib/opal/config.rb
+++ b/lib/opal/config.rb
@@ -1,0 +1,42 @@
+module Opal
+  module Config
+    def self.default_config
+      {
+        method_missing_enabled:    true,
+        arity_check_enabled:       false,
+        const_missing_enabled:     true,
+        dynamic_require_severity:  :error, # :error, :warning or :ignore
+        irb_enabled:               false,
+        inline_operators_enabled:  true,
+        source_map_enabled:        true,
+      }
+    end
+
+    def self.config
+      @config ||= default_config
+    end
+
+    def self.reset!
+      @config = nil
+    end
+
+    COMPILER_KEYS = Set.new %i[
+      method_missing
+      arity_check
+      const_missing
+      dynamic_require_severity
+      irb
+      inline_operators
+    ]
+
+    def self.compiler_options
+      compiler_keys = COMPILER_KEYS
+      config.select { |k,_v| compiler_keys.include? k }
+    end
+
+    default_config.keys.each do |config_option|
+      define_singleton_method(config_option) { config[config_option] }
+      define_singleton_method("#{config_option}=") { |value| config[config_option] = value }
+    end
+  end
+end

--- a/lib/opal/config.rb
+++ b/lib/opal/config.rb
@@ -1,3 +1,5 @@
+require 'set'
+
 module Opal
   module Config
     def self.default_config
@@ -20,18 +22,22 @@ module Opal
       @config = nil
     end
 
-    COMPILER_KEYS = Set.new %i[
-      method_missing
-      arity_check
-      const_missing
-      dynamic_require_severity
-      irb
-      inline_operators
-    ]
+    COMPILER_KEYS = {
+      method_missing:           :method_missing_enabled,
+      arity_check:              :arity_check_enabled,
+      const_missing:            :const_missing_enabled,
+      dynamic_require_severity: :dynamic_require_severity,
+      irb:                      :irb_enabled,
+      inline_operators:         :inline_operators_enabled,
+    }
 
     def self.compiler_options
-      compiler_keys = COMPILER_KEYS
-      config.select { |k,_v| compiler_keys.include? k }
+      config = self.config
+      compiler_options = {}
+      COMPILER_KEYS.each do |compiler_option_name, option_name|
+        compiler_options[compiler_option_name] = config[option_name]
+      end
+      compiler_options
     end
 
     default_config.keys.each do |config_option|

--- a/lib/opal/sprockets/processor.rb
+++ b/lib/opal/sprockets/processor.rb
@@ -12,15 +12,11 @@ module Opal
   # available to any sprockets based server. Processor will then get passed any
   # ruby source file to build.
   class Processor < TiltTemplate
-    class << self
-      attr_accessor :source_map_enabled
-    end
-
     # DEPRECATED:
     # Support legacy accessors to default options, now moved to Opal::Config
     Opal::Config.default_config.keys.each do |config_option|
-      define_method(config_option) { Opal::Config.config[config_option] }
-      define_method("#{config_option}=") { |value| Opal::Config.config[config_option] = value }
+      define_singleton_method(config_option) { Opal::Config.config[config_option] }
+      define_singleton_method("#{config_option}=") { |value| Opal::Config.config[config_option] = value }
     end
 
     def evaluate(context, locals, &block)

--- a/lib/opal/sprockets/processor.rb
+++ b/lib/opal/sprockets/processor.rb
@@ -176,8 +176,5 @@ module Opal
   end
 end
 
-Tilt.register 'rb',   Opal::Processor
-Tilt.register 'opal', Opal::Processor
-
 Sprockets.register_engine '.rb',  Opal::Processor
 Sprockets.register_engine '.opal',  Opal::Processor

--- a/lib/opal/sprockets/processor.rb
+++ b/lib/opal/sprockets/processor.rb
@@ -8,16 +8,19 @@ require 'opal/sprockets/source_map_server'
 $OPAL_SOURCE_MAPS = {}
 
 module Opal
+  # The Processor class is used to make ruby files (with rb or opal extensions)
+  # available to any sprockets based server. Processor will then get passed any
+  # ruby source file to build.
   class Processor < TiltTemplate
     class << self
       attr_accessor :source_map_enabled
     end
 
-    self.source_map_enabled          = true
-
-    def self.inherited(subclass)
-      super
-      subclass.source_map_enabled = source_map_enabled
+    # DEPRECATED:
+    # Support legacy accessors to default options, now moved to Opal::Config
+    Opal::Config.default_config.keys.each do |config_option|
+      define_method(config_option) { Opal::Config.config[config_option] }
+      define_method("#{config_option}=") { |value| Opal::Config.config[config_option] = value }
     end
 
     def evaluate(context, locals, &block)
@@ -46,7 +49,7 @@ module Opal
       process_requires(compiler.requires, context)
       process_required_trees(compiler.required_trees, context)
 
-      if self.class.source_map_enabled
+      if Opal::Config.source_map_enabled
         map_contents = compiler.source_map.as_json.to_json
         ::Opal::SourceMapServer.set_map_cache(sprockets, logical_path, map_contents)
       end

--- a/lib/tilt/opal.rb
+++ b/lib/tilt/opal.rb
@@ -9,6 +9,10 @@ module Opal
   class TiltTemplate < Tilt::Template
     self.default_mime_type = 'application/javascript'
 
+    def self.inherited(subclass)
+      subclass.default_mime_type = 'application/javascript'
+    end
+
     def self.engine_initialized?
       true
     end

--- a/lib/tilt/opal.rb
+++ b/lib/tilt/opal.rb
@@ -1,48 +1,13 @@
 require 'tilt'
 require 'opal/compiler'
+require 'opal/config'
 require 'opal/version'
 
 $OPAL_SOURCE_MAPS = {}
 
 module Opal
-  # The Processor class is used to make ruby files (with rb or opal extensions)
-  # available to any sprockets based server. Processor will then get passed any
-  # ruby source file to build. There are some options you can override globally
-  # which effect how certain ruby features are handled:
-  #
-  #   * method_missing_enabled      [true by default]
-  #   * arity_check_enabled         [false by default]
-  #   * const_missing_enabled       [true by default]
-  #   * dynamic_require_severity    [:error by default]
-  #   * irb_enabled                 [false by default]
-  #   * inline_operators_enabled    [false by default]
-  #
   class TiltTemplate < Tilt::Template
-    class << self
-      attr_accessor :method_missing_enabled
-      attr_accessor :arity_check_enabled
-      attr_accessor :const_missing_enabled
-      attr_accessor :dynamic_require_severity
-      attr_accessor :irb_enabled
-      attr_accessor :inline_operators_enabled
-    end
-
-    self.method_missing_enabled      = true
-    self.arity_check_enabled         = false
-    self.const_missing_enabled       = true
-    self.dynamic_require_severity    = :error # :error, :warning or :ignore
-    self.irb_enabled                 = false
-    self.inline_operators_enabled    = true
-
     self.default_mime_type = 'application/javascript'
-
-    def self.inherited(subclass)
-      super
-      %w'default_mime_type method_missing_enabled arity_check_enabled const_missing_enabled
-         dynamic_require_severity irb_enabled inline_operators_enabled'.each do |meth|
-        subclass.send("#{meth}=", send(meth))
-      end
-    end
 
     def self.engine_initialized?
       true
@@ -53,15 +18,7 @@ module Opal
     end
 
     def self.compiler_options
-      {
-        :method_missing           => method_missing_enabled,
-        :arity_check              => arity_check_enabled,
-        :const_missing            => const_missing_enabled,
-        :dynamic_require_severity => dynamic_require_severity,
-        :irb                      => irb_enabled,
-        :inline_operators         => inline_operators_enabled,
-        :requirable               => true,
-      }
+      Opal::Config.compiler_options.merge(requirable: true)
     end
 
     def initialize_engine
@@ -72,7 +29,7 @@ module Opal
     end
 
     def evaluate(context, locals, &block)
-      compiler_options = self.compiler_options.merge(file: file)
+      compiler_options = Opal::Config.compiler_options.merge(file: file)
       compiler = Compiler.new(data, compiler_options)
       compiler.compile.to_s
     end

--- a/spec/lib/sprockets/processor_spec.rb
+++ b/spec/lib/sprockets/processor_spec.rb
@@ -18,12 +18,12 @@ describe Opal::Processor do
     is_a?: true,
   ) }
 
-  %w[rb js.rb opal js.opal].each do |ext|
+  %w[.rb .opal].each do |ext|
     let(:ext) { ext }
 
-    describe %Q{with extension ".#{ext}"} do
-      it "is registered for '.#{ext}' files" do
-        expect(Tilt["test.#{ext}"]).to eq(described_class)
+    describe %Q{with extension "#{ext}"} do
+      it "is registered for '#{ext}' files" do
+        expect(Sprockets.engines[ext]).to eq(described_class)
       end
 
       it "compiles and evaluates the template on #render" do


### PR DESCRIPTION
Completes PR #829 by @jeremyevans 

- extracts global/default config from Opal::Processor to the new entry Opal::Config (but still keeps config proxies on Opal::Processor)
- stops registering Opal::Processor as a Tilt template, we now have a dedicated class

I'll merge immediately, the PR is just to give it a bit of visibility :tophat: 