### PR TITLE
Make opal/builder depend on opal/paths

### DIFF
--- a/lib/opal/builder.rb
+++ b/lib/opal/builder.rb
@@ -1,5 +1,6 @@
 require 'opal/path_reader'
 require 'opal/builder_processors'
+require 'opal/paths'
 require 'set'
 
 module Opal


### PR DESCRIPTION
It doesn't seem to work if you require opal/builder without
opal/paths.