### PR TITLE
Lexer always goes into 'expr_beg' state after lexing an operator-assignment

### DIFF
--- a/lib/opal/parser/lexer.rb
+++ b/lib/opal/parser/lexer.rb
@@ -206,6 +206,7 @@ module Opal
 
     def new_op_asgn(value)
       self.yylval = value
+      @lex_state = :expr_beg
       :tOP_ASGN
     end
 
@@ -692,13 +693,11 @@ module Opal
 
         elsif check(/\*/)
           if scan(/\*\*\=/)
-            @lex_state = :expr_beg
             return new_op_asgn('**')
           elsif scan(/\*\*/)
             self.set_arg_state
             return :tPOW
           elsif scan(/\*\=/)
-            @lex_state = :expr_beg
             return new_op_asgn('*')
           else
             scan(/\*/)
@@ -803,7 +802,6 @@ module Opal
             return :tANDOP
 
           elsif scan(/\=/)
-            @lex_state = :expr_beg
             return new_op_asgn('&')
           end
 
@@ -823,6 +821,7 @@ module Opal
         elsif scan(/\|/)
           if scan(/\|/)
             @lex_state = :expr_beg
+
             if scan(/\=/)
               return new_op_asgn('||')
             end
@@ -875,7 +874,6 @@ module Opal
             self.strterm = new_strterm(STR_REGEXP, '/', '/')
             return :tREGEXP_BEG
           elsif scan(/\=/)
-            @lex_state = :expr_beg
             return new_op_asgn('/')
           end
 
@@ -896,7 +894,6 @@ module Opal
 
         elsif scan(/\%/)
           if scan(/\=/)
-            @lex_state = :expr_beg
             return new_op_asgn('%')
           elsif check(/[^\s]/)
             if @lex_state == :expr_beg or
@@ -1036,7 +1033,6 @@ module Opal
           return :tSYMBEG
 
         elsif scan(/\^\=/)
-          @lex_state = :expr_beg
           return new_op_asgn('^')
 
         elsif scan(/\^/)
@@ -1045,7 +1041,6 @@ module Opal
 
         elsif check(/</)
           if scan(/<<\=/)
-            @lex_state = :expr_beg
             return new_op_asgn('<<')
 
           elsif scan(/<</)
@@ -1134,7 +1129,6 @@ module Opal
           end
 
           if scan(/\=/)
-            @lex_state = :expr_beg
             return new_op_asgn(matched)
           end
 

--- a/spec/lib/parser/op_asgn_spec.rb
+++ b/spec/lib/parser/op_asgn_spec.rb
@@ -1,0 +1,17 @@
+require 'support/parser_helpers'
+
+describe "Operator assignment statements on local variables" do
+  it "parses |= with a lvar on the left and parenthesized expr on the right" do
+    # regression test; see GH issue 995
+    asgn = [:lasgn, :var, [:int, 1]]
+    opasgn = [:lasgn, :var, [:call, [:lvar, :var], :|, [:arglist, [:paren, [:int, 1]]]]]
+    parsed('var = 1; var |= (1)').should == [:block, asgn, opasgn]
+  end
+
+  it "parses >>= with a lvar on the left and parenthesized expr on the right" do
+    # regression test; see GH issue 995
+    asgn = [:lasgn, :var, [:int, 1]]
+    opasgn = [:lasgn, :var, [:call, [:lvar, :var], :>>, [:arglist, [:paren, [:int, 1]]]]]
+    parsed('var = 1; var >>= (1)').should == [:block, asgn, opasgn]
+  end
+end


### PR DESCRIPTION
The correct lexer state was not entered after lexing `|=` and `>>=`. Depending
on what followed after these operators, this could cause the parser to fail.

Fixes #599 and fixes #995.