### PR TITLE
Fix lexer bug whereby `<<self` in `class <<self` is seen as a heredoc

### DIFF
--- a/lib/opal/parser/lexer.rb
+++ b/lib/opal/parser/lexer.rb
@@ -1050,7 +1050,7 @@ module Opal
             if after_operator?
               @lex_state = :expr_arg
               return :tLSHFT
-            elsif !after_operator? && !end? && (!arg? || @space_seen)
+            elsif !after_operator? && !end? && (!arg? || @space_seen) && @lex_state != :expr_class
               if token = heredoc_identifier
                 return token
               end


### PR DESCRIPTION
Fix #992

@adambeynon it would be nice if you could take a look and confirm when you get a chance.