### PR TITLE
Fix typo in the description of the -D option

### DIFF
--- a/lib/opal/cli_options.rb
+++ b/lib/opal/cli_options.rb
@@ -119,7 +119,7 @@ module Opal
       dynamic_require_levels = %w[error warning ignore]
       on('-D', '--dynamic-require LEVEL', dynamic_require_levels,
                     'Set level of dynamic require severity.',
-                    "(deafult: error, values: #{dynamic_require_levels.join(', ')})") do |level|
+                    "(default: error, values: #{dynamic_require_levels.join(', ')})") do |level|
         options[:dynamic_require_severity] = level.to_sym
       end
 


### PR DESCRIPTION
Trivial but caught my eye on a `bundle exec opal -h`.