### PR TITLE
Handle parser errors when lexer column is 0

### DIFF
--- a/lib/opal/parser.rb
+++ b/lib/opal/parser.rb
@@ -42,7 +42,7 @@ module Opal
         error.message,
         "Source: #{@file}:#{lexer.line}:#{lexer.column}",
         source.split("\n")[lexer.line-1],
-        '~'*(lexer.column-1) + '^',
+        '~'*(lexer.column-1 > 0 ? lexer.column-1 : 0) + '^',
       ].join("\n")
 
       raise error.class, message, error.backtrace


### PR DESCRIPTION
Without this, there is an error formatting the exception message
(ArgumentError: negative argument), and the underlying exception
is lost.