### PR TITLE
add wording to explicitly clarify which spaces the CoC applies in

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -8,6 +8,8 @@ Examples of unacceptable behavior by participants include the use of sexual lang
 
 Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. Project maintainers who do not follow the Code of Conduct may be removed from the project team.
 
+This code of conduct applies both within project spaces and in public spaces where an individual explicitly associates their presence with the project; non-project related material on accounts explicitly marked as personal should not be considered to be so associated.
+
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers.
 
 This Code of Conduct is adapted from the [Contributor Covenant](http:contributor-covenant.org), version 1.0.0, available at [http://contributor-covenant.org/version/1/0/0/](http://contributor-covenant.org/version/1/0/0/)


### PR DESCRIPTION
This was originally the wording @strand and I worked out previously, which @adambeynon recently commented he thought at least the concept of was useful. It's been tweaked since though so please read the whole thread to understand where it's coming from.

I'm happy to (continue to :) bikeshed the phrasing until everybody's happy - I just think we need to draw *some* sort of explicit line here.

@adambeynon @sarciszewski @jaen @webmaven thoughts if you have any, please