### PR TITLE
Don't swallow backtrace when reraising error

### DIFF
--- a/lib/opal/builder.rb
+++ b/lib/opal/builder.rb
@@ -43,7 +43,7 @@ module Opal
       processed << asset
       self
     rescue MissingRequire => error
-      raise error, "A file required by #{filename.inspect} wasn't found.\n#{error.message}"
+      raise error, "A file required by #{filename.inspect} wasn't found.\n#{error.message}", error.backtrace
     end
 
     def build_require(path, options = {})


### PR DESCRIPTION
If you specify a message when raising an existing exception, ruby
does not use the exception's existing backtrace.