### PR TITLE
Remove Travis cache for Git submodules 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ sudo: false
 cache:
   bundler: true
   directories:
-    - test/cruby
-    - spec/corelib
     - /home/travis/.nvm/
 
 matrix:


### PR DESCRIPTION
Was an attempt to speed up the build but seems to do more harm than good 