### PR TITLE
Fix #877 (compiler generates accidental global var if proc arg used outside proc)

### DIFF
--- a/lib/opal/nodes/iter.rb
+++ b/lib/opal/nodes/iter.rb
@@ -115,7 +115,7 @@ module Opal
         sexp.each do |arg|
           if arg[0] == :lasgn
             ref = variable(arg[1])
-            scope.add_arg ref
+            self.add_arg ref
             result << ref
           elsif arg[0] == :array
             result << scope.next_temp


### PR DESCRIPTION
Fix #877

Basically what was happening is that args to a proc inside of a method were incorrectly set as args on the parent scope. Then, since they supposedly already exist in the args array, they were excluded from being declared with `var`.