### PR TITLE
Correct earlier duplication of RubySpec for class descendants issue

### DIFF
--- a/spec/filters/bugs/module.rb
+++ b/spec/filters/bugs/module.rb
@@ -1,6 +1,5 @@
 opal_filter "Module" do
   fails "Module#< raises a TypeError if the argument is not a class/module"
-  fails "Module#< returns false if self is the same as the given module"
   fails "Module#< returns nil if self is not related to the given module"
   fails "Module#< returns true if self is a subclass of or includes the given module"
   fails "Module#<= raises a TypeError if the argument is not a class/module"

--- a/spec/opal/core/language/class_spec.rb
+++ b/spec/opal/core/language/class_spec.rb
@@ -20,21 +20,3 @@ describe "Assigning Class.new to a constant" do
     ConstantWithAssignedClass.new.bar.should == :bar
   end
 end
-
-describe "Class descendant check using < operator" do
-  klass1 = Class.new
-  klass2 = Class.new(klass1)
-  klass3 = Class.new
-  
-  it "is a descendant" do
-    (klass2 < klass1).should == true    
-  end
-  
-  it "is not a descendant" do
-    (klass3 < klass1).should == false
-  end
-  
-  it "is the same class" do
-    (klass1 < klass1).should == false
-  end 
-end


### PR DESCRIPTION
Ruby specs were available for https://github.com/opal/opal/pull/1078 (commit 35b2a095dd6def54078f1ff57a141470ab62d566), so removing the custom specs that were added and using those