### PR TITLE
Fix important issue with native exceptions

### DIFF
--- a/opal/corelib/error.rb
+++ b/opal/corelib/error.rb
@@ -19,7 +19,8 @@ class Exception < `Error`
   end
 
   def initialize(*args)
-    `self.$$message = (args.length > 0) ? args[0] : nil`
+    # using self.message aka @message to retain compatibility with native exception's message property
+    `self.message = (args.length > 0) ? args[0] : nil`
   end
 
   def backtrace
@@ -44,7 +45,7 @@ class Exception < `Error`
       }
       
       var cloned = #{self.clone};
-      cloned.$$message = str;
+      cloned.message = str;
       return cloned;
     }
   end
@@ -60,8 +61,8 @@ class Exception < `Error`
   end
   
   def to_s
-    message = `self.$$message`
-    (message && message.to_s) || self.class.to_s
+    # using self.message aka @message to retain compatibility with native exception's message property
+    (@message && @message.to_s) || self.class.to_s
   end
 end
 

--- a/spec/opal/core/exception_spec.rb
+++ b/spec/opal/core/exception_spec.rb
@@ -11,3 +11,10 @@ describe "Exception" do
     ExceptionSubclassTest.new.custom_method.should == 42
   end
 end
+
+describe "Native exception" do
+  it "handles messages for native exceptions" do
+    exception = `new Error("native message")`
+    exception.message.should == "native message"
+  end
+end


### PR DESCRIPTION
Have to go back to using @message to retain compatibility, made note and added an Opal test

Fixes problem introduced in https://github.com/opal/opal/pull/1151