### PR TITLE
Stdlib/Set methods, add the +,| operations and union method

### DIFF
--- a/spec/rubyspecs
+++ b/spec/rubyspecs
@@ -232,6 +232,8 @@ stdlib/rubysl-set/spec/replace_spec
 stdlib/rubysl-set/spec/size_spec
 stdlib/rubysl-set/spec/subtract_spec
 stdlib/rubysl-set/spec/to_a_spec
+stdlib/rubysl-set/spec/plus_spec
+stdlib/rubysl-set/spec/union_spec
 # stdlib/rubysl-set/spec/divide_spec
 # stdlib/rubysl-set/spec/exclusion_spec
 # stdlib/rubysl-set/spec/flatten_merge_spec
@@ -241,7 +243,6 @@ stdlib/rubysl-set/spec/to_a_spec
 # stdlib/rubysl-set/spec/inspect_spec
 # stdlib/rubysl-set/spec/intersection_spec
 # stdlib/rubysl-set/spec/keep_if_spec
-# stdlib/rubysl-set/spec/plus_spec
 # stdlib/rubysl-set/spec/pretty_print_cycle_spec
 # stdlib/rubysl-set/spec/pretty_print_spec
 # stdlib/rubysl-set/spec/proper_subset_spec
@@ -250,7 +251,6 @@ stdlib/rubysl-set/spec/to_a_spec
 # stdlib/rubysl-set/spec/select_spec
 # stdlib/rubysl-set/spec/subset_spec
 # stdlib/rubysl-set/spec/superset_spec
-# stdlib/rubysl-set/spec/union_spec
 
 stdlib/rubysl-date/spec/date/add_month_spec
 stdlib/rubysl-date/spec/date/add_spec

--- a/stdlib/set.rb
+++ b/stdlib/set.rb
@@ -147,6 +147,16 @@ class Set
     enum.each { |item| delete item }
     self
   end
+  
+  def |(enum)
+    unless enum.respond_to? :each
+      raise ArgumentError, "value must be enumerable"
+    end
+    dup.merge(enum)
+  end
+  
+  alias + |
+  alias union |
 
   def to_a
     @hash.keys


### PR DESCRIPTION
Added support for this based on Ruby's stdlib implementation. Observed while trying to make opal-rspec work with RSpec 3.1.