### PR TITLE
Fix remnants of is_mod->is_module rename

### DIFF
--- a/opal/corelib/module.rb
+++ b/opal/corelib/module.rb
@@ -397,7 +397,7 @@ class Module
           continue;
         }
 
-        if (!self.$$is_mod) {
+        if (!self.$$is_module) {
           if (self !== Opal.BasicObject && proto[prop] === Opal.BasicObject.$$proto[prop]) {
             continue;
           }
@@ -536,7 +536,7 @@ class Module
   end
 
   def to_s
-    `Opal.Module.$name.call(self)` || "#<#{`self.$$is_mod ? 'Module' : 'Class'`}:0x#{__id__.to_s(16)}>"
+    `Opal.Module.$name.call(self)` || "#<#{`self.$$is_module ? 'Module' : 'Class'`}:0x#{__id__.to_s(16)}>"
   end
 
   def undef_method(*names)


### PR DESCRIPTION
Fixed both `Module#instance_methods` and `Module#to_s`

Rubyspecs that will catch this are:
* https://github.com/ruby/rubyspec/pull/148
* https://github.com/ruby/rubyspec/pull/149