### PR TITLE
Optimize Class#new

### DIFF
--- a/opal/corelib/class.rb
+++ b/opal/corelib/class.rb
@@ -40,12 +40,13 @@ class Class
   end
 
   %x{
-    def.$new = TMP_2 = function() {
-      var $iter = TMP_2.$$p;
+    var TMP_NEW;
+    def.$new = TMP_NEW = function() {
+      var $iter = TMP_NEW.$$p;
       var block = $iter || nil;
 
       var args = $slice.call(arguments, 0);
-      TMP_2.$$p = null;
+      TMP_NEW.$$p = null;
 
       var obj = this.$allocate();
 

--- a/opal/corelib/class.rb
+++ b/opal/corelib/class.rb
@@ -39,15 +39,21 @@ class Class
   def inherited(cls)
   end
 
-  def new(*args, &block)
-    %x{
-      var obj = #{allocate};
+  %x{
+    def.$new = TMP_2 = function() {
+      var $iter = TMP_2.$$p;
+      var block = $iter || nil;
+
+      var args = $slice.call(arguments, 0);
+      TMP_2.$$p = null;
+
+      var obj = this.$allocate();
 
       obj.$initialize.$$p = block;
       obj.$initialize.apply(obj, args);
       return obj;
-    }
-  end
+    };
+  }
 
   def superclass
     `self.$$super || nil`


### PR DESCRIPTION
This is the result of modifying `Class#new` with one of my experiments from #1045 and rendering an intentionally large VDOM in a Clearwater app went from 303ms down to 267ms in Chrome, a time savings of 11.8% — roughly what I saw in those experiments.

After the VM invokes the JIT/optimizer (about 2-3 renders in), rendering without this patch converged on 123ms. With this patch, those same renders hit 101ms. This is 17.9% better, so subsequent renders benefit even more.