### PR TITLE
Optimize Kernel#hash

### DIFF
--- a/opal/corelib/kernel.rb
+++ b/opal/corelib/kernel.rb
@@ -749,7 +749,7 @@ module Kernel
   end
 
   def hash
-    "#{self.class}:#{self.class.__id__}:#{__id__}"
+    __id__
   end
 
   def initialize_copy(other)

--- a/opal/corelib/number.rb
+++ b/opal/corelib/number.rb
@@ -392,10 +392,6 @@ class Number < Numeric
     [gcd, lcm]
   end
 
-  def hash
-    `'Numeric:'+self.toString()`
-  end
-
   def integer?
     `self % 1 === 0`
   end


### PR DESCRIPTION
Using the class name and id aren't necessary in the hash function since the [Hash redux](https://github.com/opal/opal/pull/1035), which emulates MRI behavior with hash-function collisions.

Below is the change in performance in this PR. `Opal1` is current master. `Opal2` removes class metadata, but coerces `#hash` to a string. `Opal3` foregoes explicit string coercion because JS VMs coerce object property names to strings internally, which is faster. `Ruby1` is MRI 2.2.3p173.

```
Benchmark                                       Opal1   Opal2   Opal3  Ruby1
benchmark/bm_hash_assoc_object.rb               0.568   0.508   0.498  0.011
benchmark/bm_hash_assoc_string.rb               2.062   2.095   2.167  0.010
benchmark/bm_hash_clone_object.rb               2.208   2.151   1.647  0.659
benchmark/bm_hash_clone_string.rb               0.346   0.403   0.395  0.300
benchmark/bm_hash_delete_object.rb              0.083   0.061   0.053  0.014
benchmark/bm_hash_delete_string.rb              0.024   0.021   0.020  0.007
benchmark/bm_hash_each_key_object.rb            0.137   0.120   0.115  0.774
benchmark/bm_hash_each_key_string.rb            0.126   0.125   0.125  0.669
benchmark/bm_hash_each_object.rb                0.720   0.812   0.756  0.923
benchmark/bm_hash_each_string.rb                0.735   0.749   0.748  0.677
benchmark/bm_hash_each_value_object.rb          0.137   0.129   0.125  0.749
benchmark/bm_hash_each_value_string.rb          0.160   0.160   0.158  0.637
benchmark/bm_hash_element_reference_object.rb   0.075   0.055   0.049  0.009
benchmark/bm_hash_element_reference_string.rb   0.013   0.013   0.012  0.006
benchmark/bm_hash_element_set_object.rb         0.306   0.223   0.169  0.070
benchmark/bm_hash_element_set_string.rb         0.117   0.129   0.106  0.042
benchmark/bm_hash_equal_value_object.rb         7.702   3.174   1.482  2.056
benchmark/bm_hash_equal_value_string.rb         0.183   0.183   0.175  0.848
benchmark/bm_hash_fetch_object.rb               0.056   0.047   0.040  0.007
benchmark/bm_hash_fetch_string.rb               0.010   0.009   0.010  0.004
benchmark/bm_hash_flatten_object.rb             0.184   0.182   0.174  0.536
benchmark/bm_hash_flatten_string.rb             0.233   0.232   0.231  0.509
benchmark/bm_hash_has_key_object.rb             0.069   0.052   0.044  0.009
benchmark/bm_hash_has_key_string.rb             0.012   0.012   0.012  0.006
benchmark/bm_hash_has_value_object.rb           0.117   0.093   0.086  0.050
benchmark/bm_hash_has_value_string.rb           0.079   0.092   0.079  0.036
benchmark/bm_hash_hash_object.rb                1.338   0.864   0.820  0.029
benchmark/bm_hash_hash_string.rb                1.162   0.759   0.748  0.032
benchmark/bm_hash_inspect_object.rb             1.407   1.288   0.930  2.703
benchmark/bm_hash_inspect_string.rb             1.114   1.004   1.045  0.720
benchmark/bm_hash_invert_object.rb              0.709   0.213   0.149  0.053
benchmark/bm_hash_invert_string.rb              0.729   0.266   0.478  0.053
benchmark/bm_hash_keep_if_object.rb             2.048   1.708   1.810  0.397
benchmark/bm_hash_keep_if_string.rb             1.910   1.782   1.778  0.392
benchmark/bm_hash_key_object.rb                 0.115   0.098   0.113  0.082
benchmark/bm_hash_key_string.rb                 0.082   0.078   0.089  0.036
benchmark/bm_hash_keys_object.rb                0.653   0.618   0.621  0.248
benchmark/bm_hash_keys_string.rb                0.512   0.503   0.507  0.240
benchmark/bm_hash_literal_mixed_large.rb        3.109   1.932   1.711  0.528
benchmark/bm_hash_literal_mixed_small.rb        0.176   0.065   0.053  0.042
benchmark/bm_hash_literal_object_large.rb       3.272   0.980   0.813  0.608
benchmark/bm_hash_literal_object_small.rb       0.398   0.089   0.072  0.049
benchmark/bm_hash_literal_string_large.rb       0.044   0.045   0.045  2.856
benchmark/bm_hash_literal_string_small.rb       0.010   0.010   0.012  0.274
benchmark/bm_hash_merge_object.rb              10.142   3.048   1.757  1.878
benchmark/bm_hash_merge_string.rb               1.426   1.571   1.436  0.709
benchmark/bm_hash_rassoc_object.rb              0.102   0.103   0.100  0.077
benchmark/bm_hash_rassoc_string.rb              0.082   0.088   0.089  0.037
benchmark/bm_hash_rehash_object.rb              4.280   1.610   0.246  3.486
benchmark/bm_hash_rehash_string.rb              0.050   0.047   0.053  2.007
benchmark/bm_hash_reject_bang_object.rb         0.925   0.838   0.857  3.522
benchmark/bm_hash_reject_bang_string.rb         1.220   1.177   1.229  3.481
benchmark/bm_hash_reject_object.rb              1.844   1.397   1.326  0.287
benchmark/bm_hash_reject_string.rb              0.798   0.794   0.809  0.188
benchmark/bm_hash_replace_object.rb             9.550   5.070   3.977  2.087
benchmark/bm_hash_replace_string.rb             2.230   1.958   1.873  1.218
benchmark/bm_hash_select_bang_object.rb         1.166   1.053   1.021  3.510
benchmark/bm_hash_select_bang_string.rb         1.413   1.375   1.390  3.549
benchmark/bm_hash_select_object.rb              2.118   1.464   1.366  0.286
benchmark/bm_hash_select_string.rb              0.886   0.841   0.919  0.184
benchmark/bm_hash_shift_object.rb               6.388   4.115   3.061  0.627
benchmark/bm_hash_shift_string.rb               1.692   1.557   1.472  0.630
benchmark/bm_hash_to_a_object.rb                1.052   1.045   1.062  3.286
benchmark/bm_hash_to_a_string.rb                1.181   1.166   1.171  3.151
benchmark/bm_hash_to_h_object.rb               20.569  13.093  11.453  0.763
benchmark/bm_hash_to_h_string.rb                4.305   3.948   4.405  0.760
benchmark/bm_hash_values_object.rb              0.129   0.142   0.138  2.622
benchmark/bm_hash_values_string.rb              0.177   0.183   0.182  0.083
```

The biggest win here is `Hash#merge`, which improves by an order of magnitude and catches up to MRI 2.2.3 performance. This is huge when you're using hashes as "immutable" trees (like in [GrandCentral](https://github.com/clearwater-rb/grand_central).

Also, comparing hashes by value (`==`) goes from over 3.5x slower than MRI before this PR to 25% _faster_ than MRI (7.7s on master, 1.5s in this PR, 2.06s on MRI).

Several other object-key benchmarks improve by up to 30-100% vs master. In fact, there are a couple benchmarks that were negatively affected by the Hash redux which are now even faster than they were prior to it. They're methods that aren't heavily used (which is why it wasn't a problem with the Hash redux), but I thought that was pretty cool.