### PR TITLE
Make Array #&, #|, #-, #uniq, #uniq! use `Hash` to match MRI semantics

### DIFF
--- a/opal/corelib/hash.rb
+++ b/opal/corelib/hash.rb
@@ -592,15 +592,19 @@ class Hash
 
   def keys
     %x{
-      var keys = self.keys.slice();
+      var result = [];
 
-      for (var i = 0, length = keys.length, key; i < length; i++) {
+      for (var i = 0, keys = self.keys, length = keys.length, key; i < length; i++) {
         key = keys[i];
 
-        if (!key.$$is_string) { keys[i] = key.key; }
+        if (key.$$is_string) {
+          result.push(key);
+        } else {
+          result.push(key.key);
+        }
       }
 
-      return keys;
+      return result;
     }
   end
 
@@ -931,7 +935,7 @@ class Hash
     %x{
       var result = [];
 
-      for (var i = 0, keys = self.keys, length = keys.length, key, value; i < length; i++) {
+      for (var i = 0, keys = self.keys, length = keys.length, key; i < length; i++) {
         key = keys[i];
 
         if (key.$$is_string) {
@@ -939,7 +943,6 @@ class Hash
         } else {
           result.push(key.value);
         }
-
       }
 
       return result;


### PR DESCRIPTION
The performance numbers below make this one a difficult sell. But... here's the background. MRI uses helper hashes to implement these `Array` methods, automatically giving them `Hash`-y semantics. In Opal, I hand-coded said `Hash` semantics into the implementation of these methods because at the time `Hash` itself was not fully compliant. Now it is, and having this duplication comes with all the usual "benefits" of code duplication, plus more. RubySpec is awesome, but it is neither perfect nor complete at any point in time. It does specify `Hash` behavior separately from these `Array` behaviors, meaning there is some overlap in spec coverage, but also meaning there can be gaps in both. Having a single code path for these behaviors means that we benefit from all the `Hash` specs and all the `Array` specs, with the overlap filling any potential gaps in each.

So, the tradeoff here is performance vs correctness and maintainability in the long-term. I think Opal is *fast enough*, and it is more important for it to be correct than to shave a few tenths of a second over some 2_000_000 method calls (in benchmarks I use arrays of 1000 elements, 1000 iterations, 2 method calls per iteration).

Hope you agree with my reasoning (or offer a way to further improve performance) :sweat_smile:  

`Opal1` is master, `Opal2` is after the changes, `Ruby1` is MRI (ruby 2.2.2p95 (2015-04-13 revision 50295) [x86_64-darwin14])
```
$ bundle exec rake bench:report
Benchmark                                   Opal1  Opal2  Ruby1
benchmark/bm_array_intersection_numbers.rb  1.267  1.532  0.717
benchmark/bm_array_intersection_objects.rb  2.322  3.109  3.204
benchmark/bm_array_intersection_strings.rb  0.791  0.914  1.042
benchmark/bm_array_minus_numbers.rb         1.403  2.711  0.775
benchmark/bm_array_minus_objects.rb         2.293  3.633  2.200
benchmark/bm_array_minus_strings.rb         0.795  0.920  0.977
benchmark/bm_array_union_numbers.rb         2.041  4.304  1.182
benchmark/bm_array_union_objects.rb         4.145  5.349  2.571
benchmark/bm_array_union_strings.rb         1.524  1.379  1.347
benchmark/bm_array_uniq_bang_numbers.rb     0.524  0.805  0.209
benchmark/bm_array_uniq_bang_objects.rb     1.077  1.765  0.591
benchmark/bm_array_uniq_bang_strings.rb     0.345  0.429  0.409
benchmark/bm_array_uniq_numbers.rb          0.536  1.958  0.277
benchmark/bm_array_uniq_objects.rb          1.153  2.464  0.735
benchmark/bm_array_uniq_strings.rb          0.387  0.615  0.414
```
Note that we are taking a hit on arrays of numbers because they are now treated as object keys in the hash, so their performance basically levels up to that of arrays of objects. If `Hash` were to special-case numbers as it does strings, the performance of number arrays would be closer to that of string arrays than that of object arrays. @elia I hope you understand (given this example) what I meant regarding special-casing numbers. Yes, it is a rare use case to have numeric keys in hashes, but you're thinking about user-land hashes. Hashes are used internally in Ruby for all sorts of things like this. I'm not arguing for it though - like I said above, I think it's fast enough, and only looks slower in comparison with the previous numbers :wink: 