### PR TITLE
Simplify Hash#merge

### DIFF
--- a/opal/corelib/hash.rb
+++ b/opal/corelib/hash.rb
@@ -615,13 +615,7 @@ class Hash
   alias member? has_key?
 
   def merge(other, &block)
-    unless Hash === other
-      other = Opal.coerce_to!(other, Hash, :to_hash)
-    end
-
-    cloned = clone
-    cloned.merge!(other, &block)
-    cloned
+    dup.merge!(other, &block)
   end
 
   def merge!(other, &block)


### PR DESCRIPTION
`Hash#merge`, being implemented in terms of `Hash#merge!`, doesn't need to worry about coercion or returning the duplicate because those are taken care of in `merge!`, allowing us to simplify this to a single line of code.