### PR TITLE
Add support for recursive Struct comparison using #== and #eql?.

### DIFF
--- a/opal/corelib/struct.rb
+++ b/opal/corelib/struct.rb
@@ -106,6 +106,78 @@ class Struct
     `self.$$data[name] = value`
   end
 
+  def ==(other)
+    return false unless other.instance_of?(self.class)
+
+    %x{
+      var recursed1 = {}, recursed2 = {};
+
+      function _eqeq(struct, other) {
+        var key, a, b;
+
+        recursed1[#{`struct`.__id__}] = true;
+        recursed2[#{`other`.__id__}] = true;
+
+        for (key in struct.$$data) {
+          a = struct.$$data[key];
+          b = other.$$data[key];
+
+          if (#{Struct === `a`}) {
+            if (!recursed1.hasOwnProperty(#{`a`.__id__}) || !recursed2.hasOwnProperty(#{`b`.__id__})) {
+              if (!_eqeq(a, b)) {
+                return false;
+              }
+            }
+          } else {
+            if (!#{`a` == `b`}) {
+              return false;
+            }
+          }
+        }
+
+        return true;
+      }
+
+      return _eqeq(self, other);
+    }
+  end
+
+  def eql?(other)
+    return false unless other.instance_of?(self.class)
+
+    %x{
+      var recursed1 = {}, recursed2 = {};
+
+      function _eqeq(struct, other) {
+        var key, a, b;
+
+        recursed1[#{`struct`.__id__}] = true;
+        recursed2[#{`other`.__id__}] = true;
+
+        for (key in struct.$$data) {
+          a = struct.$$data[key];
+          b = other.$$data[key];
+
+          if (#{Struct === `a`}) {
+            if (!recursed1.hasOwnProperty(#{`a`.__id__}) || !recursed2.hasOwnProperty(#{`b`.__id__})) {
+              if (!_eqeq(a, b)) {
+                return false;
+              }
+            }
+          } else {
+            if (!#{`a`.eql?(`b`)}) {
+              return false;
+            }
+          }
+        }
+
+        return true;
+      }
+
+      return _eqeq(self, other);
+    }
+  end
+
   def each
     return enum_for(:each){self.size} unless block_given?
 
@@ -118,12 +190,6 @@ class Struct
 
     members.each { |name| yield [name, self[name]] }
     self
-  end
-
-  def eql?(other)
-    hash == other.hash || other.each_with_index.all? {|object, index|
-      self[members[index]] == object
-    }
   end
 
   def length

--- a/spec/filters/bugs/struct.rb
+++ b/spec/filters/bugs/struct.rb
@@ -1,8 +1,4 @@
 opal_filter "Struct" do
-  fails "Struct#== handles recursive structures by returning false if a difference can be found"
-  fails "Struct#== returns true if the other has all the same fields"
-  fails "Struct#eql? handles recursive structures by returning false if a difference can be found"
-  fails "Struct#eql? returns false if any corresponding elements are not #eql?"
   fails "Struct#hash returns the same fixnum for structs with the same content"
   fails "Struct#hash returns the same hash for recursive structs"
   fails "Struct#hash returns the same value if structs are #eql?"

--- a/spec/filters/unsupported/float.rb
+++ b/spec/filters/unsupported/float.rb
@@ -48,4 +48,6 @@ opal_filter "Float" do
 
   # precision error
   fails "Math.gamma returns approximately (n-1)! given n for n between 24 and 30"
+
+  fails "Struct#eql? returns false if any corresponding elements are not #eql?" # Rubyspec uses 1.eql?(1.0) which always returns true in compiled JS
 end


### PR DESCRIPTION
The [spec](https://github.com/ruby/rubyspec/blob/master/core/struct/eql_spec.rb#L8) `Struct#eql? returns false if any corresponding elements are not #eql?` just cannot be implemented because of JS limitations. It automatically typecasts 1.0 to 1 (so they become eql).