### PR TITLE
Fix all accidental global variables except the compiler-generated ones

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -12,8 +12,14 @@
   "unused"        : true, // Warn when you define and never use your variables
 
   "globals": {
-    "Opal": true
+    "Opal": true,
+    "OpalNode": true,
+    "callPhantom": true,
+    "JSON": true
   },
+
+  "browser": true,
+  "node": true,
 
   // Currently the following checks are failing:
 

--- a/opal/corelib/enumerable.rb
+++ b/opal/corelib/enumerable.rb
@@ -943,7 +943,7 @@ module Enumerable
     return enum_for :partition unless block_given?
 
     %x{
-      var truthy = [], falsy = [];
+      var truthy = [], falsy = [], result;
 
       self.$each.$$p = function() {
         var param = #{Opal.destructure(`arguments`)},

--- a/opal/corelib/hash.rb
+++ b/opal/corelib/hash.rb
@@ -363,7 +363,7 @@ class Hash
     %x{
       var _map = self.map,
           smap = self.smap,
-          keys = self.keys;
+          keys = self.keys, key, map, khash;
 
       for (var i = 0, length = keys.length; i < length; i++) {
         key = keys[i];
@@ -613,7 +613,7 @@ class Hash
 
         var key, value,
             inspect = [],
-            keys = self.keys
+            keys = self.keys,
             id = self.$object_id(),
             counter = 0;
 
@@ -820,7 +820,7 @@ class Hash
       var keys = self.keys,
           _map = self.map,
           smap = self.smap,
-          key, khash, value;
+          key, khash, value, map;
 
       for (var i = 0, length = keys.length; i < length; i++) {
         key = keys[i]
@@ -967,7 +967,7 @@ class Hash
           smap = self.smap,
           keys = self.keys,
           result = nil,
-          key, khash, value, object;
+          key, khash, value, object, map;
 
       for (var i = 0, length = keys.length; i < length; i++) {
         key = keys[i];
@@ -1039,7 +1039,7 @@ class Hash
           _map = self.map,
           smap = self.smap,
           result = [],
-          map, key;
+          map, key, khash;
 
       for (var i = 0, length = keys.length; i < length; i++) {
         key = keys[i];
@@ -1096,7 +1096,7 @@ class Hash
           smap = self.smap,
           keys = self.keys,
           result = [],
-          map, khash;
+          map, khash, key;
 
       for (var i = 0, length = keys.length; i < length; i++) {
         key = keys[i];

--- a/opal/corelib/module.rb
+++ b/opal/corelib/module.rb
@@ -198,7 +198,7 @@ class Module
     raise NameError, "wrong constant name #{name}" unless name =~ /^[A-Z]\w*$/
 
     %x{
-      scopes = [self.$$scope];
+      var scopes = [self.$$scope];
 
       if (inherit || self === Opal.Object) {
         var parent = self.$$super;

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -1155,7 +1155,7 @@
         keys = [],
         _map = {},
         smap = {},
-        key, obj, length, khash;
+        key, obj, length, khash, map;
 
     hash.map   = _map;
     hash.smap  = smap;

--- a/stdlib/native.rb
+++ b/stdlib/native.rb
@@ -492,7 +492,7 @@ class Hash
           keys   = self.keys,
           _map   = self.map,
           smap   = self.smap,
-          map, khash, value;
+          map, khash, value, key;
 
       for (var i = 0, length = keys.length; i < length; i++) {
         key   = keys[i];


### PR DESCRIPTION
Fix all accidental global variables except for those that are generated because of compiler bugs #875, #876, and #877.