### PR TITLE
Optimize aliasing methods

### DIFF
--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -1341,28 +1341,6 @@
     }
   };
 
-  // This black magic is required to avoid clashes of internal special fields,
-  // like $$donated.
-  function wrap(body) {
-    function alias() {
-      body.$$p = alias.$$p;
-      body.$$s = alias.$$s;
-
-      try {
-        return body.apply(this, $slice.call(arguments));
-      }
-      finally {
-        alias.$$s = null;
-        alias.$$p = null;
-      }
-    }
-
-    alias.$$target = body;
-    alias.$$arity  = body.length;
-
-    return alias;
-  }
-
   Opal.alias = function(obj, name, old) {
     var id     = '$' + name,
         old_id = '$' + old,
@@ -1386,7 +1364,7 @@
       }
     }
 
-    Opal.defn(obj, id, wrap(body));
+    Opal.defn(obj, id, body);
 
     return obj;
   };
@@ -1399,7 +1377,7 @@
       throw Opal.NameError.$new("undefined native method `" + native_name + "' for class `" + obj.$name() + "'")
     }
 
-    Opal.defn(obj, id, wrap(body));
+    Opal.defn(obj, id, body);
 
     return obj;
   };


### PR DESCRIPTION
I noticed a deoptimization in some of my profiling due to a `try` / `finally` block, which appears to come from [aliased methods](https://github.com/opal/opal/blob/2696a38c64e6b2e84a05e9ebc100bf6e3e651b3a/opal/corelib/runtime.js#L1351-L1358), which causes a deoptimization for that function. The profiler isn't mentioning the slice on `arguments`, probably because it stopped caring why the deoptimization occurred when it saw the try/finally.

This shows up a lot when using `Enumerable` seemingly because I use `map` instead of `collect` everywhere, including some of the hot spots [within Clearwater itself](https://github.com/clearwater-rb/clearwater/blob/master/opal/clearwater/component.rb#L177). But given how many methods on `Enumerable` alone are aliased and how frequently it may be used, this can have significant impact on an app. These deoptimized calls are 2-5% of the runtime in some of my Clearwater apps, for example.

I tried adjusting the function wrapping to happen within the `Opal.alias` call, but I couldn't get it to go cleanly due to `$$p` and `$$s`. Everything just worked when I just removed the wrapping function — my Clearwater apps still rendered and the Opal tests still passed — so it doesn't seem that it's necessary anymore. In addition to removing unneeded function calls, this removes the deoptimizations that occur due to the try/finally block inside the wrapped alias function.

Before I tried it, I thought surely this wasn't going to work. There has to be a reason this was here. Whatever that reason was, it doesn't seem to be necessary anymore. :-)