### PR TITLE
Make sprockets a development dependency instead of runtime, allow tilt 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ matrix:
     - rvm: 2.2
       env: RUN=default TZ="/usr/share/zoneinfo/Pacific/Fiji"
 
+    - rvm: 2.2
+      env: RUN=rspec TILT_VERSION=2.0.1
+
     - rvm: 2.1
       env: RUN=rspec
 

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,9 @@ group :repl do
   gem 'therubyrhino', :platform => :jruby
 end
 
+tilt_version = ENV['TILT_VERSION']
+gem 'tilt', tilt_version if tilt_version
+
 unless ENV['CI']
   gem 'rb-fsevent'
   gem 'guard', require: false

--- a/opal.gemspec
+++ b/opal.gemspec
@@ -21,10 +21,10 @@ Gem::Specification.new do |s|
   required_ruby_version = '>= 1.9.3'
 
   s.add_dependency 'sourcemap', '~> 0.1.0'
+  s.add_dependency 'sprockets', '~> 3.1'
   s.add_dependency 'hike', '~> 1.2'
   s.add_dependency 'tilt', '>= 1.4'
 
-  s.add_development_dependency 'sprockets', '~> 3.1'
   s.add_development_dependency 'mspec', '1.5.20'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'racc'

--- a/opal.gemspec
+++ b/opal.gemspec
@@ -21,10 +21,10 @@ Gem::Specification.new do |s|
   required_ruby_version = '>= 1.9.3'
 
   s.add_dependency 'sourcemap', '~> 0.1.0'
-  s.add_dependency 'sprockets', '~> 3.1'
   s.add_dependency 'hike', '~> 1.2'
-  s.add_dependency 'tilt', '~> 1.4'
+  s.add_dependency 'tilt', '>= 1.4'
 
+  s.add_development_dependency 'sprockets', '~> 3.1'
   s.add_development_dependency 'mspec', '1.5.20'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'racc'


### PR DESCRIPTION
Now that you can build complex opal projects using tilt instead of
sprockets, it doesn't make sense to require sprockets.

As sprockets 3+ doesn't require tilt, it doesn't really make sense
to keep tilt as a runtime dependency, since you should be able to
use sprockets without using tilt. However, Opal::Processor is
currently a subclass of Opal::TiltTemplate, so it doesn't matter
if you are using opal with tilt or sprockets, in either case tilt
is still required for using opal.

If Opal::Processor can be made to run without tilt, I think we
should make both tilt and sprockets development dependencies
instead of runtime dependencies.

The tilt/opal tests run fine with tilt 2, so I don't think we
should restrict people to using tilt 1.4, as then users of opal
can't use the new useful features in tilt 2, such as multiple
mappings, and they will miss out on useful bug fixes in tilt 2
that will not get backported to tilt 1.4, such as the sorting of
locals when caching templates.