### PR TITLE
Define only the necessary constants for MSpec

### DIFF
--- a/stdlib/rbconfig.rb
+++ b/stdlib/rbconfig.rb
@@ -15,6 +15,5 @@ module RbConfig
 end
 
 # required for mspec it would appear
-RUBY_NAME = 'opal'
-RUBY_EXE = 'opal'
-RUBY_PATCHLEVEL = "327"
+RUBY_EXE = 'bundle exec bin/opal'
+RUBY_PATCHLEVEL = 0


### PR DESCRIPTION
The first is needed for `ruby_exe` but I am not confident if this works yet.
The second is a standard `RUBY_` constant along VERSION, ENGINE, etc.