### PR TITLE
Treat require_tree '.' at root as a special case

### DIFF
--- a/opal/corelib/kernel.rb
+++ b/opal/corelib/kernel.rb
@@ -1047,6 +1047,7 @@ module Kernel
   # `path` should be the full path to be found in registered modules (`Opal.modules`)
   def require_tree(path)
     path = File.expand_path(path)
+    path = '' if path == '.'
 
     %x{
       for (var name in Opal.modules) {


### PR DESCRIPTION
I'd like some advice on how to test this as the problem arises only with `require_tree '.'` used at root level.

cc @vais https://github.com/opal/opal-rails/issues/50