### PR TITLE
`Module#ancestors` now works correctly except for singleton classes

### DIFF
--- a/opal/corelib/module.rb
+++ b/opal/corelib/module.rb
@@ -73,9 +73,11 @@ class Module
 
       while (parent) {
         result.push(parent);
-        result = result.concat(parent.$$inc);
+        for (var i=0; i < parent.$$inc.length; i++) {
+          result = result.concat(parent.$$inc[i].$ancestors());
+        }
 
-        parent = parent.$$super;
+        parent = parent.$$is_class ? parent.$$super : null;
       }
 
       return result;

--- a/spec/filters/bugs/module.rb
+++ b/spec/filters/bugs/module.rb
@@ -23,7 +23,6 @@ opal_filter "Module" do
   fails "Module#alias_method preserves the arguments information of the original methods"
   fails "Module#alias_method raises a TypeError when the given name can't be converted using to_str"
   fails "Module#alias_method retains method visibility"
-  fails "Module#ancestors returns a list of modules included in self (including self)"
   fails "Module#ancestors returns only modules and classes"
   fails "Module#ancestors when called on a singleton class includes the singleton classes of ancestors"
   fails "Module#append_features copies own tainted status to the given module"


### PR DESCRIPTION
Returns only self when it should, complies with 1 more rubyspec than before