### PR TITLE
Allow PathReader to deal with absolute and ./ and ../ relative paths

### DIFF
--- a/lib/opal/path_reader.rb
+++ b/lib/opal/path_reader.rb
@@ -13,7 +13,11 @@ module Opal
     end
 
     def expand(path)
-      file_finder.find(path)
+      if Pathname.new(path).absolute? || path =~ %r{\A.?.#{File::SEPARATOR}}
+        path
+      else
+        file_finder.find(path)
+      end
     end
 
     def paths

--- a/lib/opal/path_reader.rb
+++ b/lib/opal/path_reader.rb
@@ -13,7 +13,7 @@ module Opal
     end
 
     def expand(path)
-      if Pathname.new(path).absolute? || path =~ %r{\A.?.#{File::SEPARATOR}}
+      if Pathname.new(path).absolute? || path =~ %r{\A\.?\.#{File::SEPARATOR}}
         path
       else
         file_finder.find(path)

--- a/spec/lib/path_reader_spec.rb
+++ b/spec/lib/path_reader_spec.rb
@@ -20,5 +20,17 @@ describe Opal::PathReader do
   include_examples :path_finder
   include_examples :path_reader do
     let(:path_reader) { file_reader }
+
+    it 'works with absolute paths' do
+      expect(path_reader.read(File.expand_path(__FILE__))).not_to be_nil
+    end
+
+    it 'works with relative paths starting with ./' do
+      expect(path_reader.read('./spec/lib/shared/path_reader_shared.rb')).not_to be_nil
+    end
+
+    it 'works with absolute paths' do
+      expect(path_reader.read("../#{File.basename(Dir.pwd)}/spec/lib/shared/path_reader_shared.rb")).not_to be_nil
+    end
   end
 end


### PR DESCRIPTION
This allows you do do things like:

  Opal::Builder.build('/path/to/file.rb')
  Opal::Builder.build('./path/to/file.rb')
  Opal::Builder.build('../path/to/file.rb')

Previously, you couldn't build a file without adding a directory
containing the file to the paths to examine.  This makes Opal::Builder
operate more like ruby itself.

Note that this does not let you use absolute and ./ and ../ relative
paths in require, that requires additional changes, probably to
Builder#process_require.