### PR TITLE
Basic implementation of Marshal.load and Marshal.dump.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ Whitespace conventions:
 - Fixed an issue with `"-"` inside the second arg of `String#tr`
 - Fixed Base64 and enabled specs
 - Fixed method definition in method body.
+- Partially implemented `Marshal.load`/`Marshal.dump`. In order to use it require `opal/full`.
 
 
 ### Removed

--- a/opal/corelib/array.rb
+++ b/opal/corelib/array.rb
@@ -2227,4 +2227,8 @@ class Array < `Array`
       }
     }
   end
+
+  def instance_variables
+    super.reject { |ivar| `/^@\d+$/.test(#{ivar})` || ivar == '@length' }
+  end
 end

--- a/opal/corelib/hash.rb
+++ b/opal/corelib/hash.rb
@@ -175,7 +175,7 @@ class Hash
   end
 
   def default(key = undefined)
-     %x{
+    %x{
       if (key !== undefined && self.$$proc !== nil && self.$$proc !== undefined) {
         return self.$$proc.$call(self, key);
       }
@@ -196,12 +196,12 @@ class Hash
   end
 
   def default_proc
-     %x{
-       if (self.$$proc !== undefined) {
-         return self.$$proc;
-       }
-       return nil;
-     }
+    %x{
+      if (self.$$proc !== undefined) {
+        return self.$$proc;
+      }
+      return nil;
+    }
   end
 
   def default_proc=(proc)

--- a/opal/corelib/marshal.rb
+++ b/opal/corelib/marshal.rb
@@ -1,0 +1,31 @@
+require 'corelib/marshal/read_buffer'
+require 'corelib/marshal/write_buffer'
+
+module Marshal
+  MAJOR_VERSION = 4
+  MINOR_VERSION = 8
+
+  # For simulating binary strings
+  #
+  class BinaryString < String
+    def encoding
+      Encoding::BINARY
+    end
+
+    def +(other)
+      BinaryString.new(super)
+    end
+  end
+
+  class << self
+  def dump(object)
+      WriteBuffer.new(object).write
+    end
+
+    def load(marshaled)
+      ReadBuffer.new(marshaled).read
+    end
+
+    alias restore load
+  end
+end

--- a/opal/corelib/marshal/read_buffer.rb
+++ b/opal/corelib/marshal/read_buffer.rb
@@ -1,0 +1,427 @@
+module Marshal
+  class ReadBuffer
+    %x{
+      function stringToBytes(string) {
+        var i,
+            singleByte,
+            l = string.length,
+            result = [];
+
+        for (i = 0; i < l; i++) {
+          singleByte = string.charCodeAt(i);
+          result.push(singleByte);
+        }
+        return result;
+      }
+    }
+
+    attr_reader :version, :buffer, :index, :user_class, :extended, :object_cache, :symbols_cache
+
+    def initialize(input)
+      @buffer = `stringToBytes(#{input.to_s})`
+      @index = 0
+      major = read_byte
+      minor = read_byte
+      if major != MAJOR_VERSION || minor != MINOR_VERSION
+        raise TypeError, "incompatible marshal file format (can't be read)"
+      end
+      @version = "#{major}.#{minor}"
+      @object_cache = []
+      @symbols_cache = []
+      @extended = []
+      @ivars = []
+    end
+
+    def length
+      @buffer.length
+    end
+
+    def read(cache: true, ivar_index: nil)
+      code = read_char
+      # The first character indicates the type of the object
+      result = case code
+      when '0'
+        nil
+      when 'T'
+        true
+      when 'F'
+        false
+      when 'i'
+        read_fixnum
+      when 'e'
+        read_extended
+        object = read
+        apply_extends(object)
+        object
+      when 'C'
+        read_user_class
+        read
+      when 'o'
+        read_object
+      when 'd'
+        raise NotImplementedError, 'Data type cannot be demarshaled'
+      when 'u'
+        raise NotImplementedError, 'UserDef type cannot be demarshaled yet' # read_userdef
+      when 'U'
+        read_usrmarshal
+      when 'f'
+        read_float
+      when 'l'
+        read_bignum
+      when '"'
+        read_string(cache: cache)
+      when '/'
+        read_regexp
+      when '['
+        read_array
+      when '{'
+        read_hash
+      when '}'
+        raise NotImplementedError, 'Hashdef type cannot be demarshaled yet' # read_hashdef
+      when 'S'
+        read_struct
+      when 'M'
+        raise NotImplementedError, 'ModuleOld type cannot be demarshaled yet' # read_module_old
+      when 'c'
+        read_class
+      when 'm'
+        read_module
+      when ':'
+        read_symbol
+      when ';'
+        symbols_cache[read_fixnum]
+      when 'I'
+        ivar_index = @ivars.length
+        @ivars << true
+        object = read(cache: cache, ivar_index: ivar_index)
+        set_ivars(object) if @ivars.pop
+        object
+      when '@'
+        object_cache[read_fixnum]
+      else
+        raise ArgumentError, "dump format error"
+      end
+      result
+    end
+
+    def read_byte
+      if @index >= length
+        raise ArgumentError, "marshal data too short"
+      end
+      result = @buffer[@index]
+      @index += 1
+      result
+    end
+
+    def read_char
+      `String.fromCharCode(#{read_byte})`
+    end
+
+    def set_ivars(obj)
+      data = read_hash(cache: false)
+
+      data.each do |ivar, value|
+        case ivar
+        when :E then # encodings are not supported
+        when :encoding # encodings are not supported
+        else
+          if ivar.start_with?('@')
+            obj.instance_variable_set(ivar, value)
+          end
+        end
+      end
+
+      if obj.respond_to?(:marshal_load)
+        obj.marshal_load(data)
+      end
+    end
+
+    # Reads and returns a fixnum from an input stream
+    #
+    def read_fixnum
+      %x{
+        var x, i, c = (#{read_byte} ^ 128) - 128;
+        if (c === 0) {
+          return 0;
+        }
+
+        if (c > 0) {
+          if (4 < c && c < 128) {
+            return c - 5;
+          }
+          x = 0;
+          for (i = 0; i < c; i++) {
+            x |= (#{read_byte} << (8*i));
+          }
+        } else {
+          if (-129 < c && c < -4) {
+            return c + 5;
+          }
+
+          c = -c;
+          x = -1;
+
+          for (i = 0; i < c; i++) {
+            x &= ~(0xff << (8*i));
+            x |= (#{read_byte} << (8*i));
+          }
+        }
+
+        return x;
+      }
+    end
+
+    # Reads and returns a string from an input stream
+    # Sometimes string shouldn't be cached using
+    # an internal object cache, for a:
+    #  + class/module name
+    #  + float
+    #  + regexp
+    #
+    def read_string(cache: true)
+      length = read_fixnum
+      %x{
+        var i, result = '';
+
+        for (i = 0; i < length; i++) {
+          result += #{read_char};
+        }
+
+        if (cache) {
+          self.object_cache.push(result);
+        }
+
+        return result;
+      }
+    end
+
+    # Reads and returns a symbol from an input stream
+    #
+    def read_symbol
+      length = read_fixnum
+      %x{
+        var i, result = '';
+
+        for (i = 0; i < length; i++) {
+          result += #{read_char};
+        }
+
+        self.symbols_cache.push(result);
+
+        return result;
+      }
+    end
+
+    # Reads and returns an array from an input stream
+    #
+    def read_array
+      result = []
+      @object_cache << result
+      length = read_fixnum
+      %x{
+        if (length > 0) {
+
+          while (result.length < length) {
+            result.push(#{read});
+          }
+        }
+
+        return result;
+      }
+    end
+
+    # Reads and returns a hash from an input stream
+    # Sometimes hash shouldn't  be cached using
+    # an internal object cache, for a:
+    #  + hash of instance variables
+    #  + hash of struct attributes
+    #
+    def read_hash(cache: true)
+      result = {}
+
+      if cache
+        @object_cache << result
+      end
+
+      length = read_fixnum
+      %x{
+        if (length > 0) {
+          var key, value, i;
+          for (i = 0; i < #{length}; i++) {
+            key = #{read};
+            value = #{read};
+            #{result[`key`] = `value`};
+          }
+        }
+        return result;
+      }
+    end
+
+    # Returns a constant by passed const_name,
+    #  re-raises Marshal-specific error when it's missing
+    #
+    def safe_const_get(const_name)
+      begin
+        Object.const_get(const_name)
+      rescue NameError
+        raise ArgumentError, "undefined class/module #{const_name}"
+      end
+    end
+
+    # Reads and saves a user class from an input stream
+    #  Used for cases like String/Array subclasses
+    #
+    def read_user_class
+      @user_class = read(cache: false)
+    end
+
+    # Constantizes and resets saved user class
+    #
+    def get_user_class
+      klass = safe_const_get(@user_class)
+      @user_class = nil
+      klass
+    end
+
+    # Reads and returns a Class from an input stream
+    #
+    def read_class
+      klass_name = read_string(cache: false)
+      result = safe_const_get(klass_name)
+      unless result.class == Class
+        raise ArgumentError, "#{klass_name} does not refer to a Class"
+      end
+      @object_cache << result
+      result
+    end
+
+    # Reads and returns a Module from an input stream
+    #
+    def read_module
+      mod_name = read_string(cache: false)
+      result = safe_const_get(mod_name)
+      unless result.class == Module
+        raise ArgumentError, "#{mod_name} does not refer to a Module"
+      end
+      @object_cache << result
+      result
+    end
+
+    # Reads and returns an abstract object from an input stream
+    #
+    def read_object
+      klass_name = read(cache: false)
+      klass = safe_const_get(klass_name)
+      result = if @ivars.last
+        data = read_hash(cache: false)
+        load_object(klass, data)
+      else
+        object = klass.allocate
+        set_ivars(object)
+        object
+      end
+      @object_cache << result
+      result
+    end
+
+    # Loads an instance of passed klass using
+    #  default marshal hooks
+    #
+    def load_object(klass, args)
+      return klass._load(args) if klass.respond_to?(:_load)
+      instance = klass.allocate
+      instance.marshal_load(args) if instance.respond_to?(:marshal_load)
+      instance
+    end
+
+    # Reads and returns a Struct from an input stream
+    #
+    def read_struct
+      klass_name = read(cache: false)
+      klass = safe_const_get(klass_name)
+      args = read_hash(cache: false)
+      result = load_object(klass, args)
+      @object_cache << result
+      result
+    end
+
+    # Reads and saves a Module from an input stream
+    #  that was extending marshalled object
+    #
+    def read_extended
+      @extended << read
+    end
+
+    # Applies all saved extending modules
+    #  on the passed object
+    #
+    def apply_extends(object)
+      @extended.each do |e|
+        mod = safe_const_get(e)
+        object.extend(mod)
+      end
+      @extended = []
+    end
+
+    # Reads and returns Bignum from an input stream
+    #
+    def read_bignum
+      sign = read_char == '-' ? -1 : 1
+      size = read_fixnum * 2
+      result = 0
+      (0...size).each do |exp|
+        result += (read_char.ord) * 2 ** (exp * 8)
+      end
+      result = result.to_i * sign
+      @object_cache << result
+      result
+    end
+
+    # Reads and returns Float from an input stream
+    #
+    def read_float
+      s = read_string(cache: false)
+      result = if s == "nan"
+        0.0 / 0
+      elsif s == "inf"
+        1.0 / 0
+      elsif s == "-inf"
+        -1.0 / 0
+      else
+        s.to_f
+      end
+      @object_cache << result
+      result
+    end
+
+    # Reads and returns Regexp from an input stream
+    #
+    def read_regexp
+      args = [read_string(cache: false), read_byte]
+
+      result = if @user_class
+        load_object(get_user_class, args)
+      else
+        load_object(Regexp, args)
+      end
+      @object_cache << result
+      result
+    end
+
+    # Reads and returns an abstract object from an input stream
+    #  when the class of this object has custom marshalling rules
+    #
+    def read_usrmarshal
+      klass_name = read
+      klass = safe_const_get(klass_name)
+      result = klass.allocate
+      @object_cache << result
+      data = read
+      unless result.respond_to?(:marshal_load)
+        raise TypeError, "instance of #{klass} needs to have method `marshal_load'"
+      end
+      result.marshal_load(data)
+      result
+    end
+  end
+end

--- a/opal/corelib/marshal/write_buffer.rb
+++ b/opal/corelib/marshal/write_buffer.rb
@@ -1,0 +1,383 @@
+class NilClass
+  def __marshal__(buffer)
+    buffer.append('0')
+  end
+end
+
+class Boolean
+  def __marshal__(buffer)
+    if `self`
+      buffer.append('T')
+    else
+      buffer.append('F')
+    end
+  end
+end
+
+class Fixnum
+  def __marshal__(buffer)
+    buffer.append('i')
+    buffer.write_fixnum(self)
+  end
+end
+
+class Float
+  def __marshal__(buffer)
+    buffer.save_link(self)
+    buffer.append('f')
+    buffer.write_float(self)
+  end
+end
+
+class String
+  def __marshal__(buffer)
+    buffer.save_link(self)
+    buffer.write_ivars_prefix(self)
+    buffer.write_extends(self)
+    buffer.write_user_class(String, self)
+    buffer.append('"')
+    buffer.write_string(self)
+  end
+end
+
+class Array
+  def __marshal__(buffer)
+    buffer.save_link(self)
+    buffer.write_ivars_prefix(self)
+    buffer.write_extends(self)
+    buffer.write_user_class(Array, self)
+    buffer.append('[')
+    buffer.write_array(self)
+    buffer.write_ivars_suffix(self)
+  end
+end
+
+class Hash
+  def __marshal__(buffer)
+    if default_proc
+      raise TypeError, "can't dump hash with default proc"
+    end
+
+    buffer.save_link(self)
+    buffer.write_ivars_prefix(self)
+    buffer.write_extends(self)
+    buffer.write_user_class(Hash, self)
+    if default
+      buffer.append('}')
+      buffer.write_hash(self)
+      buffer.write(default)
+    else
+      buffer.append('{')
+      buffer.write_hash(self)
+    end
+    buffer.write_ivars_suffix(self)
+  end
+end
+
+class Regexp
+  def __marshal__(buffer)
+    buffer.save_link(self)
+    buffer.write_ivars_prefix(self)
+    buffer.write_extends(self)
+    buffer.write_user_class(Regexp, self)
+    buffer.append('/')
+    buffer.write_regexp(self)
+    buffer.write_ivars_suffix(self)
+  end
+end
+
+class Proc
+  def __marshal__(buffer)
+    raise TypeError, "no _dump_data is defined for class #{self.class}"
+  end
+end
+
+class Method
+  def __marshal__(buffer)
+    raise TypeError, "no _dump_data is defined for class #{self.class}"
+  end
+end
+
+class MatchData
+  def __marshal__(buffer)
+    raise TypeError, "no _dump_data is defined for class #{self.class}"
+  end
+end
+
+class Module
+  def __marshal__(buffer)
+    unless name
+      raise TypeError, "can't dump anonymous module"
+    end
+
+    buffer.save_link(self)
+    buffer.append("m")
+    buffer.write_module(self)
+  end
+end
+
+class Class
+  def __marshal__(buffer)
+    unless name
+      raise TypeError, "can't dump anonymous class"
+    end
+
+    if singleton_class?
+      raise TypeError, "singleton class can't be dumped"
+    end
+
+    buffer.save_link(self)
+    buffer.append("c")
+    buffer.write_class(self)
+  end
+end
+
+class BasicObject
+  def __marshal__(buffer)
+    buffer.save_link(self)
+    buffer.write_extends(self)
+    buffer.append("o")
+    buffer.write_object(self)
+  end
+end
+
+class Range
+  def __marshal__(buffer)
+    buffer.save_link(self)
+    buffer.write_extends(self)
+    buffer.append("o")
+    buffer.append_symbol(self.class.name)
+    buffer.write_fixnum(3)
+    buffer.append_symbol('excl')
+    buffer.write(exclude_end?)
+    buffer.append_symbol('begin')
+    buffer.write(self.begin)
+    buffer.append_symbol('end')
+    buffer.write(self.end)
+  end
+end
+
+class Struct
+  def __marshal__(buffer)
+    buffer.save_link(self)
+    buffer.write_ivars_prefix(self)
+    buffer.write_extends(self)
+    buffer.append('S')
+    buffer.append_symbol(self.class.name)
+    buffer.write_fixnum(self.length)
+    each_pair do |attr_name, value|
+      buffer.append_symbol(attr_name)
+      buffer.write(value)
+    end
+    buffer.write_ivars_suffix(self)
+  end
+end
+
+module Marshal
+  class WriteBuffer
+    attr_reader :buffer
+
+    def initialize(object)
+      @object = object
+      @buffer = BinaryString.new
+      @cache = []
+      @extends = Hash.new { |h, k| h[k] = [] }
+      append(version)
+    end
+
+    def write(object = @object)
+      if idx = @cache.index(object.object_id)
+        write_object_link(idx)
+      elsif object.respond_to?(:marshal_dump)
+        write_usr_marshal(object)
+      elsif object.respond_to?(:_dump)
+        write_userdef(object)
+      else
+        case object
+        when nil, true, false, Proc, Method, MatchData, Range, Struct, Array, Class, Module, Hash, Regexp
+          object.__marshal__(self)
+        when Integer
+          Fixnum.instance_method(:__marshal__).bind(object).call(self)
+        when Float
+          Float.instance_method(:__marshal__).bind(object).call(self)
+        when String
+          String.instance_method(:__marshal__).bind(object).call(self)
+        else
+          BasicObject.instance_method(:__marshal__).bind(object).call(self)
+        end
+      end
+
+      @buffer
+    end
+
+    def write_fixnum(n)
+      %x{
+        var s;
+
+        if (n == 0) {
+          s = String.fromCharCode(n);
+        } else if (n > 0 && n < 123) {
+          s = String.fromCharCode(n + 5);
+        } else if (n < 0 && n > -124) {
+          s = String.fromCharCode(256 + n - 5);
+        } else {
+          s = "";
+          var cnt = 0;
+          for (var i = 0; i < 4; i++) {
+            var b = n & 255;
+            s += String.fromCharCode(b);
+            n >>= 8
+            cnt += 1;
+            if (n === 0 || n === -1) {
+              break;
+            }
+          }
+          var l_byte;
+          if (n < 0) {
+            l_byte = 256 - cnt;
+          } else {
+            l_byte = cnt;
+          }
+          s = String.fromCharCode(l_byte) + s;
+        }
+        #{append(`s`)}
+      }
+    end
+
+    def write_string(s)
+      write_fixnum(s.length)
+      append(s)
+    end
+
+    def append_symbol(sym)
+      append(':')
+      write_fixnum(sym.length)
+      append(sym)
+    end
+
+    def write_array(a)
+      write_fixnum(a.length)
+      a.each do |item|
+        write(item)
+      end
+    end
+
+    def write_hash(h)
+      write_fixnum(h.length)
+      h.each do |key, value|
+        write(key)
+        write(value)
+      end
+    end
+
+    def write_object(obj)
+      append_symbol(obj.class.name)
+      write_ivars_suffix(obj, true)
+    end
+
+    def write_class(klass)
+      write_string(klass.name)
+    end
+
+    def write_module(mod)
+      write_string(mod.name)
+    end
+
+    def write_regexp(regexp)
+      write_string(regexp.to_s)
+      append(`String.fromCharCode(#{regexp.options})`)
+    end
+
+    def write_float(f)
+      if f.equal?(Float::INFINITY)
+        write_string('inf')
+      elsif f.equal?(-Float::INFINITY)
+        write_string('-inf')
+      elsif f.equal?(Float::NAN)
+        write_string('nan')
+      else
+        write_string(f.to_s)
+      end
+    end
+
+    def write_ivars_suffix(object, force = false)
+      if object.instance_variables.length == 0 && !force
+        return
+      end
+
+      write_fixnum(object.instance_variables.length)
+      object.instance_variables.each do |ivar_name|
+        append_symbol(ivar_name)
+        write(object.instance_variable_get(ivar_name))
+      end
+    end
+
+    def write_extends(object)
+      singleton_mods = object.singleton_class.ancestors.reject { |mod| mod.is_a?(Class) }
+      class_mods = object.class.ancestors.reject { |mod| mod.is_a?(Class) }
+      own_mods = singleton_mods - class_mods
+      if own_mods.length > 0
+        own_mods.each do |mod|
+          append('e')
+          append_symbol(mod.name)
+        end
+      end
+    end
+
+    def write_user_class(klass, object)
+      unless object.class.equal?(klass)
+        append('C')
+        append_symbol(object.class.name)
+      end
+    end
+
+    def write_object_link(idx)
+      append('@')
+      write_fixnum(idx)
+    end
+
+    def save_link(object)
+      @cache << object.object_id
+    end
+
+    def write_usr_marshal(object)
+      value = object.marshal_dump
+      klass = object.class
+      append('U')
+      namespace = `#{klass}.$$base_module`
+      if namespace.equal?(Object)
+        append_symbol(`#{klass}.$$name`)
+      else
+        append_symbol(namespace.name + '::' + `#{klass}.$$name`)
+      end
+      write(value)
+    end
+
+    def write_userdef(object)
+      value = object._dump(0)
+
+      unless value.is_a?(String)
+        raise TypeError, "_dump() must return string"
+      end
+
+      write_ivars_prefix(value)
+      append('u')
+      append_symbol(object.class.name)
+      write_string(value)
+    end
+
+    def write_ivars_prefix(object)
+      if object.instance_variables.length > 0
+        append('I')
+      end
+    end
+
+    def append(s)
+      @buffer += s
+    end
+
+    def version
+      `String.fromCharCode(#{MAJOR_VERSION}, #{MINOR_VERSION})`
+    end
+  end
+end

--- a/opal/corelib/module.rb
+++ b/opal/corelib/module.rb
@@ -608,4 +608,19 @@ class Module
 
     self
   end
+
+  def instance_variables
+    consts = constants
+    %x{
+      var result = [];
+
+      for (var name in self) {
+        if (self.hasOwnProperty(name) && name.charAt(0) !== '$' && name !== 'constructor' && !#{consts.include?(`name`)}) {
+          result.push('@' + name);
+        }
+      }
+
+      return result;
+    }
+  end
 end

--- a/opal/corelib/range.rb
+++ b/opal/corelib/range.rb
@@ -134,4 +134,10 @@ class Range
   end
 
   alias inspect to_s
+
+  def marshal_load(args)
+    @begin = args[:begin]
+    @end = args[:end]
+    @exclude = args[:excl]
+  end
 end

--- a/opal/corelib/regexp.rb
+++ b/opal/corelib/regexp.rb
@@ -202,6 +202,10 @@ class Regexp < `RegExp`
   end
 
   alias to_s source
+
+  def self._load(args)
+    self.new(*args)
+  end
 end
 
 class MatchData

--- a/opal/corelib/string.rb
+++ b/opal/corelib/string.rb
@@ -1684,6 +1684,14 @@ class String < `String`
       return null;
     }
   }
+
+  def instance_variables
+    []
+  end
+
+  def self._load(*args)
+    self.new(*args)
+  end
 end
 
 Symbol = String

--- a/opal/corelib/string/inheritance.rb
+++ b/opal/corelib/string/inheritance.rb
@@ -116,4 +116,8 @@ class String::Wrapper
   def %(data)
     @literal % data
   end
+
+  def instance_variables
+    super - ['@literal']
+  end
 end

--- a/opal/corelib/struct.rb
+++ b/opal/corelib/struct.rb
@@ -260,4 +260,9 @@ class Struct
       return result;
     }
   end
+
+  def self._load(args)
+    attributes = args.values_at(*members)
+    self.new(*attributes)
+  end
 end

--- a/opal/corelib/unsupported.rb
+++ b/opal/corelib/unsupported.rb
@@ -133,24 +133,6 @@ module Kernel
   end
 end
 
-module Marshal
-  `var ERROR = "Marshalling is not supported by Opal";`
-
-  module_function
-
-  def dump(*)
-    raise NotImplementedError, `ERROR`
-  end
-
-  def load(*)
-    raise NotImplementedError, `ERROR`
-  end
-
-  def restore(*)
-    raise NotImplementedError, `ERROR`
-  end
-end
-
 class Module
   def public(*methods)
     %x{

--- a/opal/opal.rb
+++ b/opal/opal.rb
@@ -13,6 +13,5 @@ require 'corelib/main'
 require 'corelib/dir'
 require 'corelib/file'
 require 'corelib/process'
-require 'corelib/marshal'
 
 require 'corelib/unsupported'

--- a/opal/opal.rb
+++ b/opal/opal.rb
@@ -13,5 +13,6 @@ require 'corelib/main'
 require 'corelib/dir'
 require 'corelib/file'
 require 'corelib/process'
+require 'corelib/marshal'
 
 require 'corelib/unsupported'

--- a/opal/opal/full.rb
+++ b/opal/opal/full.rb
@@ -1,0 +1,1 @@
+require 'corelib/marshal'

--- a/spec/filters/bugs/marshal.rb
+++ b/spec/filters/bugs/marshal.rb
@@ -1,0 +1,53 @@
+opal_filter "Marshal" do
+  # Marshal.load
+  fails "Marshal.load loads an array containing objects having _dump method, and with proc"
+  fails "Marshal.load loads an array containing objects having marshal_dump method, and with proc"
+  fails "Marshal.load assigns classes to nested subclasses of Array correctly"
+  fails "Marshal.load loads subclasses of Array with overridden << and push correctly"
+  fails "Marshal.load loads a _dump object"
+  fails "Marshal.load loads a _dump object extended"
+  fails "Marshal.load raises an ArgumentError with full constant name when the dumped constant is missing"
+  fails "Marshal.load when called with a proc returns the value of the proc"
+  fails "Marshal.load when called with a proc calls the proc for recursively visited data"
+  fails "Marshal.load when called with a proc loads an Array with proc"
+  fails "Marshal.load when called on objects with custom _dump methods does not set instance variables of an object with user-defined _dump/_load"
+  fails "Marshal.load when called on objects with custom _dump methods that return an immediate value loads an array containing an instance of the object, followed by multiple instances of another object"
+  fails "Marshal.load when called on objects with custom _dump methods that return an immediate value loads any structure with multiple references to the same object, followed by multiple instances of another object"
+  fails "Marshal.load when called on objects with custom _dump methods that return an immediate value loads an array containing references to multiple instances of the object, followed by multiple instances of another object"
+  fails "Marshal.load for an Array loads an extended Array object containing a user-marshaled object"
+  fails "Marshal.load for a String loads a String subclass with custom constructor"
+  fails "Marshal.load for a Struct loads a extended_struct having fields with same objects"
+  fails "Marshal.load for a Struct does not call initialize on the unmarshaled struct"
+  fails "Marshal.load for an Exception loads a marshalled exception with no message"
+  fails "Marshal.load for an Exception loads a marshalled exception with a message"
+  fails "Marshal.load for an Exception loads a marshalled exception with a backtrace"
+  fails "Marshal.load for a user Class raises ArgumentError if the object from an 'o' stream is not dumpable as 'o' type user class"
+  fails "Marshal.load for a user Class loads an object having ivar"
+  fails "Marshal.load for a user Class that extends a core type other than Object or BasicObject raises ArgumentError if the resulting class does not extend the same type"
+  fails "Marshal.load for a Regexp loads a extended_user_regexp having ivar"
+  fails "Marshal.load for a Hash loads an extended_user_hash with a parameter to initialize"
+  fails "Marshal.load for a Rational loads"
+  fails "Marshal.load for a Complex loads"
+  fails "Marshal.load for a Time loads"
+  fails "Marshal.load for a Time loads serialized instance variables"
+  fails "Marshal.load for a Time loads Time objects stored as links"
+  fails "Marshal.load for a Time loads nanoseconds"
+  fails "Marshal.load for a Module loads an old module"
+  fails "Marshal.load when a class does not exist in the namespace raises an ArgumentError" # an issue with constant resolving, e.g. String::Array
+
+  # Marshal.dump
+  fails "Marshal.dump dumps an object that has had an ivar added and removed as though the ivar never was set" # depends on Kernel#remove_instance_variable
+  fails "Marshal.dump with an Object dumps an Object that has had an instance variable added and removed as though it was never set" # depends on Kernel#remove_instance_variable
+  fails "Marshal.dump ignores the recursion limit if the limit is negative" # no support yet
+  fails "Marshal.dump with an object responding to #_dump dumps the object returned by #marshal_dump"
+  fails "Marshal.dump with a Time dumps the zone and the offset"
+  fails "Marshal.dump with a Time dumps the zone and the offset"
+  fails "Marshal.dump with a Regexp dumps a Regexp with instance variables" # //.source.should == ''
+  fails "Marshal.dump with a Regexp dumps a Regexp subclass" # requires Class.new(Regexp).new("").class != Regexp
+  fails "Marshal.dump with a Hash dumps an Hash subclass with a parameter to initialize"
+  fails "Marshal.dump with an Object dumps a BasicObject subclass if it defines respond_to?"
+  fails "Marshal.dump with a Time dumps the zone, but not the offset if zone is UTC"
+  fails "Marshal.dump with an Exception dumps an empty Exception"
+  fails "Marshal.dump with an Exception dumps the message for the exception"
+  fails "Marshal.dump with an Exception contains the filename in the backtrace"
+end

--- a/spec/filters/unsupported/bignum.rb
+++ b/spec/filters/unsupported/bignum.rb
@@ -44,4 +44,9 @@ opal_filter "Bignum" do
   fails "Rational#** when passed Bignum returns Rational(-1) when self is Rational(-1) and the exponent is positive and odd"
   fails "Rational#** when passed Bignum returns Rational(1) when self is Rational(-1) and the exponent is positive and even"
   fails "Rational#round with a precision > 0 doesn't fail when rounding to an absurdly large positive precision"
+  fails "Marshal.load loads a Bignum 2**90"
+  fails "Marshal.load for a Integer loads an Integer 2361183241434822606847"
+  fails "Marshal.load for a Integer loads an Integer -2361183241434822606847"
+  fails "Marshal.dump with a Bignum dumps a Bignum"
+  fails "Marshal.dump with a Bignum dumps a Bignum"
 end

--- a/spec/filters/unsupported/marshal.rb
+++ b/spec/filters/unsupported/marshal.rb
@@ -1,0 +1,46 @@
+opal_filter "Marshal" do
+  # Marshal.load
+  fails "Marshal.load loads a Random" # depends on the reading from the filesystem
+  fails "Marshal.load when source is tainted returns a tainted object"
+  fails "Marshal.load when source is tainted does not taint Symbols"
+  fails "Marshal.load when source is tainted does not taint Fixnums"
+  fails "Marshal.load when source is tainted does not taint Floats"
+  fails "Marshal.load when source is tainted does not taint Bignums"
+  fails "Marshal.load returns an untainted object if source is untainted"
+  fails "Marshal.load preserves taintedness of nested structure"
+  fails "Marshal.load returns a trusted object if source is trusted"
+  fails "Marshal.load returns an untrusted object if source is untrusted"
+  fails "Marshal.load for a String loads a string through StringIO stream"
+  fails "Marshal.load raises EOFError on loading an empty file"
+  fails "Marshal.load for a String loads a string with an ivar" # depends on string mutation
+  fails "Marshal.load for a String loads a string having ivar with ref to self" # depends on string mutation
+  fails "Marshal.load for a wrapped C pointer loads"
+  fails "Marshal.load for a wrapped C pointer raises TypeError when the local class is missing _load_data"
+  fails "Marshal.load for a wrapped C pointer raises ArgumentError when the local class is a regular object"
+  fails "Marshal.load for an Array loads an array having ivar" # for some reason depends on String#instance_variable_set which is not supported. replaced with test in spec/opal
+  fails "Marshal.load raises a TypeError with bad Marshal version" # depends on String#[]=
+  fails "Marshal.load for a Hash preserves hash ivars when hash contains a string having ivar" # depends on String#instance_variable_set
+
+  # Marshal.dump
+  fails "Marshal.dump returns a tainted string if object is tainted"
+  fails "Marshal.dump returns a tainted string if nested object is tainted"
+  fails "Marshal.dump returns a trusted string if object is trusted"
+  fails "Marshal.dump returns an untrusted string if object is untrusted"
+  fails "Marshal.dump returns an untrusted string if nested object is untrusted"
+  fails "Marshal.dump returns an untainted string if object is untainted"
+  fails "Marshal.dump when passed an IO writes the serialized data to the IO-Object"
+  fails "Marshal.dump when passed an IO returns the IO-Object"
+  fails "Marshal.dump when passed an IO raises an Error when the IO-Object does not respond to #write"
+  fails "Marshal.dump raises a TypeError if dumping a IO/File instance"
+  fails "Marshal.dump with a Regexp dumps a Regexp" # depends on utf-8 encoding which is not required, replaced with test in spec/opal
+  fails "Marshal.dump with a String dumps a String with instance variables"  # depends on string mutation
+  fails "Marshal.dump with a Float dumps a Float" # depends on the string mutating, replaced with test in spec/opal
+  fails "Marshal.dump with a Regexp dumps a Regexp with flags" # depends on string encoding, replaced with test in spec/opal
+  fails "Marshal.dump with a Regexp dumps an extended Regexp" # depends on string encoding, replaced with test in spec/opal
+  fails "Marshal.dump with a String dumps a String extended with a Module" # depends on string mutation
+  fails "Marshal.dump dumps subsequent appearances of a symbol as a link" # depends on Symbol-s
+  fails "Marshal.dump with an object responding to #marshal_dump dumps the object returned by #marshal_dump" # depends on Symbol-s, replaced with test in spec/opal
+  fails "Marshal.dump with a Regexp dumps a binary Regexp"
+  fails "Marshal.dump with a Regexp dumps a UTF-8 Regexp"
+  fails "Marshal.dump with a Regexp dumps a Regexp in another encoding"
+end

--- a/spec/filters/unsupported/symbol.rb
+++ b/spec/filters/unsupported/symbol.rb
@@ -11,4 +11,9 @@ opal_filter "Symbol" do
   fails "A Symbol literal can be created by the %s-delimited expression"
   fails "A Symbol literal can contain null in the string"
   fails "A Symbol literal can be an empty string"
+  fails "Marshal.dump with a Symbol dumps a Symbol"
+  fails "Marshal.dump with a Symbol dumps a big Symbol"
+  fails "Marshal.dump with a Symbol dumps an encoded Symbol"
+  fails "Marshal.dump with a Symbol dumps a binary encoded Symbol"
+  fails "Marshal.dump with an Array dumps a non-empty Array" # this particular spec dumps a Symbol, spec with String instead of Symbol is in spec/opal/
 end

--- a/spec/opal/core/kernel/instance_variables_spec.rb
+++ b/spec/opal/core/kernel/instance_variables_spec.rb
@@ -11,6 +11,12 @@ describe "Kernel#instance_variables" do
     end
   end
 
+  context 'for non-empty string' do
+    it 'returns blank array' do
+      expect('test'.instance_variables).to eq([])
+    end
+  end
+
   context 'for hash' do
     it 'returns blank array' do
       expect({}.instance_variables).to eq([])
@@ -28,6 +34,24 @@ describe "Kernel#instance_variables" do
         hash = Hash.new { 0 }
         expect(hash.instance_variables).to eq([])
       end
+    end
+  end
+
+  context 'for non-empty hash' do
+    it 'returns blank array' do
+      expect({ 1 => 2 }.instance_variables).to eq([])
+    end
+  end
+
+  context 'for array' do
+    it 'returns blank array' do
+      expect([].instance_variables).to eq([])
+    end
+  end
+
+  context 'for non-empty array' do
+    it 'returns blank array' do
+      expect((1..20).to_a.instance_variables).to eq([])
     end
   end
 
@@ -65,6 +89,22 @@ describe "Kernel#instance_variables" do
           expect(obj.instance_variables).to eq([ivar])
         end
       end
+    end
+  end
+
+  context 'for a class' do
+    it 'returns blank array' do
+      expect(Class.new.instance_variables).to eq([])
+    end
+  end
+
+  context 'for a class with nested constant' do
+    class ClassWithConstantWithoutIvar
+      A = 1
+    end
+
+    it 'returns blank array' do
+      expect(ClassWithConstantWithoutIvar.instance_variables).to eq([])
     end
   end
 end

--- a/spec/opal/core/marshal/dump_spec.rb
+++ b/spec/opal/core/marshal/dump_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+module MarshalExtension
+end
+
+class MarshalUserRegexp < Regexp
+end
+
+class UserMarshal
+  attr_reader :data
+
+  def initialize
+    @data = 'stuff'
+  end
+  def marshal_dump() 'data' end
+  def marshal_load(data) @data = data end
+  def ==(other) self.class === other and @data == other.data end
+end
+
+describe 'Marshal.dump' do
+  it 'dumps non-empty Array' do
+    expect(Marshal.dump(['a', 1, 2])).to eq("\u0004\b[\b\"\u0006ai\u0006i\a")
+  end
+
+  it 'dumps case-sensitive regexp' do
+    expect(Marshal.dump(/\w+/)).to eq("\u0004\b/\b\\w+\u0000")
+  end
+
+  it 'dumps case-insensitive regexp' do
+    expect(Marshal.dump(/\w+/i)).to eq("\u0004\b/\b\\w+\u0001")
+  end
+
+  it "dumps a Float" do
+    Marshal.dump(123.4567).should == "\004\bf\r123.4567"
+    Marshal.dump(-0.841).should == "\x04\bf\v-0.841"
+    Marshal.dump(9876.345).should == "\004\bf\r9876.345"
+    Marshal.dump(Float::INFINITY).should == "\004\bf\binf"
+    Marshal.dump(-Float::INFINITY).should == "\004\bf\t-inf"
+    Marshal.dump(Float::NAN).should == "\004\bf\bnan"
+  end
+
+  it "dumps a Regexp with flags" do
+    Marshal.dump(/\w/im).should == "\x04\b/\a\\w\u0005"
+  end
+
+  it 'dumps an extended Regexp' do
+    Marshal.dump(/\w/.extend(MarshalExtension)).should == "\x04\be:\u0015MarshalExtension/\a\\w\u0000"
+  end
+
+  it 'dumps object#marshal_dump when object responds to #marshal_dump' do
+    Marshal.dump(UserMarshal.new).should == "\u0004\bU:\u0010UserMarshal\"\tdata"
+  end
+end

--- a/spec/opal/core/marshal/load_spec.rb
+++ b/spec/opal/core/marshal/load_spec.rb
@@ -1,0 +1,7 @@
+describe "Marshal.load" do
+  it 'loads array with instance variable' do
+    a = Marshal.load("\x04\bI[\bi\x06i\ai\b\x06:\n@ivari\x01{")
+    a.should == [1, 2, 3]
+    a.instance_variable_get(:@ivar).should == 123
+  end
+end

--- a/spec/ruby_specs
+++ b/spec/ruby_specs
@@ -69,6 +69,11 @@ ruby/core/method
 
 ruby/core/module
 
+ruby/core/marshal/load_spec
+ruby/core/marshal/dump_spec
+ruby/core/marshal/major_version_spec
+ruby/core/marshal/minor_version_spec
+
 ruby/core/nil
 ruby/core/numeric
 

--- a/tasks/testing.rake
+++ b/tasks/testing.rake
@@ -85,6 +85,7 @@ module Testing
     File.write filename, <<-RUBY
       require 'spec_helper'
       require 'opal/platform'
+      require 'opal/full'
       OSpecRunner.main.will_start
       #{enter_benchmarking_mode}
       #{requires.join("\n    ")}
@@ -125,7 +126,7 @@ DESC
     mkdir_p File.dirname(filename)
     Testing.write_file filename, Testing.specs(ENV.to_hash.merge 'SUITE' => suite)
 
-    Testing.stubs.each {|s| ::Opal::Processor.stub_file s }
+    Testing.stubs.each {|s| ::Opal::Config.stubbed_files << s }
 
     Opal::Config.arity_check_enabled = true
     Opal::Config.freezing_stubs_enabled = true


### PR DESCRIPTION
Things that has been changed to make `Marshal` working:
+ `Array#instance_variables` doesn't return indexes
+ `Module#instance_variables` doesn't return constants
+ `String` subclasses do not return `@literal` in ivars list.

Limitations:
+ `Marshal.dump(:symbol)` - no Symbols support
+ String encoding - dumping/loading a string with custom encoding always dumps/loads utf-16 encoded string
+ Everything about String mutating - extended strings, ivars on strings and so on.
+ `Bignum`'s can't be encoded/decoded

218 examples from rubyspec are passing (`Marshal#restore` is an alias to `Marshal#load`, so probably even 300), ~50 are failing.