### PR TITLE
Handle null and undefined in if statements

### DIFF
--- a/lib/opal/nodes/helpers.rb
+++ b/lib/opal/nodes/helpers.rb
@@ -131,7 +131,7 @@ module Opal
             expr(sexp)
           end
         elsif [:lvar, :self].include? sexp.type
-          [expr(sexp.dup), fragment(" !== false && "), expr(sexp.dup), fragment(" !== nil &&"), expr(sexp.dup), fragment(" != null")]
+          [expr(sexp.dup), fragment(" !== false && "), expr(sexp.dup), fragment(" !== nil && "), expr(sexp.dup), fragment(" != null")]
         end
       end
     end

--- a/lib/opal/nodes/helpers.rb
+++ b/lib/opal/nodes/helpers.rb
@@ -95,7 +95,7 @@ module Opal
         end
 
         with_temp do |tmp|
-          [fragment("((#{tmp} = "), expr(sexp), fragment(") !== nil && (!#{tmp}.$$is_boolean || #{tmp} == true))")]
+          [fragment("((#{tmp} = "), expr(sexp), fragment(") !== nil && #{tmp} != null && (!#{tmp}.$$is_boolean || #{tmp} == true))")]
         end
       end
 
@@ -109,7 +109,7 @@ module Opal
         end
 
         with_temp do |tmp|
-          [fragment("((#{tmp} = "), expr(sexp), fragment(") === nil || (#{tmp}.$$is_boolean && #{tmp} == false))")]
+          [fragment("((#{tmp} = "), expr(sexp), fragment(") === nil || #{tmp} == null || (#{tmp}.$$is_boolean && #{tmp} == false))")]
         end
       end
 
@@ -131,7 +131,7 @@ module Opal
             expr(sexp)
           end
         elsif [:lvar, :self].include? sexp.type
-          [expr(sexp.dup), fragment(" !== false && "), expr(sexp.dup), fragment(" !== nil")]
+          [expr(sexp.dup), fragment(" !== false && "), expr(sexp.dup), fragment(" !== nil &&"), expr(sexp.dup), fragment(" != null")]
         end
       end
     end

--- a/lib/opal/nodes/logic.rb
+++ b/lib/opal/nodes/logic.rb
@@ -86,7 +86,7 @@ module Opal
       def compile
         with_temp do |tmp|
           push expr(value)
-          wrap "(#{tmp} = ", ", (#{tmp} === nil || #{tmp} === false))"
+          wrap "(#{tmp} = ", ", (#{tmp} === nil || #{tmp} === false || #{tmp} == null))"
         end
       end
     end
@@ -138,7 +138,7 @@ module Opal
         with_temp do |tmp|
           push "(((#{tmp} = "
           push expr(lhs)
-          push ") !== false && #{tmp} !== nil) ? #{tmp} : "
+          push ") !== false && #{tmp} !== nil && #{tmp} != null) ? #{tmp} : "
           push expr(rhs)
           push ")"
         end
@@ -146,7 +146,7 @@ module Opal
 
       def compile_if
         with_temp do |tmp|
-          push "if (#{tmp} = ", expr(lhs), ", #{tmp} !== false && #{tmp} !== nil) {"
+          push "if (#{tmp} = ", expr(lhs), ", #{tmp} !== false && #{tmp} !== nil && #{tmp} != null) {"
           indent do
             line tmp
           end
@@ -176,7 +176,7 @@ module Opal
           else
             push "(#{tmp} = "
             push expr(lhs)
-            push ", #{tmp} !== false && #{tmp} !== nil ?"
+            push ", #{tmp} !== false && #{tmp} !== nil && #{tmp} != null ?"
             push expr(rhs)
             push " : #{tmp})"
           end
@@ -188,7 +188,7 @@ module Opal
           if truthy_opt = js_truthy_optimize(lhs)
             push "if (#{tmp} = ", truthy_opt, ") {"
           else
-            push "if (#{tmp} = ", expr(lhs), ", #{tmp} !== false && #{tmp} !== nil) {"
+            push "if (#{tmp} = ", expr(lhs), ", #{tmp} !== false && #{tmp} !== nil && #{tmp} != null) {"
           end
           indent do
             line expr(rhs)

--- a/spec/lib/compiler_spec.rb
+++ b/spec/lib/compiler_spec.rb
@@ -172,7 +172,7 @@ describe Opal::Compiler do
         end
 
         it 'adds nil check for strings' do
-          expect_compiled('foo = 42 if "test" > "bar"').to include('if ((($a = $rb_gt("test", "bar")) !== nil && (!$a.$$is_boolean || $a == true)))')
+          expect_compiled('foo = 42 if "test" > "bar"').to include('if ((($a = $rb_gt("test", "bar")) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))')
         end
 
         it 'specifically == excludes nil check for strings' do
@@ -180,7 +180,7 @@ describe Opal::Compiler do
         end
 
         it 'adds nil check for lvars' do
-          expect_compiled("bar = 4\nfoo = 42 if bar > 5").to include('if ((($a = $rb_gt(bar, 5)) !== nil && (!$a.$$is_boolean || $a == true)))')
+          expect_compiled("bar = 4\nfoo = 42 if bar > 5").to include('if ((($a = $rb_gt(bar, 5)) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))')
         end
 
         it 'specifically == excludes nil check for lvars' do
@@ -188,7 +188,7 @@ describe Opal::Compiler do
         end
 
         it 'adds nil check for constants' do
-          expect_compiled("foo = 42 if Test > 4").to include("if ((($a = $rb_gt($scope.get('Test'), 4)) !== nil && (!$a.$$is_boolean || $a == true))) ")
+          expect_compiled("foo = 42 if Test > 4").to include("if ((($a = $rb_gt($scope.get('Test'), 4)) !== nil && $a != null && (!$a.$$is_boolean || $a == true))) ")
         end
 
         it 'specifically == excludes nil check for constants' do
@@ -198,25 +198,25 @@ describe Opal::Compiler do
 
       context 'without operators' do
         it 'adds nil check for primitives' do
-          expect_compiled('foo = 42 if 2').to include('if ((($a = 2) !== nil && (!$a.$$is_boolean || $a == true)))')
-          expect_compiled('foo = 42 if 2.5').to include('if ((($a = 2.5) !== nil && (!$a.$$is_boolean || $a == true)))')
-          expect_compiled('foo = 42 if true').to include('if ((($a = true) !== nil && (!$a.$$is_boolean || $a == true)))')
+          expect_compiled('foo = 42 if 2').to include('if ((($a = 2) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))')
+          expect_compiled('foo = 42 if 2.5').to include('if ((($a = 2.5) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))')
+          expect_compiled('foo = 42 if true').to include('if ((($a = true) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))')
         end
 
         it 'adds nil check for boolean method calls' do
-          expect_compiled('foo = 42 if true.something').to include('if ((($a = true.$something()) !== nil && (!$a.$$is_boolean || $a == true)))')
+          expect_compiled('foo = 42 if true.something').to include('if ((($a = true.$something()) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))')
         end
 
         it 'adds nil check for strings' do
-          expect_compiled('foo = 42 if "test"').to include('if ((($a = "test") !== nil && (!$a.$$is_boolean || $a == true)))')
+          expect_compiled('foo = 42 if "test"').to include('if ((($a = "test") !== nil && $a != null && (!$a.$$is_boolean || $a == true)))')
         end
 
         it 'adds nil check for lvars' do
-          expect_compiled("bar = 4\nfoo = 42 if bar").to include('if (bar !== false && bar !== nil)')
+          expect_compiled("bar = 4\nfoo = 42 if bar").to include('if (bar !== false && bar !== nil && bar != null)')
         end
 
         it 'adds nil check for constants' do
-          expect_compiled("foo = 42 if Test").to include("if ((($a = $scope.get('Test')) !== nil && (!$a.$$is_boolean || $a == true)))")
+          expect_compiled("foo = 42 if Test").to include("if ((($a = $scope.get('Test')) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))")
         end
       end
     end
@@ -224,52 +224,52 @@ describe Opal::Compiler do
     context 'parentheses' do
       context 'with operators' do
         it 'adds nil check for primitives' do
-          expect_compiled('foo = 42 if (2 > 3)').to include('if ((($a = ($rb_gt(2, 3))) !== nil && (!$a.$$is_boolean || $a == true)))')
-          expect_compiled('foo = 42 if (2.5 > 3.5)').to include('if ((($a = ($rb_gt(2.5, 3.5))) !== nil && (!$a.$$is_boolean || $a == true)))')
-          expect_compiled('foo = 42 if (true > false)').to include('if ((($a = ($rb_gt(true, false))) !== nil && (!$a.$$is_boolean || $a == true)))')
+          expect_compiled('foo = 42 if (2 > 3)').to include('if ((($a = ($rb_gt(2, 3))) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))')
+          expect_compiled('foo = 42 if (2.5 > 3.5)').to include('if ((($a = ($rb_gt(2.5, 3.5))) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))')
+          expect_compiled('foo = 42 if (true > false)').to include('if ((($a = ($rb_gt(true, false))) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))')
 
-          expect_compiled('foo = 42 if (2 == 3)').to include("if ((($a = ((2)['$=='](3))) !== nil && (!$a.$$is_boolean || $a == true)))")
-          expect_compiled('foo = 42 if (2.5 == 3.5)').to include("if ((($a = ((2.5)['$=='](3.5))) !== nil && (!$a.$$is_boolean || $a == true)))")
-          expect_compiled('foo = 42 if (true == false)').to include("if ((($a = (true['$=='](false))) !== nil && (!$a.$$is_boolean || $a == true)))")
+          expect_compiled('foo = 42 if (2 == 3)').to include("if ((($a = ((2)['$=='](3))) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))")
+          expect_compiled('foo = 42 if (2.5 == 3.5)').to include("if ((($a = ((2.5)['$=='](3.5))) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))")
+          expect_compiled('foo = 42 if (true == false)').to include("if ((($a = (true['$=='](false))) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))")
         end
 
         it 'adds nil check for strings' do
-          expect_compiled('foo = 42 if ("test" > "bar")').to include('if ((($a = ($rb_gt("test", "bar"))) !== nil && (!$a.$$is_boolean || $a == true)))')
-          expect_compiled('foo = 42 if ("test" == "bar")').to include("if ((($a = (\"test\"['$=='](\"bar\"))) !== nil && (!$a.$$is_boolean || $a == true)))")
+          expect_compiled('foo = 42 if ("test" > "bar")').to include('if ((($a = ($rb_gt("test", "bar"))) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))')
+          expect_compiled('foo = 42 if ("test" == "bar")').to include("if ((($a = (\"test\"['$=='](\"bar\"))) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))")
         end
 
         it 'adds nil check for lvars' do
-          expect_compiled("bar = 4\nfoo = 42 if (bar > 5)").to include('if ((($a = ($rb_gt(bar, 5))) !== nil && (!$a.$$is_boolean || $a == true)))')
-          expect_compiled("bar = 4\nfoo = 42 if (bar == 5)").to include("if ((($a = (bar['$=='](5))) !== nil && (!$a.$$is_boolean || $a == true))) ")
+          expect_compiled("bar = 4\nfoo = 42 if (bar > 5)").to include('if ((($a = ($rb_gt(bar, 5))) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))')
+          expect_compiled("bar = 4\nfoo = 42 if (bar == 5)").to include("if ((($a = (bar['$=='](5))) !== nil && $a != null && (!$a.$$is_boolean || $a == true))) ")
         end
 
         it 'adds nil check for constants' do
-          expect_compiled("foo = 42 if (Test > 4)").to include("if ((($a = ($rb_gt($scope.get('Test'), 4))) !== nil && (!$a.$$is_boolean || $a == true)))")
-          expect_compiled("foo = 42 if (Test == 4)").to include("if ((($a = ($scope.get('Test')['$=='](4))) !== nil && (!$a.$$is_boolean || $a == true)))")
+          expect_compiled("foo = 42 if (Test > 4)").to include("if ((($a = ($rb_gt($scope.get('Test'), 4))) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))")
+          expect_compiled("foo = 42 if (Test == 4)").to include("if ((($a = ($scope.get('Test')['$=='](4))) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))")
         end
       end
 
       context 'without operators' do
         it 'adds nil check for primitives' do
-          expect_compiled('foo = 42 if (2)').to include('if ((($a = (2)) !== nil && (!$a.$$is_boolean || $a == true)))')
-          expect_compiled('foo = 42 if (2.5)').to include('if ((($a = (2.5)) !== nil && (!$a.$$is_boolean || $a == true)))')
-          expect_compiled('foo = 42 if (true)').to include('if ((($a = (true)) !== nil && (!$a.$$is_boolean || $a == true)))')
+          expect_compiled('foo = 42 if (2)').to include('if ((($a = (2)) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))')
+          expect_compiled('foo = 42 if (2.5)').to include('if ((($a = (2.5)) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))')
+          expect_compiled('foo = 42 if (true)').to include('if ((($a = (true)) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))')
         end
 
         it 'adds nil check for boolean method calls' do
-          expect_compiled('foo = 42 if (true.something)').to include('if ((($a = (true.$something())) !== nil && (!$a.$$is_boolean || $a == true)))')
+          expect_compiled('foo = 42 if (true.something)').to include('if ((($a = (true.$something())) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))')
         end
 
         it 'adds nil check for strings' do
-          expect_compiled('foo = 42 if ("test")').to include('if ((($a = ("test")) !== nil && (!$a.$$is_boolean || $a == true)))')
+          expect_compiled('foo = 42 if ("test")').to include('if ((($a = ("test")) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))')
         end
 
         it 'adds nil check for lvars' do
-          expect_compiled("bar = 4\nfoo = 42 if (bar)").to include('if ((($a = (bar)) !== nil && (!$a.$$is_boolean || $a == true)))')
+          expect_compiled("bar = 4\nfoo = 42 if (bar)").to include('if ((($a = (bar)) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))')
         end
 
         it 'adds nil check for constants' do
-          expect_compiled("foo = 42 if (Test)").to include("if ((($a = ($scope.get('Test'))) !== nil && (!$a.$$is_boolean || $a == true)))")
+          expect_compiled("foo = 42 if (Test)").to include("if ((($a = ($scope.get('Test'))) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))")
         end
       end
     end

--- a/spec/opal/core/runtime/truthy_spec.rb
+++ b/spec/opal/core/runtime/truthy_spec.rb
@@ -34,4 +34,30 @@ describe "Opal truthyness" do
     
     is_falsey.should be_true
   end
+
+  it "should consider false, nil, null, and undefined as not truthy" do
+    called = nil
+    [`false`, `nil`, `null`, `undefined`].each do |v|
+      if v
+        called = true
+      end
+    end
+
+    called.should be_nil
+  end
+
+  it "should true as truthy" do
+    if `true`
+      called = true
+    end
+
+    called.should be_true
+  end
+
+  it "should handle logic operators correctly for false, nil, null, and undefined" do
+    (`false` || `nil` || `null` || `undefined` || 1).should == 1
+    [`false`, `nil`, `null`, `undefined`].each do |v|
+      `#{1 && v} === #{v}`.should == true
+    end
+  end
 end


### PR DESCRIPTION
Previously using null or undefined in an if statement would result
in something like: TypeError: Cannot read property '$$is_boolean'
of undefined.