### PR TITLE
Replace ^ and $ with \A and \z in regular expressions

### DIFF
--- a/lib/mspec/opal/rake_task.rb
+++ b/lib/mspec/opal/rake_task.rb
@@ -163,7 +163,7 @@ module MSpec
 
       def paths_from_glob pattern
         Dir.glob(File.expand_path(pattern)).map do |s|
-          s.sub(/^#{basedir}\//, '').sub(/\.rb$/, '')
+          s.sub(/\A#{basedir}\//, '').sub(/\.rb\z/, '')
         end
       end
 

--- a/lib/opal/builder.rb
+++ b/lib/opal/builder.rb
@@ -84,7 +84,7 @@ module Opal
         globs = extensions.map { |ext| File.join base, tree, '**', "*.#{ext}" }
 
         Dir[*globs].map do |file|
-          Pathname(file).relative_path_from(Pathname(base)).to_s.gsub(/(\.js)?(\.(?:#{extensions.join '|'}))\z/, '')
+          Pathname(file).relative_path_from(Pathname(base)).to_s.gsub(/(\.js)?(\.(?:#{extensions.join '|'}))#{REGEXP_END}/, '')
         end
       end
     end
@@ -101,7 +101,7 @@ module Opal
     end
 
     def process_require(filename, options)
-      filename.gsub!(/\.(rb|js|opal)\z/, '')
+      filename.gsub!(/\.(rb|js|opal)#{REGEXP_END}/, '')
       return if prerequired.include?(filename)
       return if already_processed.include?(filename)
       already_processed << filename

--- a/lib/opal/builder.rb
+++ b/lib/opal/builder.rb
@@ -84,7 +84,7 @@ module Opal
         globs = extensions.map { |ext| File.join base, tree, '**', "*.#{ext}" }
 
         Dir[*globs].map do |file|
-          Pathname(file).relative_path_from(Pathname(base)).to_s.gsub(/(\.js)?(\.(?:#{extensions.join '|'}))$/, '')
+          Pathname(file).relative_path_from(Pathname(base)).to_s.gsub(/(\.js)?(\.(?:#{extensions.join '|'}))\z/, '')
         end
       end
     end
@@ -101,7 +101,7 @@ module Opal
     end
 
     def process_require(filename, options)
-      filename.gsub!(/\.(rb|js|opal)$/, '')
+      filename.gsub!(/\.(rb|js|opal)\z/, '')
       return if prerequired.include?(filename)
       return if already_processed.include?(filename)
       already_processed << filename

--- a/lib/opal/builder_processors.rb
+++ b/lib/opal/builder_processors.rb
@@ -27,7 +27,7 @@ module Opal
         matches = extensions.join('|')
         matches = "(#{matches})" if extensions.size == 1
 
-        @match_regexp = Regexp.new "\\.#{matches}$"
+        @match_regexp = Regexp.new "\\.#{matches}\z"
       end
 
       def self.extensions
@@ -87,7 +87,7 @@ module Opal
 
       def compiled
         @compiled ||= begin
-          compiler = compiler_for(@source, file: @filename.gsub(/\.(rb|js|opal)$/, ''))
+          compiler = compiler_for(@source, file: @filename.gsub(/\.(rb|js|opal)\z/, ''))
           compiler.compile
           compiler
         end

--- a/lib/opal/builder_processors.rb
+++ b/lib/opal/builder_processors.rb
@@ -27,7 +27,7 @@ module Opal
         matches = extensions.join('|')
         matches = "(#{matches})" if extensions.size == 1
 
-        @match_regexp = Regexp.new "\\.#{matches}\z"
+        @match_regexp = Regexp.new "\\.#{matches}$"
       end
 
       def self.extensions

--- a/lib/opal/builder_processors.rb
+++ b/lib/opal/builder_processors.rb
@@ -27,7 +27,7 @@ module Opal
         matches = extensions.join('|')
         matches = "(#{matches})" if extensions.size == 1
 
-        @match_regexp = Regexp.new "\\.#{matches}$"
+        @match_regexp = Regexp.new "\\.#{matches}#{REGEXP_END}"
       end
 
       def self.extensions
@@ -87,7 +87,7 @@ module Opal
 
       def compiled
         @compiled ||= begin
-          compiler = compiler_for(@source, file: @filename.gsub(/\.(rb|js|opal)\z/, ''))
+          compiler = compiler_for(@source, file: @filename.gsub(/\.(rb|js|opal)#{REGEXP_END}/, ''))
           compiler.compile
           compiler
         end

--- a/lib/opal/erb.rb
+++ b/lib/opal/erb.rb
@@ -76,7 +76,7 @@ module Opal
       end
 
       def wrap_compiled(result)
-        path = @file_name.sub(/\.opalerb$/, '')
+        path = @file_name.sub(/\.opalerb\z/, '')
         result = "Template.new('#{path}') do |output_buffer|\noutput_buffer.append(\"#{result}\")\noutput_buffer.join\nend\n"
       end
     end

--- a/lib/opal/erb.rb
+++ b/lib/opal/erb.rb
@@ -76,7 +76,7 @@ module Opal
       end
 
       def wrap_compiled(result)
-        path = @file_name.sub(/\.opalerb\z/, '')
+        path = @file_name.sub(/\.opalerb#{REGEXP_END}/, '')
         result = "Template.new('#{path}') do |output_buffer|\noutput_buffer.append(\"#{result}\")\noutput_buffer.join\nend\n"
       end
     end

--- a/lib/opal/nodes/call.rb
+++ b/lib/opal/nodes/call.rb
@@ -90,7 +90,7 @@ module Opal
       end
 
       def attr_assignment?
-        @assignment ||= meth.to_s =~ /\A[\da-z]+\=\z/i
+        @assignment ||= meth.to_s =~ /#{REGEXP_START}[\da-z]+\=#{REGEXP_END}/i
       end
 
       # Used to generate the code to use this sexp as an ivar var reference

--- a/lib/opal/nodes/call.rb
+++ b/lib/opal/nodes/call.rb
@@ -90,7 +90,7 @@ module Opal
       end
 
       def attr_assignment?
-        @assignment ||= meth.to_s =~ /^[\da-z]+\=$/i
+        @assignment ||= meth.to_s =~ /\A[\da-z]+\=\z/i
       end
 
       # Used to generate the code to use this sexp as an ivar var reference

--- a/lib/opal/nodes/call_special.rb
+++ b/lib/opal/nodes/call_special.rb
@@ -12,7 +12,7 @@ module Opal
 
       def default_compile
         # Skip, for now, if the method has square brackets: []=
-        return super if meth.to_s !~ /^\w+=$/
+        return super if meth.to_s !~ /\A\w+=\z/
 
         with_temp do |args_tmp|
           with_temp do |recv_tmp|

--- a/lib/opal/nodes/call_special.rb
+++ b/lib/opal/nodes/call_special.rb
@@ -12,7 +12,7 @@ module Opal
 
       def default_compile
         # Skip, for now, if the method has square brackets: []=
-        return super if meth.to_s !~ /\A\w+=\z/
+        return super if meth.to_s !~ /#{REGEXP_START}\w+=#{REGEXP_END}/
 
         with_temp do |args_tmp|
           with_temp do |recv_tmp|

--- a/lib/opal/nodes/helpers.rb
+++ b/lib/opal/nodes/helpers.rb
@@ -1,19 +1,21 @@
+require 'opal/regexp_anchors'
+
 module Opal
   module Nodes
     module Helpers
 
       # Reserved javascript keywords - we cannot create variables with the
       # same name (ref: http://stackoverflow.com/a/9337272/601782)
-      ES51_RESERVED_WORD = /\A(?:do|if|in|for|let|new|try|var|case|else|enum|eval|false|null|this|true|void|with|break|catch|class|const|super|throw|while|yield|delete|export|import|public|return|static|switch|typeof|default|extends|finally|package|private|continue|debugger|function|arguments|interface|protected|implements|instanceof)\z/
+      ES51_RESERVED_WORD = /#{REGEXP_START}(?:do|if|in|for|let|new|try|var|case|else|enum|eval|false|null|this|true|void|with|break|catch|class|const|super|throw|while|yield|delete|export|import|public|return|static|switch|typeof|default|extends|finally|package|private|continue|debugger|function|arguments|interface|protected|implements|instanceof)#{REGEXP_END}/
 
       # ES3 reserved words that aren’t ES5.1 reserved words
-      ES3_RESERVED_WORD_EXCLUSIVE = /\A(?:int|byte|char|goto|long|final|float|short|double|native|throws|boolean|abstract|volatile|transient|synchronized)\z/
+      ES3_RESERVED_WORD_EXCLUSIVE = /#{REGEXP_START}(?:int|byte|char|goto|long|final|float|short|double|native|throws|boolean|abstract|volatile|transient|synchronized)#{REGEXP_END}/
 
       # Immutable properties of the global object
-      IMMUTABLE_PROPS = /\A(?:NaN|Infinity|undefined)\z/
+      IMMUTABLE_PROPS = /#{REGEXP_START}(?:NaN|Infinity|undefined)#{REGEXP_END}/
 
       # Doesn't take in account utf8
-      BASIC_IDENTIFIER_RULES = /\A[$_a-z][$_a-z\d]*\z/i
+      BASIC_IDENTIFIER_RULES = /#{REGEXP_START}[$_a-z][$_a-z\d]*#{REGEXP_END}/i
 
 
       def property(name)

--- a/lib/opal/nodes/helpers.rb
+++ b/lib/opal/nodes/helpers.rb
@@ -4,16 +4,16 @@ module Opal
 
       # Reserved javascript keywords - we cannot create variables with the
       # same name (ref: http://stackoverflow.com/a/9337272/601782)
-      ES51_RESERVED_WORD = /^(?:do|if|in|for|let|new|try|var|case|else|enum|eval|false|null|this|true|void|with|break|catch|class|const|super|throw|while|yield|delete|export|import|public|return|static|switch|typeof|default|extends|finally|package|private|continue|debugger|function|arguments|interface|protected|implements|instanceof)$/
+      ES51_RESERVED_WORD = /\A(?:do|if|in|for|let|new|try|var|case|else|enum|eval|false|null|this|true|void|with|break|catch|class|const|super|throw|while|yield|delete|export|import|public|return|static|switch|typeof|default|extends|finally|package|private|continue|debugger|function|arguments|interface|protected|implements|instanceof)\z/
 
       # ES3 reserved words that aren’t ES5.1 reserved words
-      ES3_RESERVED_WORD_EXCLUSIVE = /^(?:int|byte|char|goto|long|final|float|short|double|native|throws|boolean|abstract|volatile|transient|synchronized)$/
+      ES3_RESERVED_WORD_EXCLUSIVE = /\A(?:int|byte|char|goto|long|final|float|short|double|native|throws|boolean|abstract|volatile|transient|synchronized)\z/
 
       # Immutable properties of the global object
-      IMMUTABLE_PROPS = /^(?:NaN|Infinity|undefined)$/
+      IMMUTABLE_PROPS = /\A(?:NaN|Infinity|undefined)\z/
 
       # Doesn't take in account utf8
-      BASIC_IDENTIFIER_RULES = /^[$_a-z][$_a-z\d]*$/i
+      BASIC_IDENTIFIER_RULES = /\A[$_a-z][$_a-z\d]*\z/i
 
 
       def property(name)

--- a/lib/opal/parser/lexer.rb
+++ b/lib/opal/parser/lexer.rb
@@ -1,3 +1,4 @@
+require 'opal/regexp_anchors'
 require 'strscan'
 require 'opal/parser/keywords'
 
@@ -558,7 +559,7 @@ module Opal
             matched += scanner.matched
           end
 
-        elsif matched =~ /\A[A-Z]/
+        elsif matched =~ /#{REGEXP_START}[A-Z]/
           result = :tCONSTANT
         else
           result = :tIDENTIFIER
@@ -627,7 +628,7 @@ module Opal
         @lex_state = :expr_end
       end
 
-      return matched =~ /\A[A-Z]/ ? :tCONSTANT : :tIDENTIFIER
+      return matched =~ /#{REGEXP_START}[A-Z]/ ? :tCONSTANT : :tIDENTIFIER
     end
 
     # Does the heavy lifting for `next_token`.

--- a/lib/opal/parser/lexer.rb
+++ b/lib/opal/parser/lexer.rb
@@ -558,7 +558,7 @@ module Opal
             matched += scanner.matched
           end
 
-        elsif matched =~ /^[A-Z]/
+        elsif matched =~ /\A[A-Z]/
           result = :tCONSTANT
         else
           result = :tIDENTIFIER
@@ -627,7 +627,7 @@ module Opal
         @lex_state = :expr_end
       end
 
-      return matched =~ /^[A-Z]/ ? :tCONSTANT : :tIDENTIFIER
+      return matched =~ /\A[A-Z]/ ? :tCONSTANT : :tIDENTIFIER
     end
 
     # Does the heavy lifting for `next_token`.

--- a/lib/opal/regexp_anchors.rb
+++ b/lib/opal/regexp_anchors.rb
@@ -1,0 +1,5 @@
+module Opal
+  REGEXP_START = RUBY_ENGINE == 'opal' ? '^' : '\A'.freeze
+  REGEXP_END = RUBY_ENGINE == 'opal' ? '$' : '\z'.freeze 
+end
+

--- a/lib/opal/sprockets/erb.rb
+++ b/lib/opal/sprockets/erb.rb
@@ -11,7 +11,7 @@ module Opal
       end
 
       def evaluate(context, locals, &block)
-        compiler = Opal::ERB::Compiler.new(@data, context.logical_path.sub(/^templates\//, ''))
+        compiler = Opal::ERB::Compiler.new(@data, context.logical_path.sub(/\Atemplates\//, ''))
         @data = compiler.prepared_source
         super
       end

--- a/lib/opal/sprockets/erb.rb
+++ b/lib/opal/sprockets/erb.rb
@@ -11,7 +11,7 @@ module Opal
       end
 
       def evaluate(context, locals, &block)
-        compiler = Opal::ERB::Compiler.new(@data, context.logical_path.sub(/\Atemplates\//, ''))
+        compiler = Opal::ERB::Compiler.new(@data, context.logical_path.sub(/#{REGEXP_START}templates\//, ''))
         @data = compiler.prepared_source
         super
       end

--- a/lib/opal/sprockets/processor.rb
+++ b/lib/opal/sprockets/processor.rb
@@ -55,7 +55,7 @@ module Opal
 
     def self.sprockets_extnames_regexp(sprockets)
       joined_extnames = sprockets.engines.keys.map { |ext| Regexp.escape(ext) }.join('|')
-      Regexp.new("(#{joined_extnames})*\z")
+      Regexp.new("(#{joined_extnames})*$")
     end
 
     def sprockets_extnames_regexp

--- a/lib/opal/sprockets/processor.rb
+++ b/lib/opal/sprockets/processor.rb
@@ -55,7 +55,7 @@ module Opal
 
     def self.sprockets_extnames_regexp(sprockets)
       joined_extnames = sprockets.engines.keys.map { |ext| Regexp.escape(ext) }.join('|')
-      Regexp.new("(#{joined_extnames})*$")
+      Regexp.new("(#{joined_extnames})*\z")
     end
 
     def sprockets_extnames_regexp
@@ -75,7 +75,7 @@ module Opal
 
       # This is the root dir of the logical path, we need this because
       # the compiler gives us the path relative to the file's logical path.
-      dirname = File.dirname(file).gsub(/#{Regexp.escape File.dirname(context.logical_path)}$/, '')
+      dirname = File.dirname(file).gsub(/#{Regexp.escape File.dirname(context.logical_path)}\z/, '')
       dirname = Pathname(dirname)
 
       required_trees.each do |original_required_tree|
@@ -131,14 +131,14 @@ module Opal
     end
 
     def self.load_asset_code(sprockets, name)
-      asset = sprockets[name.sub(/(\.(js|rb|opal))*$/, '.js')]
+      asset = sprockets[name.sub(/(\.(js|rb|opal))*\z/, '.js')]
       return '' if asset.nil?
 
       opal_extnames = sprockets.engines.map do |ext, engine|
         ext if engine <= ::Opal::Processor
       end.compact
 
-      module_name = -> asset { asset.logical_path.sub(/\.js$/, '') }
+      module_name = -> asset { asset.logical_path.sub(/\.js\z/, '') }
       path_extnames = -> path { File.basename(path).scan(/\.[^.]+/) }
       mark_as_loaded = -> path { "Opal.mark_as_loaded(#{path.inspect});" }
       processed_by_opal = -> asset { (path_extnames[asset.pathname] & opal_extnames).any? }

--- a/lib/opal/sprockets/processor.rb
+++ b/lib/opal/sprockets/processor.rb
@@ -75,7 +75,7 @@ module Opal
 
       # This is the root dir of the logical path, we need this because
       # the compiler gives us the path relative to the file's logical path.
-      dirname = File.dirname(file).gsub(/#{Regexp.escape File.dirname(context.logical_path)}\z/, '')
+      dirname = File.dirname(file).gsub(/#{Regexp.escape File.dirname(context.logical_path)}#{REGEXP_END}/, '')
       dirname = Pathname(dirname)
 
       required_trees.each do |original_required_tree|
@@ -131,14 +131,14 @@ module Opal
     end
 
     def self.load_asset_code(sprockets, name)
-      asset = sprockets[name.sub(/(\.(js|rb|opal))*\z/, '.js')]
+      asset = sprockets[name.sub(/(\.(js|rb|opal))*#{REGEXP_END}/, '.js')]
       return '' if asset.nil?
 
       opal_extnames = sprockets.engines.map do |ext, engine|
         ext if engine <= ::Opal::Processor
       end.compact
 
-      module_name = -> asset { asset.logical_path.sub(/\.js\z/, '') }
+      module_name = -> asset { asset.logical_path.sub(/\.js#{REGEXP_END}/, '') }
       path_extnames = -> path { File.basename(path).scan(/\.[^.]+/) }
       mark_as_loaded = -> path { "Opal.mark_as_loaded(#{path.inspect});" }
       processed_by_opal = -> asset { (path_extnames[asset.pathname] & opal_extnames).any? }

--- a/lib/opal/sprockets/source_map_server.rb
+++ b/lib/opal/sprockets/source_map_server.rb
@@ -45,13 +45,13 @@ module Opal
     end
 
     def self.get_map_cache(sprockets, logical_path)
-      logical_path = logical_path.gsub(/\.js$/, '')
+      logical_path = logical_path.gsub(/\.js\z/, '')
       cache_key = cache_key_for_path(logical_path+'.map')
       cache(sprockets).cache_get(cache_key)
     end
 
     def self.set_map_cache(sprockets, logical_path, map_contents)
-      logical_path = logical_path.gsub(/\.js$/, '')
+      logical_path = logical_path.gsub(/\.js\z/, '')
       cache_key = cache_key_for_path(logical_path+'.map')
       cache(sprockets).cache_set(cache_key, map_contents)
     end
@@ -61,7 +61,7 @@ module Opal
     end
 
     def self.cache_key_for_path(logical_path)
-      base_name = logical_path.gsub(/\.js$/, '')
+      base_name = logical_path.gsub(/\.js\z/, '')
       File.join('opal', 'source_maps', base_name)
     end
 
@@ -98,7 +98,7 @@ module Opal
         return [200, {"Content-Type" => "text/json"}, [source.to_s]]
       when %r{^(.*)\.rb$}
         begin
-          asset = sprockets.resolve(path_info.sub(/\.rb$/,''))
+          asset = sprockets.resolve(path_info.sub(/\.rb\z/,''))
         rescue Sprockets::FileNotFound
           return not_found(path_info)
         end

--- a/lib/opal/sprockets/source_map_server.rb
+++ b/lib/opal/sprockets/source_map_server.rb
@@ -45,13 +45,13 @@ module Opal
     end
 
     def self.get_map_cache(sprockets, logical_path)
-      logical_path = logical_path.gsub(/\.js\z/, '')
+      logical_path = logical_path.gsub(/\.js#{REGEXP_END}/, '')
       cache_key = cache_key_for_path(logical_path+'.map')
       cache(sprockets).cache_get(cache_key)
     end
 
     def self.set_map_cache(sprockets, logical_path, map_contents)
-      logical_path = logical_path.gsub(/\.js\z/, '')
+      logical_path = logical_path.gsub(/\.js#{REGEXP_END}/, '')
       cache_key = cache_key_for_path(logical_path+'.map')
       cache(sprockets).cache_set(cache_key, map_contents)
     end
@@ -61,7 +61,7 @@ module Opal
     end
 
     def self.cache_key_for_path(logical_path)
-      base_name = logical_path.gsub(/\.js\z/, '')
+      base_name = logical_path.gsub(/\.js#{REGEXP_END}/, '')
       File.join('opal', 'source_maps', base_name)
     end
 
@@ -98,7 +98,7 @@ module Opal
         return [200, {"Content-Type" => "text/json"}, [source.to_s]]
       when %r{^(.*)\.rb$}
         begin
-          asset = sprockets.resolve(path_info.sub(/\.rb\z/,''))
+          asset = sprockets.resolve(path_info.sub(/\.rb#{REGEXP_END}/,''))
         rescue Sprockets::FileNotFound
           return not_found(path_info)
         end


### PR DESCRIPTION
Unless you specifically want to match the start and end of any line
in the string, as opposed to the start and end of the string itself,
you should avoid using ^ and $.

I'm not sure if all of these changes are correct.  Maybe in some cases
where I made changes, you do want to match start/end of any line
in the string instead of the start/end of the string itself.