### PR TITLE
alias public_methods methods

### DIFF
--- a/opal/corelib/kernel.rb
+++ b/opal/corelib/kernel.rb
@@ -56,6 +56,8 @@ module Kernel
     }
   end
 
+  alias public_methods methods
+
   def Array(object)
     %x{
       var coerced;


### PR DESCRIPTION
@elia here's the PR as requested via #675.

I also saw @meh said "There's no concept of private or public in Opal...".  Shouldn't we add some way to track public and private methods?  There are a few ruby methods that rely on it, which would cause unexpected results if you are using the same class client/server side.