### PR TITLE
Fix Kernel#instance_variables for Hash and nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 0.9.0 (edge)
 
+* Renamed:
+    * `Hash.keys` => `Hash.$$keys`
+    * `Hash.map` => `Hash.$$map`
+    * `Hash.smap` => `Hash.$$smap`
+
 * A `console` wrapper has been added to the stdlib, requiring it will make available the `$console` global variable.
 
 * `Kernel#pp` no longer forwards arguments directly to `console.log`, this behavior has been replaced by stdlib's own `console.rb` (see above).

--- a/lib/opal/nodes/def.rb
+++ b/lib/opal/nodes/def.rb
@@ -199,14 +199,14 @@ module Opal
             arg_name = kwarg[1]
             var_name = variable(arg_name.to_s)
             add_local var_name
-            line "if ((#{var_name} = $kwargs.smap['#{arg_name}']) == null) {"
+            line "if ((#{var_name} = $kwargs.$$smap['#{arg_name}']) == null) {"
             line "  #{var_name} = ", expr(kwarg[2])
             line "}"
           when :kwarg
             arg_name = kwarg[1]
             var_name = variable(arg_name.to_s)
             add_local var_name
-            line "if ((#{var_name} = $kwargs.smap['#{arg_name}']) == null) {"
+            line "if ((#{var_name} = $kwargs.$$smap['#{arg_name}']) == null) {"
             line "  throw new Error('expecting keyword arg: #{arg_name}')"
             line "}"
           when :kwrestarg

--- a/opal/corelib/hash.rb
+++ b/opal/corelib/hash.rb
@@ -93,16 +93,16 @@ class Hash
         return false;
       }
 
-      if (self.keys.length !== other.keys.length) {
+      if (self.$$keys.length !== other.$$keys.length) {
         return false;
       }
 
-      for (var i = 0, keys = self.keys, length = keys.length, key, value, other_value; i < length; i++) {
+      for (var i = 0, keys = self.$$keys, length = keys.length, key, value, other_value; i < length; i++) {
         key = keys[i];
 
         if (key.$$is_string) {
-          value = self.smap[key];
-          other_value = other.smap[key];
+          value = self.$$smap[key];
+          other_value = other.$$smap[key];
         } else {
           value = key.value;
           other_value = Opal.hash_get(other, key.key);
@@ -138,12 +138,12 @@ class Hash
 
   def assoc(object)
     %x{
-      for (var i = 0, keys = self.keys, length = keys.length, key; i < length; i++) {
+      for (var i = 0, keys = self.$$keys, length = keys.length, key; i < length; i++) {
         key = keys[i];
 
         if (key.$$is_string) {
           if (#{`key` == object}) {
-            return [key, self.smap[key]];
+            return [key, self.$$smap[key]];
           }
         } else {
           if (#{`key.key` == object}) {
@@ -233,11 +233,11 @@ class Hash
     return enum_for(:delete_if){self.size} unless block
 
     %x{
-      for (var i = 0, keys = self.keys, length = keys.length, key, value, obj; i < length; i++) {
+      for (var i = 0, keys = self.$$keys, length = keys.length, key, value, obj; i < length; i++) {
         key = keys[i];
 
         if (key.$$is_string) {
-          value = self.smap[key];
+          value = self.$$smap[key];
         } else {
           value = key.value;
           key = key.key;
@@ -267,11 +267,11 @@ class Hash
     return enum_for(:each){self.size} unless block
 
     %x{
-      for (var i = 0, keys = self.keys, length = keys.length, key, value, obj; i < length; i++) {
+      for (var i = 0, keys = self.$$keys, length = keys.length, key, value, obj; i < length; i++) {
         key = keys[i];
 
         if (key.$$is_string) {
-          value = self.smap[key];
+          value = self.$$smap[key];
         } else {
           value = key.value;
           key = key.key;
@@ -292,7 +292,7 @@ class Hash
     return enum_for(:each_key){self.size} unless block
 
     %x{
-      for (var i = 0, keys = self.keys, length = keys.length, key; i < length; i++) {
+      for (var i = 0, keys = self.$$keys, length = keys.length, key; i < length; i++) {
         key = keys[i];
 
         if (block(key.$$is_string ? key : key.key) === $breaker) {
@@ -310,10 +310,10 @@ class Hash
     return enum_for(:each_value){self.size} unless block
 
     %x{
-      for (var i = 0, keys = self.keys, length = keys.length, key; i < length; i++) {
+      for (var i = 0, keys = self.$$keys, length = keys.length, key; i < length; i++) {
         key = keys[i];
 
-        if (block(key.$$is_string ? self.smap[key] : key.value) === $breaker) {
+        if (block(key.$$is_string ? self.$$smap[key] : key.value) === $breaker) {
           return $breaker.$v;
         }
       }
@@ -323,7 +323,7 @@ class Hash
   end
 
   def empty?
-    `self.keys.length === 0`
+    `self.$$keys.length === 0`
   end
 
   alias eql? ==
@@ -360,11 +360,11 @@ class Hash
     %x{
       var result = [];
 
-      for (var i = 0, keys = self.keys, length = keys.length, key, value; i < length; i++) {
+      for (var i = 0, keys = self.$$keys, length = keys.length, key, value; i < length; i++) {
         key = keys[i];
 
         if (key.$$is_string) {
-          value = self.smap[key];
+          value = self.$$smap[key];
         } else {
           value = key.value;
           key = key.key;
@@ -395,10 +395,10 @@ class Hash
 
   def has_value?(value)
     %x{
-      for (var i = 0, keys = self.keys, length = keys.length, key; i < length; i++) {
+      for (var i = 0, keys = self.$$keys, length = keys.length, key; i < length; i++) {
         key = keys[i];
 
-        if (#{`(key.$$is_string ? self.smap[key] : key.value)` == value}) {
+        if (#{`(key.$$is_string ? self.$$smap[key] : key.value)` == value}) {
           return true;
         }
       }
@@ -434,11 +434,11 @@ class Hash
 
         Opal.hash_ids[hash_id] = self;
 
-        for (var i = 0, keys = self.keys, length = keys.length; i < length; i++) {
+        for (var i = 0, keys = self.$$keys, length = keys.length; i < length; i++) {
           key = keys[i];
 
           if (key.$$is_string) {
-            result.push([key, self.smap[key].$hash()]);
+            result.push([key, self.$$smap[key].$hash()]);
           } else {
             result.push([key.key_hash, key.value.$hash()]);
           }
@@ -458,11 +458,11 @@ class Hash
 
   def index(object)
     %x{
-      for (var i = 0, keys = self.keys, length = keys.length, key, value; i < length; i++) {
+      for (var i = 0, keys = self.$$keys, length = keys.length, key, value; i < length; i++) {
         key = keys[i];
 
         if (key.$$is_string) {
-          value = self.smap[key];
+          value = self.$$smap[key];
         } else {
           value = key.value;
           key = key.key;
@@ -518,11 +518,11 @@ class Hash
 
         inspect_ids[hash_id] = true;
 
-        for (var i = 0, keys = self.keys, length = keys.length, key, value; i < length; i++) {
+        for (var i = 0, keys = self.$$keys, length = keys.length, key, value; i < length; i++) {
           key = keys[i];
 
           if (key.$$is_string) {
-            value = self.smap[key];
+            value = self.$$smap[key];
           } else {
             value = key.value;
             key = key.key;
@@ -545,11 +545,11 @@ class Hash
     %x{
       var hash = Opal.hash();
 
-      for (var i = 0, keys = self.keys, length = keys.length, key, value; i < length; i++) {
+      for (var i = 0, keys = self.$$keys, length = keys.length, key, value; i < length; i++) {
         key = keys[i];
 
         if (key.$$is_string) {
-          value = self.smap[key];
+          value = self.$$smap[key];
         } else {
           value = key.value;
           key = key.key;
@@ -566,11 +566,11 @@ class Hash
     return enum_for(:keep_if){self.size} unless block
 
     %x{
-      for (var i = 0, keys = self.keys, length = keys.length, key, value, obj; i < length; i++) {
+      for (var i = 0, keys = self.$$keys, length = keys.length, key, value, obj; i < length; i++) {
         key = keys[i];
 
         if (key.$$is_string) {
-          value = self.smap[key];
+          value = self.$$smap[key];
         } else {
           value = key.value;
           key = key.key;
@@ -602,7 +602,7 @@ class Hash
     %x{
       var result = [];
 
-      for (var i = 0, keys = self.keys, length = keys.length, key; i < length; i++) {
+      for (var i = 0, keys = self.$$keys, length = keys.length, key; i < length; i++) {
         key = keys[i];
 
         if (key.$$is_string) {
@@ -617,7 +617,7 @@ class Hash
   end
 
   def length
-    `self.keys.length`
+    `self.$$keys.length`
   end
 
   alias member? has_key?
@@ -632,14 +632,14 @@ class Hash
         other = #{Opal.coerce_to!(other, Hash, :to_hash)};
       }
 
-      var i, other_keys = other.keys, length = other_keys.length, key, value, other_value;
+      var i, other_keys = other.$$keys, length = other_keys.length, key, value, other_value;
 
       if (block === nil) {
         for (i = 0; i < length; i++) {
           key = other_keys[i];
 
           if (key.$$is_string) {
-            other_value = other.smap[key];
+            other_value = other.$$smap[key];
           } else {
             other_value = key.value;
             key = key.key;
@@ -655,7 +655,7 @@ class Hash
         key = other_keys[i];
 
         if (key.$$is_string) {
-          other_value = other.smap[key];
+          other_value = other.$$smap[key];
         } else {
           other_value = key.value;
           key = key.key;
@@ -677,11 +677,11 @@ class Hash
 
   def rassoc(object)
     %x{
-      for (var i = 0, keys = self.keys, length = keys.length, key, value; i < length; i++) {
+      for (var i = 0, keys = self.$$keys, length = keys.length, key, value; i < length; i++) {
         key = keys[i];
 
         if (key.$$is_string) {
-          value = self.smap[key];
+          value = self.$$smap[key];
         } else {
           value = key.value;
           key = key.key;
@@ -709,11 +709,11 @@ class Hash
     %x{
       var hash = Opal.hash();
 
-      for (var i = 0, keys = self.keys, length = keys.length, key, value, obj; i < length; i++) {
+      for (var i = 0, keys = self.$$keys, length = keys.length, key, value, obj; i < length; i++) {
         key = keys[i];
 
         if (key.$$is_string) {
-          value = self.smap[key];
+          value = self.$$smap[key];
         } else {
           value = key.value;
           key = key.key;
@@ -740,11 +740,11 @@ class Hash
     %x{
       var changes_were_made = false;
 
-      for (var i = 0, keys = self.keys, length = keys.length, key, value, obj; i < length; i++) {
+      for (var i = 0, keys = self.$$keys, length = keys.length, key, value, obj; i < length; i++) {
         key = keys[i];
 
         if (key.$$is_string) {
-          value = self.smap[key];
+          value = self.$$smap[key];
         } else {
           value = key.value;
           key = key.key;
@@ -775,11 +775,11 @@ class Hash
     %x{
       Opal.hash_init(self);
 
-      for (var i = 0, other_keys = other.keys, length = other_keys.length, key, value, other_value; i < length; i++) {
+      for (var i = 0, other_keys = other.$$keys, length = other_keys.length, key, value, other_value; i < length; i++) {
         key = other_keys[i];
 
         if (key.$$is_string) {
-          other_value = other.smap[key];
+          other_value = other.$$smap[key];
         } else {
           other_value = key.value;
           key = key.key;
@@ -804,11 +804,11 @@ class Hash
     %x{
       var hash = Opal.hash();
 
-      for (var i = 0, keys = self.keys, length = keys.length, key, value, obj; i < length; i++) {
+      for (var i = 0, keys = self.$$keys, length = keys.length, key, value, obj; i < length; i++) {
         key = keys[i];
 
         if (key.$$is_string) {
-          value = self.smap[key];
+          value = self.$$smap[key];
         } else {
           value = key.value;
           key = key.key;
@@ -835,11 +835,11 @@ class Hash
     %x{
       var result = nil;
 
-      for (var i = 0, keys = self.keys, length = keys.length, key, value, obj; i < length; i++) {
+      for (var i = 0, keys = self.$$keys, length = keys.length, key, value, obj; i < length; i++) {
         key = keys[i];
 
         if (key.$$is_string) {
-          value = self.smap[key];
+          value = self.$$smap[key];
         } else {
           value = key.value;
           key = key.key;
@@ -866,7 +866,7 @@ class Hash
 
   def shift
     %x{
-      var keys = self.keys,
+      var keys = self.$$keys,
           key;
 
       if (keys.length > 0) {
@@ -889,11 +889,11 @@ class Hash
     %x{
       var result = [];
 
-      for (var i = 0, keys = self.keys, length = keys.length, key, value; i < length; i++) {
+      for (var i = 0, keys = self.$$keys, length = keys.length, key, value; i < length; i++) {
         key = keys[i];
 
         if (key.$$is_string) {
-          value = self.smap[key];
+          value = self.$$smap[key];
         } else {
           value = key.value;
           key = key.key;
@@ -937,11 +937,11 @@ class Hash
     %x{
       var result = [];
 
-      for (var i = 0, keys = self.keys, length = keys.length, key; i < length; i++) {
+      for (var i = 0, keys = self.$$keys, length = keys.length, key; i < length; i++) {
         key = keys[i];
 
         if (key.$$is_string) {
-          result.push(self.smap[key]);
+          result.push(self.$$smap[key]);
         } else {
           result.push(key.value);
         }

--- a/opal/corelib/helpers.rb
+++ b/opal/corelib/helpers.rb
@@ -112,5 +112,5 @@ module Opal
     end
 
     name
-  end  
+  end
 end

--- a/opal/corelib/kernel.rb
+++ b/opal/corelib/kernel.rb
@@ -787,10 +787,8 @@ module Kernel
       var result = [];
 
       for (var name in self) {
-        if (name.charAt(0) !== '$') {
-          if (name !== '$$class' && name !== '$$id') {
-            result.push('@' + name);
-          }
+        if (self.hasOwnProperty(name) && name.charAt(0) !== '$') {
+          result.push('@' + name);
         }
       }
 

--- a/opal/corelib/nil.rb
+++ b/opal/corelib/nil.rb
@@ -71,6 +71,10 @@ class NilClass
   def to_r
     Rational(0, 1)
   end
+
+  def instance_variables
+    []
+  end
 end
 
 NIL = nil

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -1112,7 +1112,7 @@
     var keys      = [],
         map       = {},
         key       = null,
-        given_map = given_args.smap;
+        given_map = given_args.$$smap;
 
     for (key in given_map) {
       if (!used_args[key]) {
@@ -1359,20 +1359,20 @@
   };
 
   Opal.hash_init = function (hash) {
-    hash.map  = {};
-    hash.smap = {};
-    hash.keys = [];
+    hash.$$map  = {};
+    hash.$$smap = {};
+    hash.$$keys = [];
   };
 
   Opal.hash_clone = function (from_hash, to_hash) {
     to_hash.none = from_hash.none;
     to_hash.proc = from_hash.proc;
 
-    for (var i = 0, keys = from_hash.keys, length = keys.length, key, value; i < length; i++) {
-      key = from_hash.keys[i];
+    for (var i = 0, keys = from_hash.$$keys, length = keys.length, key, value; i < length; i++) {
+      key = from_hash.$$keys[i];
 
       if (key.$$is_string) {
-        value = from_hash.smap[key];
+        value = from_hash.$$smap[key];
       } else {
         value = key.value;
         key = key.key;
@@ -1384,23 +1384,23 @@
 
   Opal.hash_put = function (hash, key, value) {
     if (key.$$is_string) {
-      if (!hash.smap.hasOwnProperty(key)) {
-        hash.keys.push(key);
+      if (!hash.$$smap.hasOwnProperty(key)) {
+        hash.$$keys.push(key);
       }
-      hash.smap[key] = value;
+      hash.$$smap[key] = value;
       return;
     }
 
     var key_hash = key.$hash(), bucket, last_bucket;
 
-    if (!hash.map.hasOwnProperty(key_hash)) {
+    if (!hash.$$map.hasOwnProperty(key_hash)) {
       bucket = {key: key, key_hash: key_hash, value: value};
-      hash.keys.push(bucket);
-      hash.map[key_hash] = bucket;
+      hash.$$keys.push(bucket);
+      hash.$$map[key_hash] = bucket;
       return;
     }
 
-    bucket = hash.map[key_hash];
+    bucket = hash.$$map[key_hash];
 
     while (bucket) {
       if (key === bucket.key || key['$eql?'](bucket.key)) {
@@ -1414,23 +1414,23 @@
 
     if (last_bucket) {
       bucket = {key: key, key_hash: key_hash, value: value};
-      hash.keys.push(bucket);
+      hash.$$keys.push(bucket);
       last_bucket.next = bucket;
     }
   };
 
   Opal.hash_get = function (hash, key) {
     if (key.$$is_string) {
-      if (hash.smap.hasOwnProperty(key)) {
-        return hash.smap[key];
+      if (hash.$$smap.hasOwnProperty(key)) {
+        return hash.$$smap[key];
       }
       return;
     }
 
     var key_hash = key.$hash(), bucket;
 
-    if (hash.map.hasOwnProperty(key_hash)) {
-      bucket = hash.map[key_hash];
+    if (hash.$$map.hasOwnProperty(key_hash)) {
+      bucket = hash.$$map[key_hash];
 
       while (bucket) {
         if (key === bucket.key || key['$eql?'](bucket.key)) {
@@ -1442,10 +1442,10 @@
   };
 
   Opal.hash_delete = function (hash, key) {
-    var i, keys = hash.keys, length = keys.length, value;
+    var i, keys = hash.$$keys, length = keys.length, value;
 
     if (key.$$is_string) {
-      if (!hash.smap.hasOwnProperty(key)) {
+      if (!hash.$$smap.hasOwnProperty(key)) {
         return;
       }
 
@@ -1456,18 +1456,18 @@
         }
       }
 
-      value = hash.smap[key];
-      delete hash.smap[key];
+      value = hash.$$smap[key];
+      delete hash.$$smap[key];
       return value;
     }
 
     var key_hash = key.$hash();
 
-    if (!hash.map.hasOwnProperty(key_hash)) {
+    if (!hash.$$map.hasOwnProperty(key_hash)) {
       return;
     }
 
-    var bucket = hash.map[key_hash], last_bucket;
+    var bucket = hash.$$map[key_hash], last_bucket;
 
     while (bucket) {
       if (key === bucket.key || key['$eql?'](bucket.key)) {
@@ -1487,10 +1487,10 @@
           delete last_bucket.next;
         }
         else if (bucket.next) {
-          hash.map[key_hash] = bucket.next;
+          hash.$$map[key_hash] = bucket.next;
         }
         else {
-          delete hash.map[key_hash];
+          delete hash.$$map[key_hash];
         }
 
         return value;
@@ -1501,23 +1501,23 @@
   };
 
   Opal.hash_rehash = function (hash) {
-    for (var i = 0, length = hash.keys.length, key_hash, bucket, last_bucket; i < length; i++) {
+    for (var i = 0, length = hash.$$keys.length, key_hash, bucket, last_bucket; i < length; i++) {
 
-      if (hash.keys[i].$$is_string) {
+      if (hash.$$keys[i].$$is_string) {
         continue;
       }
 
-      key_hash = hash.keys[i].key.$hash();
+      key_hash = hash.$$keys[i].key.$hash();
 
-      if (key_hash === hash.keys[i].key_hash) {
+      if (key_hash === hash.$$keys[i].key_hash) {
         continue;
       }
 
-      bucket = hash.map[hash.keys[i].key_hash];
+      bucket = hash.$$map[hash.$$keys[i].key_hash];
       last_bucket = undefined;
 
       while (bucket) {
-        if (bucket === hash.keys[i]) {
+        if (bucket === hash.$$keys[i]) {
           if (last_bucket && bucket.next) {
             last_bucket.next = bucket.next;
           }
@@ -1525,10 +1525,10 @@
             delete last_bucket.next;
           }
           else if (bucket.next) {
-            hash.map[hash.keys[i].key_hash] = bucket.next;
+            hash.$$map[hash.$$keys[i].key_hash] = bucket.next;
           }
           else {
-            delete hash.map[hash.keys[i].key_hash];
+            delete hash.$$map[hash.$$keys[i].key_hash];
           }
           break;
         }
@@ -1536,18 +1536,18 @@
         bucket = bucket.next;
       }
 
-      hash.keys[i].key_hash = key_hash;
+      hash.$$keys[i].key_hash = key_hash;
 
-      if (!hash.map.hasOwnProperty(key_hash)) {
-        hash.map[key_hash] = hash.keys[i];
+      if (!hash.$$map.hasOwnProperty(key_hash)) {
+        hash.$$map[key_hash] = hash.$$keys[i];
         continue;
       }
 
-      bucket = hash.map[key_hash];
+      bucket = hash.$$map[key_hash];
       last_bucket = undefined;
 
       while (bucket) {
-        if (bucket === hash.keys[i]) {
+        if (bucket === hash.$$keys[i]) {
           last_bucket = undefined;
           break;
         }
@@ -1556,7 +1556,7 @@
       }
 
       if (last_bucket) {
-        last_bucket.next = hash.keys[i];
+        last_bucket.next = hash.$$keys[i];
       }
     }
   };
@@ -1625,9 +1625,9 @@
   Opal.hash2 = function(keys, smap) {
     var hash = new Opal.Hash.$$alloc();
 
-    hash.map  = {};
-    hash.keys = keys;
-    hash.smap = smap;
+    hash.$$map  = {};
+    hash.$$keys = keys;
+    hash.$$smap = smap;
 
     return hash;
   };

--- a/spec/filters/bugs/kernel.rb
+++ b/spec/filters/bugs/kernel.rb
@@ -41,9 +41,7 @@ opal_filter "Kernel" do
   fails "Kernel#inspect does not call #to_s if it is defined"
   fails "Kernel#inspect returns a tainted string if self is tainted"
   fails "Kernel#inspect returns an untrusted string if self is untrusted"
-  fails "Kernel#instance_variables immediate values returns the correct array if an instance variable is added"
-  fails "Kernel#instance_variables regular objects returns an empty array if no instance variables are defined"
-  fails "Kernel#instance_variables regular objects returns the correct array if an instance variable is added"
+  fails "Kernel#instance_variables immediate values returns the correct array if an instance variable is added" # depends on object freezing
   fails "Kernel#instance_variable_set on frozen objects keeps stored object after any exceptions"
   fails "Kernel#instance_variable_set on frozen objects raises a RuntimeError when passed replacement is different from stored object"
   fails "Kernel#instance_variable_set on frozen objects raises a RuntimeError when passed replacement is identical to stored object"

--- a/spec/opal/core/hash/internals_spec.rb
+++ b/spec/opal/core/hash/internals_spec.rb
@@ -6,41 +6,41 @@ describe 'Hash' do
     end
 
     it 'stores keys directly as strings in the `keys` array' do
-      `#@h.keys.length`.should == 2
-      `#@h.keys[0]`.should == 'a'
-      `#@h.keys[1]`.should == 'b'
+      `#@h.$$keys.length`.should == 2
+      `#@h.$$keys[0]`.should == 'a'
+      `#@h.$$keys[1]`.should == 'b'
 
       @h['c'] = 789
 
-      `#@h.keys.length`.should == 3
-      `#@h.keys[2]`.should == 'c'
+      `#@h.$$keys.length`.should == 3
+      `#@h.$$keys[2]`.should == 'c'
     end
 
     it 'stores values directly as objects in the `smap` object by their corresponding string key' do
-      `Object.keys(#@h.smap).length`.should == 2
-      `#@h.smap['a']`.should == 123
-      `#@h.smap['b']`.should == 456
+      `Object.keys(#@h.$$smap).length`.should == 2
+      `#@h.$$smap['a']`.should == 123
+      `#@h.$$smap['b']`.should == 456
 
       @h['c'] = 789
 
-      `Object.keys(#@h.smap).length`.should == 3
-      `#@h.smap['c']`.should == 789
+      `Object.keys(#@h.$$smap).length`.should == 3
+      `#@h.$$smap['c']`.should == 789
     end
 
     it 'does not use the `map` object' do
-      `Object.keys(#@h.map).length`.should == 0
+      `Object.keys(#@h.$$map).length`.should == 0
 
       @h['c'] = 789
 
-      `Object.keys(#@h.map).length`.should == 0
+      `Object.keys(#@h.$$map).length`.should == 0
     end
 
     it 'uses the `map` object when an object key is added' do
-      `Object.keys(#@h.map).length`.should == 0
+      `Object.keys(#@h.$$map).length`.should == 0
 
       @h[Object.new] = 789
 
-      `Object.keys(#@h.map).length`.should == 1
+      `Object.keys(#@h.$$map).length`.should == 1
     end
   end
 
@@ -52,7 +52,7 @@ describe 'Hash' do
     end
 
     it 'uses a data structure called "bucket", which is a wrapper object with `key`, `key_hash`, `value`, and `next` properties' do
-      bucket = `#@h.keys[0]`
+      bucket = `#@h.$$keys[0]`
       `#{bucket}.key`.should == @obj1
       `#{bucket}.key_hash`.should == @obj1.hash
       `#{bucket}.value`.should == 123
@@ -60,48 +60,48 @@ describe 'Hash' do
     end
 
     it 'stores keys in the `keys` array as "bucket" objects' do
-      `#@h.keys.length`.should == 2
-      `#@h.keys[0].key`.should == @obj1
-      `#@h.keys[1].key`.should == @obj2
+      `#@h.$$keys.length`.should == 2
+      `#@h.$$keys[0].key`.should == @obj1
+      `#@h.$$keys[1].key`.should == @obj2
 
       obj3 = Object.new
       @h[obj3] = 789
 
-      `#@h.keys.length`.should == 3
-      `#@h.keys[2].key`.should == obj3
+      `#@h.$$keys.length`.should == 3
+      `#@h.$$keys[2].key`.should == obj3
     end
 
     it 'stores values in the `map` object as "bucket" objects by #hash string of their corresponding object key' do
-      `Object.keys(#@h.map).length`.should == 2
-      `#@h.map[#{@obj1.hash}].value`.should == 123
-      `#@h.map[#{@obj2.hash}].value`.should == 456
+      `Object.keys(#@h.$$map).length`.should == 2
+      `#@h.$$map[#{@obj1.hash}].value`.should == 123
+      `#@h.$$map[#{@obj2.hash}].value`.should == 456
 
       obj3 = Object.new
       @h[obj3] = 789
 
-      `Object.keys(#@h.map).length`.should == 3
-      `#@h.map[#{obj3.hash}].value`.should == 789
+      `Object.keys(#@h.$$map).length`.should == 3
+      `#@h.$$map[#{obj3.hash}].value`.should == 789
     end
 
     it 'keeps a pointer to the same "bucket" object in the `keys` array and in the `map` object' do
-      `#@h.map[#{@obj1.hash}] === #@h.keys[0]`.should == true
-      `#@h.map[#{@obj2.hash}] === #@h.keys[1]`.should == true
+      `#@h.$$map[#{@obj1.hash}] === #@h.$$keys[0]`.should == true
+      `#@h.$$map[#{@obj2.hash}] === #@h.$$keys[1]`.should == true
     end
 
     it 'does not use the `smap` object' do
-      `Object.keys(#@h.smap).length`.should == 0
+      `Object.keys(#@h.$$smap).length`.should == 0
 
       @h[Object.new] = 789
 
-      `Object.keys(#@h.smap).length`.should == 0
+      `Object.keys(#@h.$$smap).length`.should == 0
     end
 
     it 'uses the `smap` object when a string key is added' do
-      `Object.keys(#@h.smap).length`.should == 0
+      `Object.keys(#@h.$$smap).length`.should == 0
 
       @h['c'] = 789
 
-      `Object.keys(#@h.smap).length`.should == 1
+      `Object.keys(#@h.$$smap).length`.should == 1
     end
 
     it 'allows multiple keys that #hash to the same value to be stored in the Hash' do
@@ -119,45 +119,45 @@ describe 'Hash' do
       @mock3.should_receive(:hash).at_least(1).and_return('hhh')
       @mock3.should_receive(:eql?).exactly(2).and_return(false)
 
-      `Object.keys(#@hash.map).length`.should == 0
-      `#@hash.keys.length`.should == 0
+      `Object.keys(#@hash.$$map).length`.should == 0
+      `#@hash.$$keys.length`.should == 0
 
       @hash[@mock1] = 123
-      `Object.keys(#@hash.map).length`.should == 1
-      `#@hash.keys.length`.should == 1
-      `#@hash.keys[0] === #@hash.map['hhh']`.should == true
-      `#@hash.keys[0].key`.should == @mock1
-      `#@hash.keys[0].key_hash`.should == @mock1.hash
-      `#@hash.keys[0].value`.should == 123
-      `#@hash.keys[0].next === undefined`.should == true
+      `Object.keys(#@hash.$$map).length`.should == 1
+      `#@hash.$$keys.length`.should == 1
+      `#@hash.$$keys[0] === #@hash.$$map['hhh']`.should == true
+      `#@hash.$$keys[0].key`.should == @mock1
+      `#@hash.$$keys[0].key_hash`.should == @mock1.hash
+      `#@hash.$$keys[0].value`.should == 123
+      `#@hash.$$keys[0].next === undefined`.should == true
 
       @hash[@mock2] = 456
-      `Object.keys(#@hash.map).length`.should == 1
-      `#@hash.keys.length`.should == 2
-      `#@hash.keys[1] === #@hash.map['hhh'].next`.should == true
-      `#@hash.keys[1].key`.should == @mock2
-      `#@hash.keys[1].key_hash`.should == @mock2.hash
-      `#@hash.keys[1].value`.should == 456
-      `#@hash.keys[1].next === undefined`.should == true
+      `Object.keys(#@hash.$$map).length`.should == 1
+      `#@hash.$$keys.length`.should == 2
+      `#@hash.$$keys[1] === #@hash.$$map['hhh'].next`.should == true
+      `#@hash.$$keys[1].key`.should == @mock2
+      `#@hash.$$keys[1].key_hash`.should == @mock2.hash
+      `#@hash.$$keys[1].value`.should == 456
+      `#@hash.$$keys[1].next === undefined`.should == true
 
       @hash[@mock3] = 789
-      `Object.keys(#@hash.map).length`.should == 1
-      `#@hash.keys.length`.should == 3
-      `#@hash.keys[2] === #@hash.map['hhh'].next.next`.should == true
-      `#@hash.keys[2].key`.should == @mock3
-      `#@hash.keys[2].key_hash`.should == @mock3.hash
-      `#@hash.keys[2].value`.should == 789
-      `#@hash.keys[2].next === undefined`.should == true
+      `Object.keys(#@hash.$$map).length`.should == 1
+      `#@hash.$$keys.length`.should == 3
+      `#@hash.$$keys[2] === #@hash.$$map['hhh'].next.next`.should == true
+      `#@hash.$$keys[2].key`.should == @mock3
+      `#@hash.$$keys[2].key_hash`.should == @mock3.hash
+      `#@hash.$$keys[2].value`.should == 789
+      `#@hash.$$keys[2].next === undefined`.should == true
 
       obj = Object.new
       @hash[obj] = 999
-      `Object.keys(#@hash.map).length`.should == 2
-      `#@hash.keys.length`.should == 4
-      `#@hash.keys[3] === #@hash.map[#{obj.hash}]`.should == true
-      `#@hash.keys[3].key`.should == obj
-      `#@hash.keys[3].key_hash`.should == obj.hash
-      `#@hash.keys[3].value`.should == 999
-      `#@hash.keys[3].next === undefined`.should == true
+      `Object.keys(#@hash.$$map).length`.should == 2
+      `#@hash.$$keys.length`.should == 4
+      `#@hash.$$keys[3] === #@hash.$$map[#{obj.hash}]`.should == true
+      `#@hash.$$keys[3].key`.should == obj
+      `#@hash.$$keys[3].key_hash`.should == obj.hash
+      `#@hash.$$keys[3].value`.should == 999
+      `#@hash.$$keys[3].next === undefined`.should == true
     end
 
     it 'correctly updates internal data structures when deleting keys' do
@@ -188,145 +188,145 @@ describe 'Hash' do
         @obj1  => 'xyz'
       }
 
-      `#@hash.map.hasOwnProperty('hhh')`.should == true
-      `#@hash.map.hasOwnProperty(#{@obj1.hash})`.should == true
-      `#@hash.smap.hasOwnProperty('a')`.should == true
-      `#@hash.smap.hasOwnProperty('b')`.should == true
-      `#@hash.smap.hasOwnProperty('c')`.should == true
+      `#@hash.$$map.hasOwnProperty('hhh')`.should == true
+      `#@hash.$$map.hasOwnProperty(#{@obj1.hash})`.should == true
+      `#@hash.$$smap.hasOwnProperty('a')`.should == true
+      `#@hash.$$smap.hasOwnProperty('b')`.should == true
+      `#@hash.$$smap.hasOwnProperty('c')`.should == true
 
-      `#@hash.keys.length`.should == 8
-      `Object.keys(#@hash.map).length`.should == 2
-      `Object.keys(#@hash.smap).length`.should == 3
+      `#@hash.$$keys.length`.should == 8
+      `Object.keys(#@hash.$$map).length`.should == 2
+      `Object.keys(#@hash.$$smap).length`.should == 3
 
-      `#@hash.keys[0].key`.should == @mock1
-      `#@hash.keys[1]`.should == 'a'
-      `#@hash.keys[2].key`.should == @mock2
-      `#@hash.keys[3]`.should == 'b'
-      `#@hash.keys[4].key`.should == @mock3
-      `#@hash.keys[5].key`.should == @mock4
-      `#@hash.keys[6]`.should == 'c'
-      `#@hash.keys[7].key`.should == @obj1
+      `#@hash.$$keys[0].key`.should == @mock1
+      `#@hash.$$keys[1]`.should == 'a'
+      `#@hash.$$keys[2].key`.should == @mock2
+      `#@hash.$$keys[3]`.should == 'b'
+      `#@hash.$$keys[4].key`.should == @mock3
+      `#@hash.$$keys[5].key`.should == @mock4
+      `#@hash.$$keys[6]`.should == 'c'
+      `#@hash.$$keys[7].key`.should == @obj1
 
-      `#@hash.map['hhh'] === #@hash.keys[0]`.should == true
-      `#@hash.keys[0].next === #@hash.keys[2]`.should == true
-      `#@hash.keys[2].next === #@hash.keys[4]`.should == true
-      `#@hash.keys[4].next === #@hash.keys[5]`.should == true
-      `#@hash.keys[5].next === undefined`.should == true
+      `#@hash.$$map['hhh'] === #@hash.$$keys[0]`.should == true
+      `#@hash.$$keys[0].next === #@hash.$$keys[2]`.should == true
+      `#@hash.$$keys[2].next === #@hash.$$keys[4]`.should == true
+      `#@hash.$$keys[4].next === #@hash.$$keys[5]`.should == true
+      `#@hash.$$keys[5].next === undefined`.should == true
 
       @hash.delete @mock2
 
-      `#@hash.keys.length`.should == 7
-      `Object.keys(#@hash.map).length`.should == 2
-      `Object.keys(#@hash.smap).length`.should == 3
+      `#@hash.$$keys.length`.should == 7
+      `Object.keys(#@hash.$$map).length`.should == 2
+      `Object.keys(#@hash.$$smap).length`.should == 3
 
-      `#@hash.keys[0].key`.should == @mock1
-      `#@hash.keys[1]`.should == 'a'
-      `#@hash.keys[2]`.should == 'b'
-      `#@hash.keys[3].key`.should == @mock3
-      `#@hash.keys[4].key`.should == @mock4
-      `#@hash.keys[5]`.should == 'c'
-      `#@hash.keys[6].key`.should == @obj1
+      `#@hash.$$keys[0].key`.should == @mock1
+      `#@hash.$$keys[1]`.should == 'a'
+      `#@hash.$$keys[2]`.should == 'b'
+      `#@hash.$$keys[3].key`.should == @mock3
+      `#@hash.$$keys[4].key`.should == @mock4
+      `#@hash.$$keys[5]`.should == 'c'
+      `#@hash.$$keys[6].key`.should == @obj1
 
-      `#@hash.map['hhh'] === #@hash.keys[0]`.should == true
-      `#@hash.keys[0].next === #@hash.keys[3]`.should == true
-      `#@hash.keys[3].next === #@hash.keys[4]`.should == true
-      `#@hash.keys[4].next === undefined`.should == true
+      `#@hash.$$map['hhh'] === #@hash.$$keys[0]`.should == true
+      `#@hash.$$keys[0].next === #@hash.$$keys[3]`.should == true
+      `#@hash.$$keys[3].next === #@hash.$$keys[4]`.should == true
+      `#@hash.$$keys[4].next === undefined`.should == true
 
       @hash.delete @mock4
 
-      `#@hash.keys.length`.should == 6
-      `Object.keys(#@hash.map).length`.should == 2
-      `Object.keys(#@hash.smap).length`.should == 3
+      `#@hash.$$keys.length`.should == 6
+      `Object.keys(#@hash.$$map).length`.should == 2
+      `Object.keys(#@hash.$$smap).length`.should == 3
 
-      `#@hash.keys[0].key`.should == @mock1
-      `#@hash.keys[1]`.should == 'a'
-      `#@hash.keys[2]`.should == 'b'
-      `#@hash.keys[3].key`.should == @mock3
-      `#@hash.keys[4]`.should == 'c'
-      `#@hash.keys[5].key`.should == @obj1
+      `#@hash.$$keys[0].key`.should == @mock1
+      `#@hash.$$keys[1]`.should == 'a'
+      `#@hash.$$keys[2]`.should == 'b'
+      `#@hash.$$keys[3].key`.should == @mock3
+      `#@hash.$$keys[4]`.should == 'c'
+      `#@hash.$$keys[5].key`.should == @obj1
 
-      `#@hash.map['hhh'] === #@hash.keys[0]`.should == true
-      `#@hash.keys[0].next === #@hash.keys[3]`.should == true
-      `#@hash.keys[3].next === undefined`.should == true
+      `#@hash.$$map['hhh'] === #@hash.$$keys[0]`.should == true
+      `#@hash.$$keys[0].next === #@hash.$$keys[3]`.should == true
+      `#@hash.$$keys[3].next === undefined`.should == true
 
       @hash.delete @mock1
 
-      `#@hash.keys.length`.should == 5
-      `Object.keys(#@hash.map).length`.should == 2
-      `Object.keys(#@hash.smap).length`.should == 3
+      `#@hash.$$keys.length`.should == 5
+      `Object.keys(#@hash.$$map).length`.should == 2
+      `Object.keys(#@hash.$$smap).length`.should == 3
 
-      `#@hash.keys[0]`.should == 'a'
-      `#@hash.keys[1]`.should == 'b'
-      `#@hash.keys[2].key`.should == @mock3
-      `#@hash.keys[3]`.should == 'c'
-      `#@hash.keys[4].key`.should == @obj1
+      `#@hash.$$keys[0]`.should == 'a'
+      `#@hash.$$keys[1]`.should == 'b'
+      `#@hash.$$keys[2].key`.should == @mock3
+      `#@hash.$$keys[3]`.should == 'c'
+      `#@hash.$$keys[4].key`.should == @obj1
 
-      `#@hash.map['hhh'] === #@hash.keys[2]`.should == true
-      `#@hash.keys[2].next === undefined`.should == true
+      `#@hash.$$map['hhh'] === #@hash.$$keys[2]`.should == true
+      `#@hash.$$keys[2].next === undefined`.should == true
 
       @hash.delete @mock3
 
-      `#@hash.keys.length`.should == 4
-      `Object.keys(#@hash.map).length`.should == 1
-      `Object.keys(#@hash.smap).length`.should == 3
+      `#@hash.$$keys.length`.should == 4
+      `Object.keys(#@hash.$$map).length`.should == 1
+      `Object.keys(#@hash.$$smap).length`.should == 3
 
-      `#@hash.keys[0]`.should == 'a'
-      `#@hash.keys[1]`.should == 'b'
-      `#@hash.keys[2]`.should == 'c'
-      `#@hash.keys[3].key`.should == @obj1
+      `#@hash.$$keys[0]`.should == 'a'
+      `#@hash.$$keys[1]`.should == 'b'
+      `#@hash.$$keys[2]`.should == 'c'
+      `#@hash.$$keys[3].key`.should == @obj1
 
-      `#@hash.map['hhh'] === undefined`.should == true
+      `#@hash.$$map['hhh'] === undefined`.should == true
 
       @hash.delete @obj1
 
-      `#@hash.keys.length`.should == 3
-      `Object.keys(#@hash.map).length`.should == 0
-      `Object.keys(#@hash.smap).length`.should == 3
+      `#@hash.$$keys.length`.should == 3
+      `Object.keys(#@hash.$$map).length`.should == 0
+      `Object.keys(#@hash.$$smap).length`.should == 3
 
-      `#@hash.keys[0]`.should == 'a'
-      `#@hash.keys[1]`.should == 'b'
-      `#@hash.keys[2]`.should == 'c'
+      `#@hash.$$keys[0]`.should == 'a'
+      `#@hash.$$keys[1]`.should == 'b'
+      `#@hash.$$keys[2]`.should == 'c'
 
-      `#@hash.map[#{@obj1.hash}] === undefined`.should == true
+      `#@hash.$$map[#{@obj1.hash}] === undefined`.should == true
 
       @hash.delete 'b'
 
-      `#@hash.keys.length`.should == 2
-      `Object.keys(#@hash.map).length`.should == 0
-      `Object.keys(#@hash.smap).length`.should == 2
+      `#@hash.$$keys.length`.should == 2
+      `Object.keys(#@hash.$$map).length`.should == 0
+      `Object.keys(#@hash.$$smap).length`.should == 2
 
-      `#@hash.keys[0]`.should == 'a'
-      `#@hash.keys[1]`.should == 'c'
-      `#@hash.smap['a']`.should == 'abc'
-      `#@hash.smap['b'] === undefined`.should == true
-      `#@hash.smap['c']`.should == 'ghi'
+      `#@hash.$$keys[0]`.should == 'a'
+      `#@hash.$$keys[1]`.should == 'c'
+      `#@hash.$$smap['a']`.should == 'abc'
+      `#@hash.$$smap['b'] === undefined`.should == true
+      `#@hash.$$smap['c']`.should == 'ghi'
 
       @hash.delete 'c'
 
-      `#@hash.keys.length`.should == 1
-      `Object.keys(#@hash.map).length`.should == 0
-      `Object.keys(#@hash.smap).length`.should == 1
+      `#@hash.$$keys.length`.should == 1
+      `Object.keys(#@hash.$$map).length`.should == 0
+      `Object.keys(#@hash.$$smap).length`.should == 1
 
-      `#@hash.keys[0]`.should == 'a'
-      `#@hash.smap['a']`.should == 'abc'
-      `#@hash.smap['b'] === undefined`.should == true
-      `#@hash.smap['c'] === undefined`.should == true
+      `#@hash.$$keys[0]`.should == 'a'
+      `#@hash.$$smap['a']`.should == 'abc'
+      `#@hash.$$smap['b'] === undefined`.should == true
+      `#@hash.$$smap['c'] === undefined`.should == true
 
       @hash.delete 'a'
 
-      `#@hash.keys.length`.should == 0
-      `Object.keys(#@hash.map).length`.should == 0
-      `Object.keys(#@hash.smap).length`.should == 0
+      `#@hash.$$keys.length`.should == 0
+      `Object.keys(#@hash.$$map).length`.should == 0
+      `Object.keys(#@hash.$$smap).length`.should == 0
 
-      `#@hash.smap['a'] === undefined`.should == true
-      `#@hash.smap['b'] === undefined`.should == true
-      `#@hash.smap['c'] === undefined`.should == true
+      `#@hash.$$smap['a'] === undefined`.should == true
+      `#@hash.$$smap['b'] === undefined`.should == true
+      `#@hash.$$smap['c'] === undefined`.should == true
 
-      `#@hash.map.hasOwnProperty('hhh')`.should == false
-      `#@hash.map.hasOwnProperty(#{@obj1.hash})`.should == false
-      `#@hash.smap.hasOwnProperty('a')`.should == false
-      `#@hash.smap.hasOwnProperty('b')`.should == false
-      `#@hash.smap.hasOwnProperty('c')`.should == false
+      `#@hash.$$map.hasOwnProperty('hhh')`.should == false
+      `#@hash.$$map.hasOwnProperty(#{@obj1.hash})`.should == false
+      `#@hash.$$smap.hasOwnProperty('a')`.should == false
+      `#@hash.$$smap.hasOwnProperty('b')`.should == false
+      `#@hash.$$smap.hasOwnProperty('c')`.should == false
     end
   end
 end

--- a/spec/opal/core/kernel/instance_variables_spec.rb
+++ b/spec/opal/core/kernel/instance_variables_spec.rb
@@ -1,0 +1,25 @@
+describe "Kernel#instance_variables" do
+  context 'for nil' do
+    it 'returns blank array' do
+      expect(nil.instance_variables).to eq([])
+    end
+  end
+
+  context 'for string' do
+    it 'returns blank array' do
+      expect(''.instance_variables).to eq([])
+    end
+  end
+
+  context 'for hash' do
+    it 'returns blank array' do
+      expect({}.instance_variables).to eq([])
+    end
+  end
+
+  context 'for object' do
+    it 'returns blank array' do
+      expect(Object.new.instance_variables).to eq([])
+    end
+  end
+end

--- a/stdlib/json.rb
+++ b/stdlib/json.rb
@@ -83,7 +83,7 @@ module JSON
     options[:object_class] ||= Hash
     options[:array_class]  ||= Array
 
-    `to_opal(js_object, options.smap)`
+    `to_opal(js_object, options.$$smap)`
   end
 
   def self.generate(obj, options = {})
@@ -143,11 +143,11 @@ class Hash
     %x{
       var result = [];
 
-      for (var i = 0, keys = self.keys, length = keys.length, key, value; i < length; i++) {
+      for (var i = 0, keys = self.$$keys, length = keys.length, key, value; i < length; i++) {
         key = keys[i];
 
         if (key.$$is_string) {
-          value = self.smap[key];
+          value = self.$$smap[key];
         } else {
           value = key.value;
           key = key.key;

--- a/stdlib/native.rb
+++ b/stdlib/native.rb
@@ -524,8 +524,8 @@ class Hash
   def initialize(defaults = undefined, &block)
     %x{
       if (defaults !== undefined && defaults.constructor === Object) {
-        var smap = self.smap,
-            keys = self.keys,
+        var smap = self.$$smap,
+            keys = self.$$keys,
             key, value;
 
         for (key in defaults) {
@@ -561,8 +561,8 @@ class Hash
   def to_n
     %x{
       var result = {},
-          keys = self.keys,
-          smap = self.smap,
+          keys = self.$$keys,
+          smap = self.$$smap,
           key, value;
 
       for (var i = 0, length = keys.length; i < length; i++) {


### PR DESCRIPTION
Before:
``` ruby
>> nil.instance_variables
=> ["@apply", "@call", "@constructor", "@toString"]
>> {}.instance_variables
=> ["@map", "@keys", "@smap", "@constructor", "@none", "@proc", "@toString"]
>> Class.new.instance_variables
=> ["@constructor", "@toString"]
>> Module.new.instance_variables
=> ["@constructor", "@toString"]
```
After:
``` ruby
>> nil.instance_variables
=> []
>> {}.instance_variables
=> []
>> Class.new.instance_variables
=> []
>> Module.new.instance_variables
=> []
```