### PR TITLE
RubySpec: Moving specs for Singleton#_dump to /unsupported

### DIFF
--- a/spec/filters/bugs/singleton.rb
+++ b/spec/filters/bugs/singleton.rb
@@ -1,6 +1,4 @@
 opal_filter "Singleton" do
-  fails "Singleton#_dump returns an empty string"
-  fails "Singleton#_dump returns an empty string from a singleton subclass"
   fails "Singleton.instance returns an instance of the singleton's clone"
   fails "Singleton.instance returns the same instance for multiple class to instance on clones"
 end

--- a/spec/filters/unsupported/marshal.rb
+++ b/spec/filters/unsupported/marshal.rb
@@ -1,0 +1,4 @@
+opal_filter "Singleton" do
+  fails "Singleton#_dump returns an empty string"
+  fails "Singleton#_dump returns an empty string from a singleton subclass"
+end


### PR DESCRIPTION
Replaces pull request #760