### PR TITLE
Fix issues #875 and #876 (compiler generates accidental globals compiling `class << ...`)

### DIFF
--- a/lib/opal/nodes/singleton_class.rb
+++ b/lib/opal/nodes/singleton_class.rb
@@ -14,8 +14,9 @@ module Opal
           add_temp '$scope = self.$$scope'
           add_temp 'def = self.$$proto'
 
+          body_stmt = stmt(compiler.returns(body))
           line scope.to_vars
-          line stmt(compiler.returns(body))
+          line body_stmt
         end
 
         line "})(", recv(object), ".$singleton_class())"


### PR DESCRIPTION
Fix #875 
Fix #876 

Basically the problem here is that the temporary variable is requested to be created in the parent scope while processing the body AFTER `to_vars` on the parent scope has already been called. I.e., it's too late for it to have any effect since `to_vars` has already been called. The solution is simple then: process the body first, then call `to_vars`.
