### PR TITLE
Raise/Fail Exception Rubyspec Compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@
 
 * Fix issue where passing a block after a parameter and a hash was causing block to not be passed (e.g. `method1 some_param, 'a' => 1, &block`)
 
+* `Kernel#raise` now properly re-raises exceptions (regardless of how many levels deep you are) and works properly if supplied a class that has an exception method.
+
 
 ## 0.8.0 2015-07-16
 

--- a/lib/opal/nodes/rescue.rb
+++ b/lib/opal/nodes/rescue.rb
@@ -115,7 +115,16 @@ module Opal
           push expr(variable), ';'
         end
 
-        line process(rescue_body, @level)
+        # Need to ensure we clear the current exception out after the rescue block ends
+        line "try {"
+        indent do
+          line process(rescue_body, @level)
+        end
+        line "} finally {"
+        indent do
+          line 'Opal.gvars["!"] = Opal.exceptions.length > 0 ? Opal.exceptions.pop() : Opal.nil;'
+        end
+        line "}"
         line "}"
       end
 

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -51,6 +51,9 @@
   // Exit function, this should be replaced by platform specific implementation
   // (See nodejs and phantom for examples)
   Opal.exit = function(status) { if (Opal.gvars.DEBUG) console.log('Exited with status '+status); };
+	
+  // keeps track of exceptions for $!
+  Opal.exceptions = [];
 
   /**
     Get a constant on the given scope. Every class and module in Opal has a

--- a/spec/filters/unsupported/kernel.rb
+++ b/spec/filters/unsupported/kernel.rb
@@ -26,4 +26,6 @@ opal_filter "Kernel" do
   fails "Kernel#dup preserves tainted state from the original"
   fails "Kernel#dup preserves untrusted state from the original"
   fails "Kernel#dup raises a TypeError for Symbol"
+  fails "Kernel.fail is a private method"
+  fails "Kernel#raise is a private method"
 end

--- a/spec/rubyspecs
+++ b/spec/rubyspecs
@@ -32,13 +32,13 @@ rubyspec/core/kernel
 !rubyspec/core/kernel/exec_spec
 !rubyspec/core/kernel/exit_spec
 !rubyspec/core/kernel/extend_spec
-!rubyspec/core/kernel/fail_spec
+rubyspec/core/kernel/fail_spec
 !rubyspec/core/kernel/fork_spec
 !rubyspec/core/kernel/gets_spec
 !rubyspec/core/kernel/load_spec
 !rubyspec/core/kernel/open_spec
 !rubyspec/core/kernel/putc_spec
-!rubyspec/core/kernel/raise_spec
+rubyspec/core/kernel/raise_spec
 !rubyspec/core/kernel/readline_spec
 !rubyspec/core/kernel/readlines_spec
 !rubyspec/core/kernel/require_relative_spec


### PR DESCRIPTION
(moved work in https://github.com/opal/opal/pull/1105 to another branch):

This passes all of the raise/fail rubyspecs (except private methods). It comes at a cost though. In order to reset $! after every rescue like MRI does, I had to alter the compiler to make it a stack (JS array).

I realize that may be too much since it adds a try {} finally {} to **every** rescue block. I thought I'd put it out here and see though.

If this can't be done cleanly using my approach or another approach, then I think Opal should explicitly say:
* $! is not a supported global variable
* As a result, you cannot re-raise exceptions by calling 'raise' without parameters

If this **is** acceptable, then:
* I could also use some feedback on how I did the compiler tweaks. I didn't spend much time trying to do it 100% right since the idea might get squashed anyways.
* I'll squash the commits