### PR TITLE
Enable JSHint's "'variable' is not defined" check (aka detect global leaks)

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -47,6 +47,5 @@
   "-W093": false, // Did you mean to return a conditional instead of an assignment?
   "-W098": false, // 'variable' is defined but never used
   "-W116": false, // Expected '===' and instead saw '=='
-  "-W117": false, // 'variable' is not defined
   "-W120": false  // You might be leaking a variable ($ClassName) here
 }


### PR DESCRIPTION
Now that https://github.com/opal/opal/pull/891 and https://github.com/opal/opal/pull/892 are merged in, we no longer have any accidental globals in JS, so it's time to enable JSHint's `'variable' is not defined` check for realz (FTW, for googness' sake, for the love of god, etc.)