### PR TITLE
Allow tilt/opal to use Opal::Builder with :build or :builder options

### DIFF
--- a/lib/opal/builder.rb
+++ b/lib/opal/builder.rb
@@ -50,6 +50,17 @@ module Opal
       process_require(path, options)
     end
 
+    def initialize_copy(other)
+      super
+      @stubs = other.stubs.dup
+      @preload = other.preload.dup
+      @processors = other.processors.dup
+      @path_reader = other.path_reader.dup
+      @prerequired = other.prerequired.dup
+      @compiler_options = other.compiler_options.dup
+      @processed = other.processed.dup
+    end
+
     def to_s
       processed.map(&:to_s).join("\n")
     end

--- a/lib/opal/builder.rb
+++ b/lib/opal/builder.rb
@@ -58,6 +58,12 @@ module Opal
       processed.map(&:source_map).reduce(:+).as_json.to_json
     end
 
+    def append_paths(*paths)
+      path_reader.append_paths(*paths)
+    end
+
+    include UseGem
+
     attr_reader :processed
 
     attr_accessor :processors, :default_processor, :path_reader,

--- a/lib/opal/cli.rb
+++ b/lib/opal/cli.rb
@@ -87,11 +87,10 @@ module Opal
 
     attr_reader :exit_status
 
-    def compiled_source
-      Opal.paths.concat load_paths
-      gems.each { |gem_name| Opal.use_gem gem_name }
-
+    def build
       builder = Opal::Builder.new stubs: stubs, compiler_options: compiler_options
+      builder.append_paths(*load_paths)
+      gems.each { |gem_name| builder.use_gem gem_name }
 
       builder.build 'opal' unless skip_opal_require?
 
@@ -116,7 +115,11 @@ module Opal
 
       builder.build_str 'Kernel.exit', '(exit)' unless no_exit
 
-      builder.to_s
+      builder
+    end
+
+    def compiled_source
+      build.to_s
     end
 
     def show_compiled_source

--- a/lib/opal/path_reader.rb
+++ b/lib/opal/path_reader.rb
@@ -24,6 +24,9 @@ module Opal
       file_finder.paths
     end
 
+    def append_paths(*paths)
+      file_finder.append_paths(*paths)
+    end
 
     private
 

--- a/lib/opal/paths.rb
+++ b/lib/opal/paths.rb
@@ -19,7 +19,7 @@ module Opal
     append_paths(path)
   end
   def self.append_paths(*paths)
-    paths.concat(paths)
+    self.paths.concat(paths)
   end
 
   module UseGem

--- a/lib/opal/paths.rb
+++ b/lib/opal/paths.rb
@@ -16,30 +16,37 @@ module Opal
   # here should only be paths which contain code targeted at being compiled by
   # Opal.
   def self.append_path(path)
-    paths << path
+    append_paths(path)
+  end
+  def self.append_paths(*paths)
+    paths.concat(paths)
   end
 
-  def self.use_gem(gem_name, include_dependencies = true)
-    require_paths_for_gem(gem_name, include_dependencies).each do |path|
-      append_path path
+  module UseGem
+    def use_gem(gem_name, include_dependencies = true)
+      append_paths(*require_paths_for_gem(gem_name, include_dependencies))
+    end
+    
+    private
+
+    def require_paths_for_gem(gem_name, include_dependencies)
+      paths = []
+      spec = Gem::Specification.find_by_name(gem_name)
+
+      spec.runtime_dependencies.each do |dependency|
+        paths += require_paths_for_gem(dependency.name, include_dependencies)
+      end if include_dependencies
+
+      gem_dir = spec.gem_dir
+      spec.require_paths.map do |path|
+        paths << File.join(gem_dir, path)
+      end
+
+      paths
     end
   end
 
-  def self.require_paths_for_gem(gem_name, include_dependencies)
-    paths = []
-    spec = Gem::Specification.find_by_name(gem_name)
-
-    spec.runtime_dependencies.each do |dependency|
-      paths += require_paths_for_gem(dependency.name, include_dependencies)
-    end if include_dependencies
-
-    gem_dir = spec.gem_dir
-    spec.require_paths.map do |path|
-      paths << File.join(gem_dir, path)
-    end
-
-    paths
-  end
+  extend UseGem
 
   # Private, don't add to these directly (use .append_path instead).
   def self.paths

--- a/lib/tilt/opal.rb
+++ b/lib/tilt/opal.rb
@@ -1,5 +1,5 @@
 require 'tilt'
-require 'opal/compiler'
+require 'opal/builder'
 require 'opal/config'
 require 'opal/version'
 
@@ -32,10 +32,16 @@ module Opal
     def prepare
     end
 
-    def evaluate(context, locals, &block)
-      compiler_options = Opal::Config.compiler_options.merge(file: file)
-      compiler = Compiler.new(data, compiler_options)
-      compiler.compile.to_s
+    def evaluate(_, _, &block)
+      if builder = @options[:builder]
+        builder.dup.build(file).to_s
+      elsif @options[:build]
+        Opal::Builder.build(file).to_s
+      else
+        compiler_options = (compiler_options || {}).merge!(file: file)
+        compiler = Compiler.new(data, compiler_options)
+        compiler.compile.to_s
+      end
     end
 
     def compiler_options

--- a/spec/lib/builder_spec.rb
+++ b/spec/lib/builder_spec.rb
@@ -11,12 +11,8 @@ describe Opal::Builder do
   end
 
   it 'respect #require_tree calls' do
-    begin
-      Opal.append_path(File.expand_path('..', __FILE__))
-      expect(builder.build('fixtures/require_tree_test').to_s).to include('Opal.modules["fixtures/required_tree_test/required_file1"]')
-    ensure
-      Opal.instance_variable_set('@paths', nil)
-    end
+    builder.append_paths(File.expand_path('..', __FILE__))
+    expect(builder.build('fixtures/require_tree_test').to_s).to include('Opal.modules["fixtures/required_tree_test/required_file1"]')
   end
 
   describe ':stubs' do

--- a/spec/lib/builder_spec.rb
+++ b/spec/lib/builder_spec.rb
@@ -48,6 +48,16 @@ describe Opal::Builder do
     end
   end
 
+  describe 'dup' do
+    it 'duplicates internal structures' do
+      b2 = builder.dup
+      b2.should_not equal(builder)
+      [:stubs, :preload, :processors, :path_reader, :prerequired, :compiler_options, :processed].each do |m|
+        b2.send(m).should_not equal(builder.send(m))
+      end
+    end
+  end
+
   describe 'requiring a native .js file' do
     it 'can be required without specifying extension' do
       builder.build_str('require "corelib/runtime"', 'foo')

--- a/spec/lib/cli_spec.rb
+++ b/spec/lib/cli_spec.rb
@@ -82,12 +82,12 @@ describe Opal::CLI do
       let(:options)  { {:gems => [gem_name], :evals => ['']} }
 
       it "adds the gem's lib paths to Opal.path" do
-        cli.run
+        builder = cli.build
 
         spec = Gem::Specification.find_by_name(gem_name)
         spec.require_paths.each do |require_path|
           require_path = File.join(spec.gem_dir, require_path)
-          expect(Opal.paths).to include(require_path)
+          expect(builder.path_reader.send(:file_finder).paths).to include(require_path)
         end
       end
     end

--- a/spec/lib/tilt/opal_spec.rb
+++ b/spec/lib/tilt/opal_spec.rb
@@ -16,4 +16,22 @@ describe Opal::TiltTemplate do
       end
     end
   end
+
+  it "support :build option" do
+    template = described_class.new('./spec/lib/fixtures/opal_file.rb', :build=>true)
+    output = template.render
+    expect(output).to include('"hi from opal!"')
+    expect(output).to include('self.$require("corelib/runtime");')
+  end
+
+  it "support :builder option" do
+    builder = Opal::Builder.new(:stubs=>['opal'])
+    template = described_class.new('./spec/lib/fixtures/opal_file.rb', :builder=>builder)
+
+    2.times do
+      output = template.render
+      expect(output.scan(/hi from opal!/).length).to eql(1)
+      expect(output).not_to include('self.$require("corelib/runtime");')
+    end
+  end
 end


### PR DESCRIPTION
If :build option is used, the Opal::Builder defaults are used.
If :builder option is used, you can pass in your own custom
builder, which could have per-build stubs, append_paths, and
use_gems to change building without modifying global state.

Using this, it's possible to build arbitrary opal projects that
require other files using tilt without sprockets.

In order to get this to work, I had to make Opal.append_path
and Opal.use_gem available per builder instance, and fix
Opal::Builder#dup to work correctly, which is what the earlier
commits are for.

The Opal::CLI commit is not necessary, but I think it's a good
idea in general to avoid mutating global state unless it is
necessary.