### PR TITLE
Ensure cloned objects do not copy ivars that are not returned by #instance_variables

### DIFF
--- a/opal/corelib/kernel.rb
+++ b/opal/corelib/kernel.rb
@@ -105,7 +105,7 @@ module Kernel
   def copy_instance_variables(other)
     %x{
       for (var name in other) {
-        if (name.charAt(0) !== '$') {
+        if (other.hasOwnProperty(name) && name.charAt(0) !== '$') {
           self[name] = other[name];
         }
       }

--- a/spec/opal/core/kernel/instance_variables_spec.rb
+++ b/spec/opal/core/kernel/instance_variables_spec.rb
@@ -22,6 +22,13 @@ describe "Kernel#instance_variables" do
       expect(Object.new.instance_variables).to eq([])
     end
   end
+  
+  context 'cloned object' do
+    it 'returns same vars as source object' do
+      object = Object.new
+      expect(object.clone.instance_variables).to eq(object.instance_variables)
+    end
+  end
 
   context 'for object with js keyword as instance variables' do
     reserved_keywords = %w(


### PR DESCRIPTION
Makes https://github.com/opal/opal/pull/1186 behavior consistent

Fixes https://github.com/opal/opal/issues/1200