### PR TITLE
Optimize Struct access

### DIFF
--- a/opal/corelib/struct.rb
+++ b/opal/corelib/struct.rb
@@ -85,11 +85,7 @@ class Struct
     elsif String === name
       %x{
         if(!self.$$data.hasOwnProperty(name)) {
-          Opal.Kernel.$raise(
-            Opal.NameError.$new(
-              "no member '" + name + "' in struct", name
-            )
-          )
+          #{raise NameError.new("no member '#{name}' in struct", name)}
         }
       }
     else

--- a/opal/corelib/struct.rb
+++ b/opal/corelib/struct.rb
@@ -38,7 +38,7 @@ class Struct
     members << name
 
     define_method name do
-      self[name]
+      `self.$$data[name]`
     end
 
     define_method "#{name}=" do |value|
@@ -83,7 +83,15 @@ class Struct
 
       name = members[name]
     elsif String === name
-      raise NameError.new("no member '#{name}' in struct", name) unless members.include?(name.to_sym)
+      %x{
+        if(!self.$$data.hasOwnProperty(name)) {
+          Opal.Kernel.$raise(
+            Opal.NameError.$new(
+              "no member '" + name + "' in struct", name
+            )
+          )
+        }
+      }
     else
       raise TypeError, "no implicit conversion of #{name.class} into Integer"
     end

--- a/opal/corelib/struct.rb
+++ b/opal/corelib/struct.rb
@@ -42,7 +42,7 @@ class Struct
     end
 
     define_method "#{name}=" do |value|
-      self[name] = value
+      `self.$$data[name] = value`
     end    
   end
 


### PR DESCRIPTION
When using methods on a struct, we don't need to check whether the struct has that as a member. If it doesn't we'll be invoking method_missing, not the subscript operator, so we can bypass all that and head straight to the good part.

Additionally, traversing the struct's members as an array is O(n), but checking whether the struct's data object has that key is O(1), so this commit speeds that up, as well.

Results from `rake bench` (from left to right: master, this PR, MRI):

```
test/cruby/benchmark/bm_vm2_struct_big_aref_hi.rb  12.814   0.796   0.261
test/cruby/benchmark/bm_vm2_struct_big_aref_lo.rb   9.565   0.794   0.266
test/cruby/benchmark/bm_vm2_struct_big_aset.rb      9.404   1.224   0.285
test/cruby/benchmark/bm_vm2_struct_small_aref.rb    5.989   0.049   0.190
test/cruby/benchmark/bm_vm2_struct_small_aset.rb    7.255   0.275   0.281
```