### PR TITLE
Improve PP stdlib defaults

### DIFF
--- a/stdlib/pp.rb
+++ b/stdlib/pp.rb
@@ -19,10 +19,8 @@ class PP
         p(*args)
       end
     else
-      def pp(obj, out=`console`, width=79)
-        if `#{out} === console`
-          `console.log(obj)`
-        elsif String === out
+      def pp(obj, out=$stdout, width=79)
+        if String === out
           out + obj.inspect + "\n"
         else
           out << obj.inspect + "\n"


### PR DESCRIPTION
* Use $stdout by default, which is closer to what MRI does (they use $<, but that would require more extensive gvars changes)
* Remove the attempt at pretty printing by console.log'ing the object

Tests for this submitted as rubyspec PR https://github.com/ruby/rubyspec/pull/130

Once that makes its way into Opal's submodule, will need to add this to spec/rubyspecs

```
rubyspec/library/pp
```