### PR TITLE
Fixed recursive array comparison.

### DIFF
--- a/opal/corelib/array.rb
+++ b/opal/corelib/array.rb
@@ -195,11 +195,9 @@ class Array < `Array`
         return 0;
       }
 
-      if (self.length != other.length) {
-        return (self.length > other.length) ? 1 : -1;
-      }
+      var count = Math.min(self.length, other.length);
 
-      for (var i = 0, length = self.length; i < length; i++) {
+      for (var i = 0; i < count; i++) {
         var tmp = #{`self[i]` <=> `other[i]`};
 
         if (tmp !== 0) {
@@ -207,7 +205,7 @@ class Array < `Array`
         }
       }
 
-      return 0;
+      return #{`self.length` <=> `other.length`};
     }
   end
 

--- a/spec/filters/bugs/array.rb
+++ b/spec/filters/bugs/array.rb
@@ -1,5 +1,4 @@
 opal_filter "Array" do
-  fails "Array#<=> properly handles recursive arrays"
   fails "Array#clone copies singleton methods"
   fails "Array#combination when no block is given returned Enumerator size returns 0 when the number of combinations is < 0"
   fails "Array#combination when no block is given returned Enumerator size returns the binomial coeficient between the array size the number of combinations"


### PR DESCRIPTION
Based on [rubinius implementation](https://github.com/rubinius/rubinius/blob/master/kernel/common/array.rb#L276).

btw, two specs from rubyspec suite are failing for me locally:
```
Kernel.lambda returns from the to_int itself, not the creation site of the to_int
Module#attr_writer creates a setter for each given attribute name
```
And they were failing before. However on CI everything seems to be fine.