### PR TITLE
Optimize rand with a range

### DIFF
--- a/opal/corelib/kernel.rb
+++ b/opal/corelib/kernel.rb
@@ -1003,9 +1003,10 @@ module Kernel
         return Math.random();
       }
       else if (max.$$is_range) {
-        var arr = #{max.to_a};
+        var min = max.begin, range = max.end - min;
+        if(!max.exclude) range++;
 
-        return arr[#{rand(`arr.length`)}];
+        return self.$rand(range) + min;
       }
       else {
         return Math.floor(Math.random() *


### PR DESCRIPTION
Creating an array out of the range and then choosing a random element is elegant but, as you might imagine, not very performant for wide ranges. :-)

This patch boosts performance of `rand(1...10)` by 8.5x in Safari 9 on my machine.