### PR TITLE
Fixed infinite recursion on calling Comparable#<=> when it was not defined.

### DIFF
--- a/opal/corelib/comparable.rb
+++ b/opal/corelib/comparable.rb
@@ -54,4 +54,8 @@ module Comparable
     return false if self > max
     return true
   end
+
+  def <=>(other)
+    nil
+  end
 end

--- a/spec/filters/bugs/comparable.rb
+++ b/spec/filters/bugs/comparable.rb
@@ -1,4 +1,0 @@
-opal_filter "Comparable" do
-  fails "Comparable#== when #<=> is not defined returns false and does not recurse infinitely"
-  fails "Comparable#== when #<=> calls super calls the defined #<=> only once for different objects"
-end


### PR DESCRIPTION
This solution creates some corner cases with `ancestors` like in the following example:
``` ruby
module ComparesByValue
  def <=>(other)
    self.value <=> other.value
  end
end

class A < Struct.new(:value)
  include ComparesByValue
  include Comparable
end

puts A.new(1) < A.new(2)
# true for MRI 2.2.3
# false for Opal
```

At the same time, rubyspecs for `Kernel#<=>` are [quite strange](https://github.com/ruby/rubyspec/blob/master/core/kernel/comparison_spec.rb). Because of specs implementation we have to call `==` in `Kernel#<=>`, while `Comparable#==` depends on `Kernel#<=>` (when it was not overwritten on subclass level) which calls infinite recursion.

I agree that this solution is not full and ideal, so I'm ok if you reject this PR, but does anyone have any other ideas?

Btw, running the following code in `opal-repl` causes MRI crash:
``` ruby
class A
  include Comparable
end
A.new <=> 1
```