### PR TITLE
More splat args optimization

### DIFF
--- a/lib/opal/nodes/def.rb
+++ b/lib/opal/nodes/def.rb
@@ -135,7 +135,12 @@ module Opal
       def compile_rest_arg
         if rest_arg and rest_arg[1]
           splat = variable(rest_arg[1].to_sym)
-          line "var #{splat} = $slice.call(arguments, #{argc});"
+          line "var array_size = arguments.length - #{argc};"
+          line "if(array_size < 0) array_size = 0;"
+          line "var #{splat} = new Array(array_size);"
+          line "for(var arg_index = 0; arg_index < array_size; arg_index++) {"
+          line "  #{splat}[arg_index] = arguments[arg_index + #{argc}];"
+          line "}"
         end
       end
 


### PR DESCRIPTION
A lot of the optimizations we did before on splat args worked really well to speed things up, but I noticed some more places during profiling that said the VM couldn't optimize certain method calls because it used `Array.prototype.slice.call(arguments, n)` during arg splatting. v8's warning message for it was "bad value context for arguments value", presumably because we were calling an Array prototype function on something that's not technically an array.

This patch replaces the `slice` call with old-school iteration. Here are the benchmarks before and after the patch — they're iteration counts over 5 seconds, so larger is better:

```
Chrome 45

Before:
1 arg : 9,700,318
3 args: 7,923,521
5 args: 8,756,920

After:
1 arg : 18,278,855
3 args: 17,146,539
5 args: 16,672,049
```

```
Safari 9

Before:
1 arg: 13,294,087
3 args: 12,640,861
5 args: 11,544,130

After:
1 arg: 17,845,844
3 args: 17,696,489
5 args: 17,382,340
```