### PR TITLE
Restore ability to call const_set on an anonymous class w/ non object super

### DIFF
--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -705,7 +705,8 @@
     var scope = base_module.$$scope;
 
     if (value.$$is_class || value.$$is_module) {
-      if (value.$$base_module === ObjectClass) {
+      // only checking ObjectClass prevents setting a const on an anonymous class that has a superclass that's not Object
+      if (value.$$is_class || value.$$base_module === ObjectClass) {
         value.$$base_module = base_module;
       }
 

--- a/spec/opal/core/language/class_spec.rb
+++ b/spec/opal/core/language/class_spec.rb
@@ -1,3 +1,27 @@
+class AssignClassNewConst
+  TEST_CONST = :bar
+  
+  def foo
+    TEST_CONST
+  end
+  
+  def self.assign_klass
+    k = Class.new(self) do
+      def foobar
+        # ensure we can still use constants from AssignClassNewConst even though we use AssignClassConstBase
+        TEST_CONST
+      end
+    end
+    AssignClassConstBase.assign_const(k)
+  end
+end
+
+module AssignClassConstBase
+  def self.assign_const(group)
+    self.const_set("MyStuff", group)    
+  end
+end
+
 describe "Assigning Class.new to a constant" do
   klass = Class.new do
     def bar
@@ -18,5 +42,14 @@ describe "Assigning Class.new to a constant" do
   it "can be reopened by the constant name" do
     ConstantWithAssignedClass.new.foo.should == :foo
     ConstantWithAssignedClass.new.bar.should == :bar
+  end
+  
+  it "respects a different base scope" do
+    AssignClassNewConst.assign_klass
+    AssignClassConstBase::MyStuff.to_s.should == "AssignClassConstBase::MyStuff"
+    AssignClassConstBase::MyStuff.name.should == "AssignClassConstBase::MyStuff"
+    obj = AssignClassConstBase::MyStuff.new
+    obj.foo.should == :bar
+    obj.foobar.should == :bar
   end
 end


### PR DESCRIPTION
Issue that was breaking opal-rspec on 0.9

See https://github.com/opal/opal/issues/1154