### PR TITLE
tweak sexual language wording

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -4,7 +4,7 @@ As contributors and maintainers of this project, we pledge to respect all people
 
 We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, age, or religion.
 
-Examples of unacceptable behavior by participants include the use of sexual language or imagery, derogatory comments or personal attacks, trolling, public or private harassment, insults, or other unprofessional conduct.
+Examples of unacceptable behavior by participants include the use of overtly sexual language or imagery, derogatory comments or personal attacks, trolling, public or private harassment, insults, or other unprofessional conduct.
 
 Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. Project maintainers who do not follow the Code of Conduct may be removed from the project team.
 


### PR DESCRIPTION
My thought here is that since harassment of any form is already specifically covered, it's better to only ban -overtly- sexual language so that a single genuine misunderstanding doesn't become a casus belli.

Bear in mind that once the misunderstanding has been explained, doing it again falls neatly under the dictionary definition of harassment and as such this tweak shouldn't allow anybody who -was- being a dick to weasel out of it.

@adambeynon @sarciszewski @jaen @webmaven thoughts if you have any, please