### PR TITLE
Optimize Enumerable#sort_by

### DIFF
--- a/opal/corelib/enumerable.rb
+++ b/opal/corelib/enumerable.rb
@@ -1090,11 +1090,11 @@ module Enumerable
   def sort_by(&block)
     return enum_for(:sort_by){self.enumerator_size} unless block_given?
 
-    map {
-      arg = Opal.destructure(`arguments`)
-
+    dup = map { |arg|
       [block.call(arg), arg]
-    }.sort { |a, b| a[0] <=> b[0] }.map { |arg| `arg[1]` }
+    }
+    dup.sort! { |a, b| `a[0]` <=> `b[0]` }
+    dup.map! { |i| `i[1]` }
   end
 
   def take(num)

--- a/opal/corelib/enumerable.rb
+++ b/opal/corelib/enumerable.rb
@@ -1090,7 +1090,8 @@ module Enumerable
   def sort_by(&block)
     return enum_for(:sort_by){self.enumerator_size} unless block_given?
 
-    dup = map { |arg|
+    dup = map {
+      arg = Opal.destructure(`arguments`)
       [block.call(arg), arg]
     }
     dup.sort! { |a, b| `a[0]` <=> `b[0]` }


### PR DESCRIPTION
I ran a benchmark that sorts a shuffled array of 50k objects. That
benchmark ran in 1040-1100ms under Safari.

Using JavaScript array indexing inside the sort function instead of Ruby array indexing dropped that number down to about 500-520ms. Mapping and sorting a single additional array (down from 3) reduced the range to 460-480ms.