### PR TITLE
Load rubyspecs filters in testing tasks before loading actual specs

### DIFF
--- a/tasks/testing.rake
+++ b/tasks/testing.rake
@@ -41,9 +41,9 @@ module Testing
 
     if pattern
       custom &= rubyspecs if whitelist_pattern
-      specs = add_specs.(:custom, custom)
       specs = add_specs.(:filters, opalspec_filters)
       specs = add_specs.(:filters, rubyspec_filters)
+      specs = add_specs.(:custom, custom)
     elsif suite == 'opal'
       specs = add_specs.(:filters, opalspec_filters)
       specs = add_specs.(:shared, shared)


### PR DESCRIPTION
Without this patch it's impossible to run rubyspecs with some pattern and use filters, e.g. task
```
env RUBYSPECS=true PATTERN="spec/rubyspec/core/array/initialize_spec.rb" bundle exec rake mspec_rubyspec_node
```
was invoking specs that are marked as `failed` or `unsupported`