### PR TITLE
Add JS module for nicer calling of native javascript operators and global functions

### DIFF
--- a/spec/opal/stdlib/js_spec.rb
+++ b/spec/opal/stdlib/js_spec.rb
@@ -14,6 +14,11 @@ describe 'javascript operations using JS module' do
     JS.new(f).JS[:color].should == 'black'
   end
 
+  it 'JS.new handles blocks' do
+    f = `function(a){this.a = a}`
+    JS.new(f){1}.JS.a.should == 1
+  end
+
   it 'JS.instanceof uses instanceof to check if value is an instance of a function' do
     f = `function(){}`
     JS.instanceof(JS.new(f), f).should == true
@@ -48,5 +53,14 @@ describe 'javascript operations using JS module' do
   it 'JS.method_missing calls global javascript methods' do
     JS.parseFloat('1.0').should == 1
     JS.parseInt('1').should == 1
+  end
+
+  it 'JS.call calls global javascript methods with blocks' do
+    begin
+      JS.global.JS[:_test_global_function] = lambda{|pr| pr.call + 1}
+      JS._test_global_function{1}.should == 2
+    ensure
+      JS.delete(JS.global, :_test_global_function)
+    end
   end
 end

--- a/spec/opal/stdlib/js_spec.rb
+++ b/spec/opal/stdlib/js_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+require 'js'
+
+describe 'javascript operations using JS module' do
+  it 'JS.typeof uses typeof to return underlying javascript type' do
+    [1, `null`, `undefined`, Object.new, [], ""].each do |v|
+      JS.typeof(v).should == `typeof #{v}`
+    end
+  end
+
+  it 'JS.new uses new to create new instance' do
+    f = `function(){}`
+    f.JS[:prototype].JS[:color] = 'black'
+    JS.new(f).JS[:color].should == 'black'
+  end
+
+  it 'JS.instanceof uses instanceof to check if value is an instance of a function' do
+    f = `function(){}`
+    JS.instanceof(JS.new(f), f).should == true
+    JS.instanceof(JS.new(f), `function(){}`).should == false 
+  end
+
+  it 'JS.delete uses delete to remove properties from objects' do
+    f = `{a:1}`
+    f.JS[:a].should == 1
+    JS.delete(f, :a)
+    `#{f.JS[:a]} === undefined`.should == true
+  end
+
+  it 'JS.in uses in to check for properties in objects' do
+    f = `{a:1}`
+    JS.in(:a, f).should == true
+    JS.in(:b, f).should == false
+  end
+
+  it 'JS.void returns undefined' do
+    f = 1
+    `#{JS.void(f += 1)} === undefined`.should == true
+    f.should == 2
+  end
+
+  it 'JS.call calls global javascript methods' do
+    JS.call(:parseFloat, '1.0').should == 1
+    JS.call(:parseInt, '1').should == 1
+    JS.call(:eval, "({a:1})").JS[:a].should == 1
+  end
+
+  it 'JS.method_missing calls global javascript methods' do
+    JS.parseFloat('1.0').should == 1
+    JS.parseInt('1').should == 1
+  end
+end

--- a/stdlib/js.rb
+++ b/stdlib/js.rb
@@ -7,6 +7,11 @@ module JS
     `delete #{object}[#{property}]`
   end
 
+  # The global object
+  def global
+    `Opal.global`
+  end
+
   # Use in to check for a property in an object.
   def in(property, object)
     `#{property} in #{object}`
@@ -18,7 +23,8 @@ module JS
   end
 
   # Use new to create a new instance of the prototype of the function.
-  def new(func, *args)
+  def new(func, *args, &block)
+    args << block if block
     f = `function(){return func.apply(this, args)}`
     f.JS[:prototype] = func.JS[:prototype]
     `new f()`
@@ -39,13 +45,9 @@ module JS
   end
 
   # Call the global javascript function with the given arguments.
-  def call(func, *args)
-    g = case
-    when `typeof window === 'object'` then `window`
-    when `typeof global === 'object'` then `global`
-    else raise "cannot determine global object, neither window or global is an object"
-    end
-
+  def call(func, *args, &block)
+    g = global
+    args << block if block
     g.JS[func].JS.apply(g, args)
   end
   alias method_missing call

--- a/stdlib/js.rb
+++ b/stdlib/js.rb
@@ -1,0 +1,54 @@
+# The JS module provides syntax sugar for calling native javascript
+# operators (e.g. typeof, instanceof, new, delete) and global functions
+# (e.g. parseFloat, parseInt).
+module JS
+  # Use delete to remove a property from an object.
+  def delete(object, property)
+    `delete #{object}[#{property}]`
+  end
+
+  # Use in to check for a property in an object.
+  def in(property, object)
+    `#{property} in #{object}`
+  end
+
+  # Use instanceof to return whether value is an instance of the function.
+  def instanceof(value, func)
+    `#{value} instanceof #{func}`
+  end
+
+  # Use new to create a new instance of the prototype of the function.
+  def new(func, *args)
+    f = `function(){return func.apply(this, args)}`
+    f.JS[:prototype] = func.JS[:prototype]
+    `new f()`
+  end
+
+  # Use typeof to return the underlying javascript type of value.
+  # Note that for undefined values, this will not work exactly like
+  # the javascript typeof operator, as the argument is evaluated before
+  # the function call.
+  def typeof(value)
+    `typeof #{value}`
+  end
+
+  # Use void to return undefined.
+  def void(expr)
+    # Could use `undefined` here, but this is closer to the intent of the method
+    `void #{expr}`
+  end
+
+  # Call the global javascript function with the given arguments.
+  def call(func, *args)
+    g = case
+    when `typeof window === 'object'` then `window`
+    when `typeof global === 'object'` then `global`
+    else raise "cannot determine global object, neither window or global is an object"
+    end
+
+    g.JS[func].JS.apply(g, args)
+  end
+  alias method_missing call
+
+  extend self
+end


### PR DESCRIPTION
This adds support for calling the following javascript operators:
delete, in, instanceof, new, typeof, and void.  It also supports
calling global javascript functions via call.  call is aliased
to method_missing, so that you can do JS.globalFunction() to
call global javascript functions.