### PR TITLE
Private class method, though unsupported, now allows multiple args

### DIFF
--- a/opal/corelib/unsupported.rb
+++ b/opal/corelib/unsupported.rb
@@ -180,8 +180,8 @@ class Module
 
   alias nesting public
 
-  def private_class_method(name)
-    `self['$' + name] || nil`
+  def private_class_method(*)
+    self
   end
 
   alias public_class_method private_class_method


### PR DESCRIPTION
Should keep code that calls this from throwing an error