### PR TITLE
Fix #1230 (interpolating an empty expr into string)

### DIFF
--- a/lib/opal/nodes/literal.rb
+++ b/lib/opal/nodes/literal.rb
@@ -129,7 +129,7 @@ module Opal
             push part.inspect
           elsif part.type == :evstr
             push "("
-            push expr(part[1])
+            push part[1] ? expr(part[1]) : '""'
             push ")"
           elsif part.type == :str
             push part[1].inspect


### PR DESCRIPTION
¯\_(ツ)_/¯