### PR TITLE
Using ruby/rubyspec for RubySpec

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "spec/corelib"]
 	path = spec/corelib
-	url = https://github.com/opal/rubyspec
+	url = https://github.com/ruby/rubyspec.git
 [submodule "test/cruby"]
 	path = test/cruby
 	url = https://github.com/ruby/ruby.git


### PR DESCRIPTION
Hello,

Here is a quick PR to discuss about using ruby/rubyspec directly, if that is what the Opal team wants.
This is not ready for merging as there are new failures due to new specs.

Using git submodule provides a very good isolation between specs and the rest, but also makes the process to change specs a bit rigid.
If changes to rubyspec are done mostly by a few people (@elia and @vais from what I saw), one solution is to allow these people to push directly to ruby/rubyspec for straightforward changes (and PR if not).

Another solution is to have a copy of rubyspec in the opal repository (with git subtree or manually) and integrate these changes upstream from time to time. This is more complex and messy but useful if many different people contribute directly to the specs.

What do you think?

P.S.: There are quite a few new failures due to new specs, do you have an automated way to tag them or is it done manually?