### PR TITLE
String#split returns the original string if no matches are found

### DIFF
--- a/opal/corelib/string.rb
+++ b/opal/corelib/string.rb
@@ -1015,6 +1015,10 @@ class String
 
       result = string.split(pattern);
 
+      if (result.length === 1 && result[0] === string) {
+        return result;
+      }
+
       while ((i = result.indexOf(undefined)) !== -1) {
         result.splice(i, 1);
       }


### PR DESCRIPTION
Fix #973

Handle the special case where no matches are found, regardless of the `limit` parameter, return an array containing a single element that is the original string.