### PR TITLE
runtime.js cleanup

### DIFF
--- a/lib/opal/nodes/helpers.rb
+++ b/lib/opal/nodes/helpers.rb
@@ -12,7 +12,7 @@ module Opal
       ES3_RESERVED_WORD_EXCLUSIVE = /#{REGEXP_START}(?:int|byte|char|goto|long|final|float|short|double|native|throws|boolean|abstract|volatile|transient|synchronized)#{REGEXP_END}/
 
       # Prototype special properties.
-      PROTO_SPECIAL_PROPS = /#{REGEXP_START}(?:constructor|__proto__|__parent__|__noSuchMethod__|__count__)#{REGEXP_END}/
+      PROTO_SPECIAL_PROPS = /#{REGEXP_START}(?:constructor|displayName|__proto__|__parent__|__noSuchMethod__|__count__)#{REGEXP_END}/
 
       # Prototype special methods.
       PROTO_SPECIAL_METHODS = /#{REGEXP_START}(?:hasOwnProperty|valueOf)#{REGEXP_END}/

--- a/opal/corelib/class.rb
+++ b/opal/corelib/class.rb
@@ -8,7 +8,7 @@ class Class
       }
 
       function AnonClass(){};
-      var klass        = Opal.boot(sup, AnonClass)
+      var klass        = Opal.boot_class(sup, AnonClass)
       klass.$$name     = nil;
       klass.$$parent   = sup;
       klass.$$is_class = true;

--- a/opal/corelib/module.rb
+++ b/opal/corelib/module.rb
@@ -2,7 +2,7 @@ class Module
   def self.new(&block)
     %x{
       function AnonModule(){}
-      var klass         = Opal.boot(Opal.Module, AnonModule);
+      var klass         = Opal.boot_class(Opal.Module, AnonModule);
       klass.$$name      = nil;
       klass.$$class     = Opal.Module;
       klass.$$dep       = []

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -84,7 +84,6 @@
   // keeps track of exceptions for $!
   Opal.exceptions = [];
 
-  //
   // Get a constant on the given scope. Every class and module in Opal has a
   // scope used to store, and inherit, constants. For example, the top level
   // `Object` in ruby has a scope accessible as `Opal.Object.$$scope`.
@@ -110,7 +109,6 @@
     return constant;
   };
 
-  //
   // Create a new constants scope for the given class with the given
   // base. Constants are looked up through their parents, so the base
   // scope will be the outer scope of the new klass.
@@ -131,7 +129,6 @@
     }
   }
 
-  //
   // A `class Foo; end` expression in ruby is compiled to call this runtime
   // method which either returns an existing class of the given name, or creates
   // a new class in the given `base` scope.
@@ -257,7 +254,6 @@
     return klass;
   }
 
-  //
   // Adds common/required properties to a module or class object
   // (as in `Module.new` / `Class.new`)
   //
@@ -312,7 +308,6 @@
     module.$$inc = [];
   }
 
-  //
   // Define new module (or return existing module). The given `base` is basically
   // the current `self` value the `module` statement was defined in. If this is
   // a ruby module or class, then it is used, otherwise if the base is a ruby
@@ -367,7 +362,6 @@
     return module;
   };
 
-  //
   // Internal function to create a new module instance. This simply sets up
   // the prototype hierarchy and method tables.
   //
@@ -386,7 +380,6 @@
     return module;
   }
 
-  //
   // Return the singleton class for the passed object.
   //
   // If the given object alredy has a singleton class, then it will be stored on
@@ -411,7 +404,6 @@
     return build_object_singleton_class(object);
   };
 
-  //
   // Build the singleton class for an existing class.
   //
   // NOTE: Actually in MRI a class' singleton class inherits from its
@@ -434,7 +426,6 @@
     return klass.$$meta = meta;
   }
 
-  //
   // Build the singleton class for a Ruby (non class) Object.
   //
   // @param [RubyObject] object
@@ -518,7 +509,6 @@
     }
   }
 
-  //
   // The actual inclusion of a module into a class.
   //
   // ## Class `$$parent` and `iclass`
@@ -604,7 +594,6 @@
     return constructor;
   }
 
-  //
   // Builds the class object for core classes:
   // - make the class object have a singleton class
   // - make the singleton class inherit from its parent singleton class
@@ -639,7 +628,6 @@
     return klass;
   }
 
-  //
   // For performance, some core Ruby classes are toll-free bridged to their
   // native JavaScript counterparts (e.g. a Ruby Array is a JavaScript Array).
   //
@@ -687,7 +675,6 @@
   }
 
 
-  //
   // constant assign
   //
   Opal.casgn = function(base_module, name, value) {
@@ -732,7 +719,6 @@
     return base_scope[name] = value;
   };
 
-  //
   // When a source module is included into the target module, we must also copy
   // its constants to the target.
   //
@@ -799,7 +785,6 @@
     }
   };
 
-  //
   // Methods stubs are used to facilitate method_missing in opal. A stub is a
   // placeholder function which just calls `method_missing` on the receiver.
   // If no method with the given name is actually defined on an object, then it
@@ -847,14 +832,12 @@
     }
   };
 
-  //
   // Keep a list of prototypes that want method_missing stubs to be added.
   //
   // @default [Prototype List] BasicObject_alloc.prototype
   //
   Opal.stub_subscribers = [BasicObject_alloc.prototype];
 
-  //
   // Add a method_missing stub function to the given prototype for the
   // given name.
   //
@@ -866,7 +849,6 @@
     prototype[stub] = method_missing_stub;
   }
 
-  //
   // Generate the method_missing stub for a given method name.
   //
   // @param [String] method_name The js-name of the method to stub (e.g. "$foo")
@@ -991,7 +973,6 @@
     return klass.$$proto;
   };
 
-  //
   // Used to return as an expression. Sometimes, we can't simply return from
   // a javascript function as if we were a method, as the return is used as
   // an expression, or even inside a block which must "return" to the outer
@@ -1134,7 +1115,6 @@
     }
   };
 
-  //
   // Used to get a list of rest keyword arguments. Method takes the given
   // keyword args, i.e. the hash literal passed to the method containing all
   // keyword arguemnts passed to method, as well as the used args which are
@@ -1162,7 +1142,6 @@
     return Opal.hash2(keys, map);
   };
 
-  //
   // Call a ruby method on a ruby object with some arguments:
   //
   //   var my_array = [1, 2, 3, 4]
@@ -1200,7 +1179,6 @@
     return recv.$method_missing.apply(recv, [mid].concat(args));
   };
 
-  //
   // Used to define methods on an object. This is a helper method, used by the
   // compiled source to define methods on special case objects when the compiler
   // can not determine the destination object, or the object is a Module
@@ -1627,7 +1605,6 @@
     return hash;
   };
 
-  //
   // hash2 is a faster creator for hashes that just use symbols and
   // strings as keys. The map and keys array can be constructed at
   // compile time, so they are just added here by the constructor
@@ -1643,7 +1620,6 @@
     return hash;
   };
 
-  //
   // Create a new range instance with first and last values, and whether the
   // range excludes the last value.
   //

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -127,7 +127,7 @@
 
     if (id) {
       Opal.cdecl(base, id, klass);
-      const_alloc.displayName = id;
+      const_alloc.displayName = id+"_alloc";
     }
   }
 
@@ -597,14 +597,14 @@
   // Boot a base class (makes instances).
   function boot_class_alloc(id, constructor, superklass) {
     if (superklass) {
-      var ctor = function() {};
-          ctor.prototype   = superklass.$$proto || superklass.prototype;
+      var alloc_proxy = function() {};
+      alloc_proxy.prototype  = superklass.$$proto || superklass.prototype;
 
       if (id) {
-        ctor.displayName = id;
+        alloc_proxy.displayName = id;
       }
 
-      constructor.prototype = new ctor();
+      constructor.prototype = new alloc_proxy();
     }
 
     constructor.prototype.constructor = constructor;

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -599,12 +599,11 @@
     if (superklass) {
       var alloc_proxy = function() {};
       alloc_proxy.prototype  = superklass.$$proto || superklass.prototype;
-
-      if (id) {
-        alloc_proxy.displayName = id;
-      }
-
       constructor.prototype = new alloc_proxy();
+    }
+
+    if (id) {
+      constructor.displayName = id+'_alloc';
     }
 
     constructor.prototype.constructor = constructor;

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -1634,17 +1634,19 @@
   };
 
   Opal.ivar = function(name) {
-    if (name === "constructor" ||
-        name === "__proto__" ||
-        name === "__parent__" ||
+    if (
+        // properties
+        name === "constructor" ||
+        name === "displayName" ||
+        name === "__count__" ||
         name === "__noSuchMethod__" ||
-        name === "__count__")
-    {
-      return name + "$";
-    }
+        name === "__parent__" ||
+        name === "__proto__" ||
 
-    if (name === "hasOwnProperty" ||
-        name === "valueOf")
+        // methods
+        name === "hasOwnProperty" ||
+        name === "valueOf"
+       )
     {
       return name + "$";
     }

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -19,19 +19,19 @@
   var ClassClass;
 
   // Constructor for instances of BasicObject
-  function BasicObject(){}
+  function BasicObject_alloc(){}
 
   // Constructor for instances of Object
-  function Object(){}
+  function Object_alloc(){}
 
   // Constructor for instances of Class
-  function Class(){}
+  function Class_alloc(){}
 
   // Constructor for instances of Module
-  function Module(){}
+  function Module_alloc(){}
 
   // Constructor for instances of NilClass (nil)
-  function NilClass(){}
+  function NilClass_alloc(){}
 
   // The Opal object that is exposed globally
   var Opal = this.Opal = {};
@@ -675,8 +675,8 @@
       _bridge(constructor, ancestors[i]);
     }
 
-    for (var name in BasicObject.prototype) {
-      var method = BasicObject.prototype[method];
+    for (var name in BasicObject_alloc.prototype) {
+      var method = BasicObject_alloc.prototype[method];
 
       if (method && method.$$stub && !(name in constructor.prototype)) {
         constructor.prototype[name] = method;
@@ -850,9 +850,9 @@
   //
   // Keep a list of prototypes that want method_missing stubs to be added.
   //
-  // @default [Prototype List] BasicObject.prototype
+  // @default [Prototype List] BasicObject_alloc.prototype
   //
-  Opal.stub_subscribers = [BasicObject.prototype];
+  Opal.stub_subscribers = [BasicObject_alloc.prototype];
 
   //
   // Add a method_missing stub function to the given prototype for the
@@ -1756,16 +1756,16 @@
   // --------------
 
   // Constructors for *instances* of core objects
-  boot_class_alloc('BasicObject', BasicObject);
-  boot_class_alloc('Object',      Object,       BasicObject);
-  boot_class_alloc('Module',      Module,       Object);
-  boot_class_alloc('Class',       Class,        Module);
+  boot_class_alloc('BasicObject', BasicObject_alloc);
+  boot_class_alloc('Object',      Object_alloc,       BasicObject_alloc);
+  boot_class_alloc('Module',      Module_alloc,       Object_alloc);
+  boot_class_alloc('Class',       Class_alloc,        Module_alloc);
 
   // Constructors for *classes* of core objects
-  BasicObjectClass = boot_core_class_object('BasicObject', BasicObject, Class);
-  ObjectClass      = boot_core_class_object('Object',      Object,      BasicObjectClass.constructor);
-  ModuleClass      = boot_core_class_object('Module',      Module,      ObjectClass.constructor);
-  ClassClass       = boot_core_class_object('Class',       Class,       ModuleClass.constructor);
+  BasicObjectClass = boot_core_class_object('BasicObject', BasicObject_alloc, Class_alloc);
+  ObjectClass      = boot_core_class_object('Object',      Object_alloc,      BasicObjectClass.constructor);
+  ModuleClass      = boot_core_class_object('Module',      Module_alloc,      ObjectClass.constructor);
+  ClassClass       = boot_core_class_object('Class',       Class_alloc,       ModuleClass.constructor);
 
   // Fix booted classes to use their metaclass
   BasicObjectClass.$$class = ClassClass;
@@ -1802,8 +1802,8 @@
   Opal.top = new ObjectClass.$$alloc();
 
   // Nil
-  Opal.klass(ObjectClass, ObjectClass, 'NilClass', NilClass);
-  nil = Opal.nil = new NilClass();
+  Opal.klass(ObjectClass, ObjectClass, 'NilClass', NilClass_alloc);
+  nil = Opal.nil = new NilClass_alloc();
   nil.$$id = nil_id;
   nil.call = nil.apply = function() { throw Opal.LocalJumpError.$new('no block given'); };
 

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -98,7 +98,7 @@
   // error.
   //
   // @param [String] name the name of the constant to lookup
-  // @returns [RubyObject]
+  // @return [RubyObject]
   //
   Opal.get = function(name) {
     var constant = this[name];
@@ -343,7 +343,7 @@
   //
   // @param [RubyModule or Class] base class or module this definition is inside
   // @param [String] id the name of the new (or existing) module
-  // @returns [RubyModule]
+  // @return [RubyModule]
   //
   Opal.module = function(base, id) {
     var module;
@@ -408,7 +408,7 @@
   // the object at `$$meta` for future use, and then returned.
   //
   // @param [RubyObject] object the ruby object
-  // @returns [RubyClass] the singleton class for object
+  // @return [RubyClass] the singleton class for object
   //
   Opal.get_singleton_class = function(object) {
     if (object.$$meta) {
@@ -428,7 +428,7 @@
   // superclass' singleton class which in turn inherits from Class.
   //
   // @param [RubyClass] klass
-  // @returns [RubyClass]
+  // @return [RubyClass]
   //
   function build_class_singleton_class(klass) {
     var meta = new Opal.Class.$$alloc();
@@ -447,7 +447,7 @@
   // Build the singleton class for a Ruby (non class) Object.
   //
   // @param [RubyObject] object
-  // @returns [RubyClass]
+  // @return [RubyClass]
   //
   function build_object_singleton_class(object) {
     var orig_class = object.$$class,
@@ -544,7 +544,7 @@
   //
   // @param [RubyModule] module the module to include
   // @param [RubyClass] klass the target class to include module into
-  // @returns [null]
+  // @return [null]
   //
   Opal.append_features = function(module, klass) {
     var iclass, donator, prototype, methods, id, i;
@@ -1232,7 +1232,7 @@
   // @param [RubyObject or Class] obj the actual obj to define method for
   // @param [String] jsid the javascript friendly method name (e.g. '$foo')
   // @param [Function] body the literal javascript function used as method
-  // @returns [null]
+  // @return [null]
   //
   Opal.defn = function(obj, jsid, body) {
     obj.$$proto[jsid] = body;

--- a/spec/opal/core/kernel/instance_variables_spec.rb
+++ b/spec/opal/core/kernel/instance_variables_spec.rb
@@ -22,7 +22,7 @@ describe "Kernel#instance_variables" do
       expect(Object.new.instance_variables).to eq([])
     end
   end
-  
+
   context 'cloned object' do
     it 'returns same vars as source object' do
       object = Object.new
@@ -33,6 +33,7 @@ describe "Kernel#instance_variables" do
   context 'for object with js keyword as instance variables' do
     reserved_keywords = %w(
       @constructor
+      @displayName
       @__proto__
       @__parent__
       @__noSuchMethod__


### PR DESCRIPTION
Should improve naming for both sanity when developing and while looking at stack traces.
All constructor should now appear with an "_alloc" suffix in stack traces, although I'm not sure I covered all cases.