### PR TITLE
Store Struct attributes in hash instead of instance variables.

### DIFF
--- a/opal/corelib/helpers.rb
+++ b/opal/corelib/helpers.rb
@@ -113,4 +113,10 @@ module Opal
 
     name
   end
+
+  def self.valid_method_name?(method_name)
+    method_name = Opal.coerce_to!(method_name, String, :to_str)
+
+    `/^[a-zA-Z_][a-zA-Z0-9_]*?$/.test(method_name)`
+  end
 end

--- a/spec/filters/bugs/struct.rb
+++ b/spec/filters/bugs/struct.rb
@@ -19,5 +19,4 @@ opal_filter "Struct" do
   fails "Struct.new fails with too many arguments"
   fails "Struct.new raises a TypeError if object doesn't respond to to_sym"
   fails "Struct.new raises a TypeError if object is not a Symbol"
-  fails "Struct#[] returns attribute names that contain hyphens"
 end

--- a/stdlib/native.rb
+++ b/stdlib/native.rb
@@ -405,20 +405,6 @@ class MatchData
 end
 
 class Struct
-  def initialize(*args)
-    if args.length == 1 && native?(args[0])
-      object = args[0]
-
-      members.each {|name|
-        instance_variable_set "@#{name}", Native(`#{object}[#{name}]`)
-      }
-    else
-      members.each_with_index {|name, index|
-        instance_variable_set "@#{name}", args[index]
-      }
-    end
-  end
-
   def to_n
     result = `{}`
 


### PR DESCRIPTION
Rubyspec says that it should be possible to override `Struct#initialize` and "try" to override attributes:
``` ruby
User = Struct.new(:name) do
  def initialize(*)
    self.name = 'Name'
    super
  end
end

# However, the username should be taken from arguments:
User.new.name
# => nil
```

To make method `user` to not raise error, variable `@data` need to be initialize before `initialize` is invoked.

That's why `Struct#@data` should be:
1. lazily initialized using method `data` (which makes impossible for `Struct` to have an attribute `data`)
2. explicitly initialized every time when we access it

Every object in MRI has some core methods, which makes impossible for `Struct` to have *any* attribute names:
``` ruby
S = Struct.new(:marshal_dump, :marshal_load)
Marshal.load(Marshal.dump(S.new))
# => ArgumentError: wrong number of arguments(1 for 0)
```
Can we just rename this 'virtual' method `data` (which actually doesn't exist yet) to something like `__data__` and lazily initialize variable `@data`?