### PR TITLE
Remove flawed method check that was causing struct issues

### DIFF
--- a/opal/corelib/helpers.rb
+++ b/opal/corelib/helpers.rb
@@ -112,11 +112,5 @@ module Opal
     end
 
     name
-  end
-
-  def self.valid_method_name?(method_name)
-    method_name = Opal.coerce_to!(method_name, String, :to_str)
-
-    `/^[a-zA-Z_][a-zA-Z0-9_]*?$/.test(method_name)`
-  end
+  end  
 end

--- a/opal/corelib/struct.rb
+++ b/opal/corelib/struct.rb
@@ -37,15 +37,13 @@ class Struct
 
     members << name
 
-    if Opal.valid_method_name?(name)
-      define_method name do
-        self[name]
-      end
-
-      define_method "#{name}=" do |value|
-        self[name] = value
-      end
+    define_method name do
+      self[name]
     end
+
+    define_method "#{name}=" do |value|
+      self[name] = value
+    end    
   end
 
   def self.members

--- a/spec/filters/bugs/struct.rb
+++ b/spec/filters/bugs/struct.rb
@@ -1,6 +1,5 @@
 opal_filter "Struct" do
   fails "Struct#hash returns the same fixnum for structs with the same content"
-  fails "Struct#initialize allows valid Ruby method names for members"
   fails "Struct#initialize can be overriden"
   fails "Struct#inspect returns a string representation of some kind"
   fails "Struct#instance_variables returns an array with one name if an instance variable is added"


### PR DESCRIPTION
Remove flawed method check that was preventing something? from working with struct

Methods ending in ?, !, etc. are valid but this check did not like them. In addition, it would fail silently, which isn't good. Since it was only used by the struct and was incomplete, I think removing it is the best option. it's probably better to have a built-in check inside define_method anyways