### PR TITLE
Struct Hash Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 * `Opal::Processor.load_asset_code(sprockets, name)` has been deprecated in favor of `Opal::Sprockets.load_asset(name, sprockets)`.
 
+* `Struct#hash` now works properly based on struct contents
+
 
 ## 0.8.0 2015-07-16
 

--- a/opal/corelib/struct.rb
+++ b/opal/corelib/struct.rb
@@ -73,6 +73,10 @@ class Struct
   def members
     self.class.members
   end
+  
+  def hash
+    Hash.new(`self.$$data`).hash
+  end
 
   def [](name)
     if Integer === name

--- a/spec/filters/bugs/struct.rb
+++ b/spec/filters/bugs/struct.rb
@@ -1,7 +1,5 @@
 opal_filter "Struct" do
   fails "Struct#hash returns the same fixnum for structs with the same content"
-  fails "Struct#hash returns the same hash for recursive structs"
-  fails "Struct#hash returns the same value if structs are #eql?"
   fails "Struct#initialize can be overriden"
   fails "Struct#inspect returns a string representation of some kind"
   fails "Struct#instance_variables returns an array with one name if an instance variable is added"


### PR DESCRIPTION
…ime.js so that Number#hash can stay how it is and not make a Ruby method call)

* Change kernel to hash the name, class ID, and object ID using the string hash method
* Since string's hash is not itself anymore, changed pathname to hash its path and keep its specs passing
* Rather than returning a string here, hash the overall result to be consistent with other changes
* Fix struct hash method