### PR TITLE
Add two failing specs to /bugs.

### DIFF
--- a/spec/filters/bugs/basicobject.rb
+++ b/spec/filters/bugs/basicobject.rb
@@ -25,4 +25,9 @@ opal_filter "BasicObject" do
   fails "BasicObject#instance_exec raises a TypeError when defining methods on an immediate"
   fails "BasicObject#instance_exec raises a TypeError when defining methods on numerics"
   fails "BasicObject#instance_exec sets class variables in the receiver"
+  fails "BasicObject#__send__ has a negative arity"
+  fails "Kernel#send has a negative arity"
+  fails "Kernel#public_send has a negative arity"
+  fails "Module#prepend does not affect the superclass"
+  fails "Module#singleton_class? returns true for singleton classes"
 end

--- a/spec/filters/bugs/kernel.rb
+++ b/spec/filters/bugs/kernel.rb
@@ -348,7 +348,7 @@ opal_filter "Kernel" do
   fails "Kernel.lambda does not check the arity when passing a Proc with &"
   fails "Kernel.lambda is a private method"
   fails "Kernel.lambda raises an ArgumentError when no block is given"
-  fails "Kernel.lambda returns from the kind_of? itself, not the creation site of the kind_of?"
+  fails "Kernel.lambda returns from the lambda itself, not the creation site of the lambda"
   fails "Kernel.lambda strictly checks the arity when 0 or 2..inf args are specified"
   fails "Kernel.loop is a private method"
   fails "Kernel.loop rescues StopIteration"

--- a/spec/filters/bugs/language.rb
+++ b/spec/filters/bugs/language.rb
@@ -213,6 +213,7 @@ opal_filter "language" do
   fails "The rescue keyword parses  'a += b rescue c' as 'a += (b rescue c)'"
   fails "The rescue keyword will execute an else block only if no exceptions were raised"
   fails "The rescue keyword will not rescue errors raised in an else block in the rescue block above it"
+  fails "The rescue keyword without classes will not rescue Exception"
   fails "The retry keyword inside a begin block's rescue block causes the begin block to be executed again"
   fails "The retry statement raises a SyntaxError when used outside of a begin statement"
   fails "The retry statement re-executes the closest block"

--- a/spec/filters/bugs/module.rb
+++ b/spec/filters/bugs/module.rb
@@ -160,6 +160,7 @@ opal_filter "Module" do
   fails "Module#module_function as a toggle (no arguments) in a Module body doesn't affect definitions when inside an eval even if the definitions are outside of it"
   fails "Module#module_function as a toggle (no arguments) in a Module body functions normally if both toggle and definitions inside a eval"
   fails "Module#module_function as a toggle (no arguments) in a Module body has no effect if inside a module_eval if the definitions are outside of it"
+  fails "Module#module_function as a toggle (no arguments) in a Module body affects evaled method definitions also even when outside the eval itself"
   fails "Module#module_function on Class raises a TypeError if calling after rebinded to Class"
   fails "Module#module_function with specific method names raises a TypeError when the given names can't be converted to string using to_str"
   fails "Module#module_function with specific method names tries to convert the given names to strings using to_str"

--- a/spec/filters/unsupported/basicobject.rb
+++ b/spec/filters/unsupported/basicobject.rb
@@ -1,0 +1,14 @@
+opal_filter "BasicObject" do
+  fails "BasicObject#method_missing for a Module with #method_missing defined is called when a protected method is called"
+  fails "BasicObject#method_missing for a Module with #method_missing defined is called when a private method is called"
+  fails "BasicObject#method_missing for a Module raises a NoMethodError when a protected method is called"
+  fails "BasicObject#method_missing for a Module raises a NoMethodError when a private method is called"
+  fails "BasicObject#method_missing for a Class with #method_missing defined is called when an protected method is called"
+  fails "BasicObject#method_missing for a Class with #method_missing defined is called when an private method is called"
+  fails "BasicObject#method_missing for a Class raises a NoMethodError when a protected method is called"
+  fails "BasicObject#method_missing for a Class raises a NoMethodError when a private method is called"
+  fails "BasicObject#method_missing for an instance with #method_missing defined is called when an protected method is called"
+  fails "BasicObject#method_missing for an instance with #method_missing defined is called when an private method is called"
+  fails "BasicObject#method_missing for an instance raises a NoMethodError when a protected method is called"
+  fails "BasicObject#method_missing for an instance raises a NoMethodError when a private method is called"
+end

--- a/spec/filters/unsupported/float.rb
+++ b/spec/filters/unsupported/float.rb
@@ -7,11 +7,11 @@ opal_filter "Float" do
   fails "Float#coerce returns [other, self] both as Floats"
   fails "Float#eql? returns false if other is not a Float"
 
-  fails "Float#CONSTANTS the MAX_10_EXP is 308"
-  fails "Float#CONSTANTS the MAX_EXP is 1024"
-  fails "Float#CONSTANTS the MIN is 2.2250738585072e-308"
-  fails "Float#CONSTANTS the MIN_10_EXP is -308"
-  fails "Float#CONSTANTS the MIN_EXP is -1021"
+  fails "Float constant MAX_10_EXP is 308"
+  fails "Float constant MIN_10_EXP is -308"
+  fails "Float constant MIN is 2.2250738585072e-308"
+  fails "Float constant MAX_EXP is 1024"
+  fails "Float constant MIN_EXP is -1021"
 
   fails "Fixnum#divmod raises a TypeError when given a non-Integer"
 


### PR DESCRIPTION
The first spec which is related to lambdas is failing because of its dynamic name. Sometimes it's called
```
Kernel.lambda returns from the kind_of? itself, not the creation site of the kind_of?
```
sometimes method name is different. When you run only one spec file containing this test, the method name in the message appears to be blank. This PR should be merged after [this pull](https://github.com/ruby/rubyspec/pull/129) is merged. And anyway, the spec if [failing](http://opalrb.org/try/?code:%24called%20%3D%20false%0A%0Adef%20test%0A%20%20lambda%20%7B%20return%20%7D.call%0A%20%20%24called%20%3D%20true%0Aend%0A%0Atest%0Aputs%20%24called%0A%0A%23%20----%0A%0A%24called%20%3D%20false%0A%0Adef%20test%0A%20%20proc%20%7B%20return%20%7D.call%0A%20%20%24called%20%3D%20true%0Aend%0A%0Atest%0Aputs%20%24called)

The second one is a bug in Opal. [Here](http://opalrb.org/try/?code:module%20M%0A%20%20eval%20%27def%20some_method%3B%20end%27%0Aend%0A%0Aputs%20Object.new.respond_to%3F(%3Asome_method)) is a quick demo. It seems that when Opal evaluates some code in context of class/module, the execution actually happens on `Kernel` and method becomes global. [This](https://github.com/ruby/rubyspec/blob/master/core/module/module_function_spec.rb#L232) is the test that generates a global method `test1`. And [this](https://github.com/ruby/rubyspec/blob/master/core/module/attr_writer_spec.rb#L11) is the test that fails because of the bug. So, one spec is actually broken, but it shows as green, the other spec becomes red because of the side effect.