### PR TITLE
Method#to_proc returns a proc that is bound to the method's receiver

### DIFF
--- a/opal/corelib/method.rb
+++ b/opal/corelib/method.rb
@@ -29,7 +29,7 @@ class Method
   def to_proc
     %x{
       var proc = function () { return self.$call.apply(self, $slice.call(arguments)); };
-      proc.___unbound___ = #@method;
+      proc.$$unbound = #@method;
       return proc;
     }
   end

--- a/opal/corelib/method.rb
+++ b/opal/corelib/method.rb
@@ -27,7 +27,11 @@ class Method
   end
 
   def to_proc
-    @method
+    %x{
+      var proc = function () { return self.$call.apply(self, $slice.call(arguments)); };
+      proc.___unbound___ = #@method;
+      return proc;
+    }
   end
 
   def inspect

--- a/opal/corelib/module.rb
+++ b/opal/corelib/module.rb
@@ -287,7 +287,7 @@ class Module
               when Proc
                 method
               when Method
-                `#{method.to_proc}.___unbound___`
+                `#{method.to_proc}.$$unbound`
               when UnboundMethod
                 lambda do |*args|
                   bound = method.bind(self)

--- a/opal/corelib/module.rb
+++ b/opal/corelib/module.rb
@@ -287,7 +287,7 @@ class Module
               when Proc
                 method
               when Method
-                method.to_proc
+                `#{method.to_proc}.___unbound___`
               when UnboundMethod
                 lambda do |*args|
                   bound = method.bind(self)

--- a/spec/opal/core/method/to_proc_spec.rb
+++ b/spec/opal/core/method/to_proc_spec.rb
@@ -1,0 +1,28 @@
+describe "Method#to_proc" do
+
+  it "returns a Proc object that is bound to the method's receiver" do
+    "hello".method(:capitalize).to_proc.call.should == "Hello"
+    "hello".method(:upcase).to_proc.call.should == "HELLO"
+  end
+
+  it "works with class methods" do
+    class Lender
+      def self.abc
+        self
+      end
+      def self.xyz
+        abc
+      end
+    end
+
+    module Namespace
+      class Borrower
+        class << self
+          define_method(:xyz, &::Lender.method(:xyz))
+        end
+      end
+    end
+
+    Namespace::Borrower.xyz.should == Lender
+  end
+end


### PR DESCRIPTION
Fix #1007 
Fix #972

Special thanks to @cj for submitting the original issue that broke opal-rspec, and to @Ajedi32 for [pointing me in the right direction](https://github.com/opal/opal/issues/972#issuecomment-120942281).