### PR TITLE
Fix 'raise Exception' message case

### DIFF
--- a/opal/corelib/kernel.rb
+++ b/opal/corelib/kernel.rb
@@ -993,7 +993,7 @@ module Kernel
     $stderr.puts(*strs) unless $VERBOSE.nil? || strs.empty?
   end
 
-  def raise(exception = undefined, string = undefined)
+  def raise(exception = undefined, string = nil)
     %x{
       if (exception == null && #$! !== nil) {
         throw #$!;

--- a/spec/opal/core/kernel/raise_spec.rb
+++ b/spec/opal/core/kernel/raise_spec.rb
@@ -1,0 +1,13 @@
+describe "Kernel#raise" do
+  # rubyspecs test most of this, but rubyspecs won't differentiate between nil and undefined
+  it "raises messages without exceptions" do
+    lambda { raise Exception }.should raise_error(Exception)
+    ex = nil
+    begin
+      raise Exception
+    rescue Exception => e
+      ex = e
+    end
+    ex.to_s.should == 'Exception'
+  end
+end


### PR DESCRIPTION
If exceptions were raised with just a class name, then undefined got set as the message, which broke the exception class

Fixes issue introduced by earlier PRs.