### PR TITLE
Fix Hash#has_value? when hash was created through initialize method.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ build/
 /node_modules
 /gh-pages
 /tmp
+.ruby-gemset
+.ruby-version
+.rvmrc

--- a/opal/corelib/hash.rb
+++ b/opal/corelib/hash.rb
@@ -537,8 +537,22 @@ class Hash
 
   def has_value?(value)
     %x{
-      for (var khash in self.map) {
-        if (#{`self.map[khash]` == value}) {
+      var _map = self.map,
+          smap = self.smap,
+          keys = self.keys, key, map, khash;
+
+      for (var i = 0, length = keys.length; i < length; i++) {
+        key = keys[i];
+
+        if (key.$$is_string) {
+          map = smap;
+          khash = key;
+        } else {
+          map = _map;
+          khash = key.$hash();
+        }
+
+        if (#{`map[khash]` == value}) {
           return true;
         }
       }

--- a/spec/opal/core/hash/has_value_spec.rb
+++ b/spec/opal/core/hash/has_value_spec.rb
@@ -1,0 +1,13 @@
+describe 'Hash#has_value?' do
+  context 'when hash contains provided value' do
+    it 'returns true' do
+      expect({ a: 1 }.has_value?(1)).to eq(true)
+    end
+  end
+
+  context 'when hash does not contain provided value' do
+    it 'returns false' do
+      expect({ a: 1 }.has_value?(2)).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
Basically, [here is the link to the demo of this issue](http://opalrb.org/try/?code:h%20%3D%20%7B%20a%3A%201%20%7D%0Aputs%20h.has_key%3F(%3Aa)%0Aputs%20h.has_value%3F(1))

It seems that `Hash#[]=` populates only one of `self.smap` / `self.map` for each key/value pair, but `Hash#has_value?` previously used just a `self.map`. I've already checked other methods - all of them use both `map` and `smap`, so this is the only affected method.