### PR TITLE
Optimize super as a bareword

### DIFF
--- a/lib/opal/nodes/def.rb
+++ b/lib/opal/nodes/def.rb
@@ -81,11 +81,11 @@ module Opal
 
           if scope.uses_zuper
             add_local '$zuper'
-            add_local 'zuper_index'
+            add_local '$zuper_index'
 
             line "$zuper = [];"
-            line "for(zuper_index = 0; zuper_index < arguments.length; zuper_index++) {"
-            line "  $zuper[zuper_index] = arguments[zuper_index];"
+            line "for($zuper_index = 0; $zuper_index < arguments.length; $zuper_index++) {"
+            line "  $zuper[$zuper_index] = arguments[$zuper_index];"
             line "}"
           end
 
@@ -147,12 +147,12 @@ module Opal
       def compile_rest_arg
         if rest_arg and rest_arg[1]
           splat = variable(rest_arg[1].to_sym)
-          add_local 'splat_index'
+          add_local '$splat_index'
           line "var array_size = arguments.length - #{argc};"
           line "if(array_size < 0) array_size = 0;"
           line "var #{splat} = new Array(array_size);"
-          line "for(splat_index = 0; splat_index < array_size; splat_index++) {"
-          line "  #{splat}[splat_index] = arguments[splat_index + #{argc}];"
+          line "for($splat_index = 0; $splat_index < array_size; $splat_index++) {"
+          line "  #{splat}[$splat_index] = arguments[$splat_index + #{argc}];"
           line "}"
         end
       end

--- a/lib/opal/nodes/def.rb
+++ b/lib/opal/nodes/def.rb
@@ -79,18 +79,21 @@ module Opal
             scope.locals.delete(rest_arg[1])
           end
 
+          if scope.uses_zuper
+            add_local '$zuper'
+            add_local 'zuper_index'
+
+            line "$zuper = [];"
+            line "for(zuper_index = 0; zuper_index < arguments.length; zuper_index++) {"
+            line "  $zuper[zuper_index] = arguments[zuper_index];"
+            line "}"
+          end
+
           unshift "\n#{current_indent}", scope.to_vars
 
           line arity_code if arity_code
 
           line stmt_code
-
-          if scope.uses_zuper
-            unshift "}"
-            unshift "  $zuper[arg_index] = arguments[arg_index];"
-            unshift "for(var arg_index = 0; arg_index < arguments.length; arg_index++) {"
-            unshift "var $zuper = [];"
-          end
 
           if scope.catch_return
             unshift "try {\n"
@@ -144,11 +147,12 @@ module Opal
       def compile_rest_arg
         if rest_arg and rest_arg[1]
           splat = variable(rest_arg[1].to_sym)
+          add_local 'splat_index'
           line "var array_size = arguments.length - #{argc};"
           line "if(array_size < 0) array_size = 0;"
           line "var #{splat} = new Array(array_size);"
-          line "for(var arg_index = 0; arg_index < array_size; arg_index++) {"
-          line "  #{splat}[arg_index] = arguments[arg_index + #{argc}];"
+          line "for(splat_index = 0; splat_index < array_size; splat_index++) {"
+          line "  #{splat}[splat_index] = arguments[splat_index + #{argc}];"
           line "}"
         end
       end

--- a/lib/opal/nodes/def.rb
+++ b/lib/opal/nodes/def.rb
@@ -85,7 +85,12 @@ module Opal
 
           line stmt_code
 
-          unshift "var $zuper = $slice.call(arguments, 0);" if scope.uses_zuper
+          if scope.uses_zuper
+            unshift "}"
+            unshift "  $zuper[arg_index] = arguments[arg_index];"
+            unshift "for(var arg_index = 0; arg_index < arguments.length; arg_index++) {"
+            unshift "var $zuper = [];"
+          end
 
           if scope.catch_return
             unshift "try {\n"


### PR DESCRIPTION
Currently, it's hardcoded in the compiler to use `$slice.call(arguments, 0)`. This PR just does the usual arguments->array copy via iteration while also making the JS code less terrible than I've been doing by declaring that target variable with the rest of the locals. :-)

Results from `rake bench` (from left to right: master, this PR, MRI):

```
test/cruby/benchmark/bm_vm2_zsuper.rb              13.864  1.780   0.547
```

As a bonus, I renamed the index variable for splat args and added a local variable for it. I hadn't intended to commit it but I apparently wasn't paying attention. :-) The only reason I changed it at all was because I originally used `arg_index` in both places, but `Struct.new` uses both splat args and bareword `super` so `var arg_index` in two places within the same scope caused JSHint to barf.