### PR TITLE
Fix parsing of `return %{string}`

### DIFF
--- a/lib/opal/parser/lexer.rb
+++ b/lib/opal/parser/lexer.rb
@@ -899,7 +899,9 @@ module Opal
             @lex_state = :expr_beg
             return new_op_asgn('%')
           elsif check(/[^\s]/)
-            if @lex_state == :expr_beg or (@lex_state == :expr_arg && @space_seen)
+            if @lex_state == :expr_beg or
+               (@lex_state == :expr_arg && @space_seen) or
+               @lex_state == :expr_mid
               start_word  = scan(/./)
               end_word    = { '(' => ')', '[' => ']', '{' => '}' }[start_word] || start_word
               self.strterm = new_strterm2(STR_DQUOTE, end_word, start_word)

--- a/spec/lib/parser/return_spec.rb
+++ b/spec/lib/parser/return_spec.rb
@@ -14,4 +14,9 @@ describe "The return keyword" do
     parsed("return 1, 2").should == [:return, [:array, [:int, 1], [:int, 2]]]
     parsed("return 1, *2").should == [:return, [:array, [:int, 1], [:splat, [:int, 2]]]]
   end
+
+  it "can handle a %{string literal with percent syntax}" do
+    # regression test; see GH issue 1089
+    parsed("return %{a}").should == [:return, [:str, "a"]]
+  end
 end


### PR DESCRIPTION
The (ludicrously convoluted) Ruby lexer has a number of states, which affect
how various constructs are lexed. There is a state called 'expr_mid', which is
entered after lexing 'return', 'rescue', and a couple of other keywords.

'expr_mid' state is very, very, very, very much like 'expr_beg' state. I still
haven't figured out exactly why it is needed. Anyways, when in expr_mid state,
we should lex %{ just like expr_beg state.