### PR TITLE
Deeper runtime cleanup, and beyond

### DIFF
--- a/opal/corelib/array.rb
+++ b/opal/corelib/array.rb
@@ -120,10 +120,6 @@ class Array < `Array`
   def *(other)
     return join(other.to_str) if other.respond_to? :to_str
 
-    unless other.respond_to? :to_int
-      raise TypeError, "no implicit conversion of #{other.class} into Integer"
-    end
-
     other = Opal.coerce_to other, Integer, :to_int
 
     if `other < 0`

--- a/opal/corelib/class.rb
+++ b/opal/corelib/class.rb
@@ -18,15 +18,14 @@ class Class
 
       sup.$inherited(klass);
 
-      if (block !== nil) {
-        var block_self = block.$$s;
-        block.$$s = null;
-        block.call(klass);
-        block.$$s = block_self;
-      }
+      #{`klass`.initialize(sup, &block)}
 
       return klass;
     }
+  end
+
+  def initialize(_sup = Object, &block)
+    `Opal.module_initialize(self, block);`
   end
 
   def allocate

--- a/opal/corelib/class.rb
+++ b/opal/corelib/class.rb
@@ -1,24 +1,25 @@
 require 'corelib/module'
 
 class Class
-  def self.new(sup = Object, &block)
+  def self.new(superclass = Object, &block)
     %x{
-      if (!sup.$$is_class) {
+      if (!superclass.$$is_class) {
         #{raise TypeError, "superclass must be a Class"};
       }
 
-      function AnonClass(){};
-      var klass        = Opal.boot_class(sup, AnonClass)
+      var alloc = Opal.boot_class_alloc(null, function(){}, superclass)
+      var klass = Opal.boot_class_object(null, superclass, alloc);
+
       klass.$$name     = nil;
-      klass.$$parent   = sup;
+      klass.$$parent   = superclass;
       klass.$$is_class = true;
 
       // inherit scope from parent
-      Opal.create_scope(sup.$$scope, klass);
+      Opal.create_scope(superclass.$$scope, klass);
 
-      sup.$inherited(klass);
+      superclass.$inherited(klass);
 
-      #{`klass`.initialize(sup, &block)}
+      #{`klass`.initialize(superclass, &block)}
 
       return klass;
     }

--- a/opal/corelib/class.rb
+++ b/opal/corelib/class.rb
@@ -4,29 +4,23 @@ class Class
   def self.new(superclass = Object, &block)
     %x{
       if (!superclass.$$is_class) {
-        #{raise TypeError, "superclass must be a Class"};
+        throw Opal.TypeError.$new("superclass must be a Class");
       }
 
       var alloc = Opal.boot_class_alloc(null, function(){}, superclass)
-      var klass = Opal.boot_class_object(null, superclass, alloc);
+      var klass = Opal.setup_class_object(null, alloc, superclass.$$name, superclass.constructor);
 
-      klass.$$name     = nil;
-      klass.$$parent   = superclass;
-      klass.$$is_class = true;
+      klass.$$super = superclass;
+      klass.$$parent = superclass;
 
       // inherit scope from parent
       Opal.create_scope(superclass.$$scope, klass);
 
       superclass.$inherited(klass);
-
-      #{`klass`.initialize(superclass, &block)}
+      Opal.module_initialize(klass, block);
 
       return klass;
     }
-  end
-
-  def initialize(_sup = Object, &block)
-    `Opal.module_initialize(self, block);`
   end
 
   def allocate

--- a/opal/corelib/module.rb
+++ b/opal/corelib/module.rb
@@ -11,15 +11,14 @@ class Module
       // inherit scope from parent
       Opal.create_scope(Opal.Module.$$scope, klass);
 
-      if (block !== nil) {
-        var block_self = block.$$s;
-        block.$$s = null;
-        block.call(klass);
-        block.$$s = block_self;
-      }
+      #{`klass`.initialize(&block)}
 
       return klass;
     }
+  end
+
+  def initialize(&block)
+    `Opal.module_initialize(self, block)`
   end
 
   def ===(object)

--- a/opal/corelib/module.rb
+++ b/opal/corelib/module.rb
@@ -262,12 +262,7 @@ class Module
 
   def const_set(name, value)
     raise NameError.new("wrong constant name #{name}", name) unless name =~ /^[A-Z]\w*$/
-
-    begin
-      name = name.to_str
-    rescue
-      raise TypeError, 'conversion with #to_str failed'
-    end
+    name = Opal.coerce_to!(name, String, :to_str)
 
     `Opal.casgn(self, name, value)`
 

--- a/opal/corelib/module.rb
+++ b/opal/corelib/module.rb
@@ -1,19 +1,11 @@
 class Module
-  def self.new(&block)
+  def self.allocate
     %x{
-      var klass         = Opal.boot_module_object();
-      klass.$$name      = nil;
-      klass.$$class     = Opal.Module;
-      klass.$$dep       = []
-      klass.$$is_module = true;
-      klass.$$proto     = {};
+      var module;
 
-      // inherit scope from parent
-      Opal.create_scope(Opal.Module.$$scope, klass);
-
-      #{`klass`.initialize(&block)}
-
-      return klass;
+      module = Opal.module_allocate();
+      Opal.create_scope(Opal.Module.$$scope, module, null);
+      return module;
     }
   end
 

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -332,7 +332,7 @@
     // The built class is the only instance of its singleton_class
     var klass = new singleton_class_alloc();
 
-    Opal.setup_class_object(klass, singleton_class_alloc, superclass, alloc.prototype);
+    Opal.setup_class_object(klass, singleton_class_alloc, alloc.prototype);
 
     // Set a displayName for the singleton_class
     singleton_class_alloc.displayName = "#<Class:"+(id || ("#<Class:"+klass.$$id+">"))+">";
@@ -344,6 +344,14 @@
     // @property $$proto.$$class Make available to instances a reference to the
     //                           class they belong to.
     klass.$$proto.$$class = klass;
+
+    // @property $$super the superclass, doesn't get changed by module inclusions
+    klass.$$super = superclass;
+
+    // @property $$parent direct parent class
+    //                    starts with the superclass, after klass inclusion is
+    //                    the last included klass
+    klass.$$parent = superclass;
 
     return klass;
   };
@@ -363,7 +371,9 @@
   // @param prototype   The prototype on which the class/module methods will
   //                    be stored.
   //
-  Opal.setup_class_object = function(module, constructor, superclass, prototype) {
+  Opal.setup_class_object = function(module, constructor, prototype) {
+    // console.log(typeof superclass);
+
     // @property $$id Each class is assigned a unique `id` that helps
     //                comparation and implementation of `#object_id`
     module.$$id = Opal.uid();
@@ -382,14 +392,6 @@
     // @property $$is_class Clearly mark this as a class
     module.$$is_class = true;
     module.$$class    = Class;
-
-    // @property $$super the superclass, doesn't get changed by module inclusions
-    module.$$super = superclass;
-
-    // @property $$parent direct parent class or module
-    //                    starts with the superclass, after module inclusion is
-    //                    the last included module
-    module.$$parent = superclass;
 
     // @property $$inc included modules
     module.$$inc = [];
@@ -745,7 +747,7 @@
     // the singleton_class acts as the class object constructor
     var klass = new singleton_class();
 
-    Opal.setup_class_object(klass, singleton_class, superclass, alloc.prototype);
+    Opal.setup_class_object(klass, singleton_class, alloc.prototype);
 
     klass.$$alloc     = alloc;
     klass.$$name      = id;

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -455,6 +455,20 @@
     return module;
   };
 
+  // The implementation for Module#initialize
+  // @param module [Module]
+  // @param block [Proc,nil]
+  // @return nil
+  Opal.module_initialize = function(module, block) {
+    if (block !== nil) {
+      var block_self = block.$$s;
+      block.$$s = null;
+      block.call(module);
+      block.$$s = block_self;
+    }
+    return nil;
+  };
+
   // Internal function to create a new module instance. This simply sets up
   // the prototype hierarchy and method tables.
   //

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -1848,12 +1848,16 @@
   Class.$$scope       = _Object.$$scope;
   Class.$$orig_scope  = _Object.$$orig_scope;
 
+  // Forward .toString() to #to_s
   _Object.$$proto.toString = function() {
     return this.$to_s();
   };
 
+  // Make Kernel#require immediately available as it's needed to require all the
+  // other corelib files.
   _Object.$$proto.$require = Opal.require;
 
+  // Instantiate the top object
   Opal.top = new _Object.$$alloc();
 
   // Nil

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -137,7 +137,7 @@
       Opal.cdecl(base_scope, id, klass);
       const_alloc.displayName = id+"_scope_alloc";
     }
-  }
+  };
 
   // Constant assignment, see also `Opal.cdecl`
   //
@@ -263,10 +263,10 @@
     }
 
     // If bridged the JS class will also be the alloc function
-    alloc = bridged || boot_class_alloc(id, constructor, superclass);
+    alloc = bridged || Opal.boot_class_alloc(id, constructor, superclass);
 
     // Create the class object (instance of Class)
-    klass = boot_class_object(id, superclass, alloc);
+    klass = Opal.boot_class_object(id, superclass, alloc);
 
     // Name the class
     klass.$$name = id;
@@ -287,7 +287,7 @@
     else {
       // Copy all parent constants to child, unless parent is Object
       if (superclass !== _Object && superclass !== BasicObject) {
-        donate_constants(superclass, klass);
+        Opal.donate_constants(superclass, klass);
       }
 
       // Call .inherited() hook with new class on the superclass
@@ -301,10 +301,10 @@
 
   // Create generic class with given superclass.
   Opal.boot_class = function(superclass, constructor) {
-    var alloc = boot_class_alloc(null, constructor, superclass)
+    var alloc = Opal.boot_class_alloc(null, constructor, superclass)
 
-    return boot_class_object(null, superclass, alloc);
-  }
+    return Opal.boot_class_object(null, superclass, alloc);
+  };
 
   // The class object itself (as in `Class.new`)
   //
@@ -312,7 +312,7 @@
   // @param alloc      [constructor]  The constructor that holds the prototype
   //                                  that will be used for instances of the
   //                                  newly constructed class.
-  function boot_class_object(id, superclass, alloc) {
+  Opal.boot_class_object = function(id, superclass, alloc) {
     // Grab the superclass prototype and use it to build an intermediary object
     // in the prototype chain.
     function Superclass_alloc_proxy() {};
@@ -327,7 +327,7 @@
     // The built class is the only instance of its singleton_class
     var klass = new SingletonClass_alloc();
 
-    setup_module_or_class_object(klass, SingletonClass_alloc, superclass, alloc.prototype);
+    Opal.setup_module_or_class_object(klass, SingletonClass_alloc, superclass, alloc.prototype);
 
     // @property $$alloc This is the constructor of instances of the current
     //                   class. Its prototype will be used for method lookup
@@ -338,7 +338,7 @@
     klass.$$proto.$$class = klass;
 
     return klass;
-  }
+  };
 
   // Adds common/required properties to a module or class object
   // (as in `Module.new` / `Class.new`)
@@ -355,7 +355,7 @@
   // @param prototype   The prototype on which the class/module methods will
   //                    be stored.
   //
-  function setup_module_or_class_object(module, constructor, superclass, prototype) {
+  Opal.setup_module_or_class_object = function(module, constructor, superclass, prototype) {
     // @property $$id Each class is assigned a unique `id` that helps
     //                comparation and implementation of `#object_id`
     module.$$id = Opal.uid();
@@ -392,7 +392,7 @@
 
     // @property $$inc included modules
     module.$$inc = [];
-  }
+  };
 
   // Define new module (or return existing module). The given `base` is basically
   // the current `self` value the `module` statement was defined in. If this is
@@ -428,7 +428,7 @@
       }
     }
     else {
-      module = boot_module_object();
+      module = Opal.boot_module_object();
 
       // name module using base (e.g. Foo or Foo::Baz)
       module.$$name = id;
@@ -451,7 +451,7 @@
   // Internal function to create a new module instance. This simply sets up
   // the prototype hierarchy and method tables.
   //
-  function boot_module_object() {
+  Opal.boot_module_object = function() {
     var mtor = function() {};
     mtor.prototype = Module_alloc.prototype;
 
@@ -461,13 +461,10 @@
     var module = new module_constructor();
     var module_prototype = {};
 
-    setup_module_or_class_object(module, module_constructor, Module, module_prototype);
+    Opal.setup_module_or_class_object(module, module_constructor, Module, module_prototype);
 
     return module;
-  }
-
-  // Make `boot_module_object` available to the JS-API
-  Opal.boot_module_object = boot_module_object;
+  };
 
   // Return the singleton class for the passed object.
   //
@@ -487,10 +484,10 @@
     }
 
     if (object.$$is_class || object.$$is_module) {
-      return build_class_singleton_class(object);
+      return Opal.build_class_singleton_class(object);
     }
 
-    return build_object_singleton_class(object);
+    return Opal.build_object_singleton_class(object);
   };
 
   // Build the singleton class for an existing class.
@@ -501,7 +498,7 @@
   // @param [RubyClass] klass
   // @return [RubyClass]
   //
-  function build_class_singleton_class(klass) {
+  Opal.build_class_singleton_class = function(klass) {
     var meta = new Opal.Class.$$alloc();
 
     meta.$$class = Opal.Class;
@@ -513,14 +510,14 @@
     meta.$$scope        = klass.$$scope;
 
     return klass.$$meta = meta;
-  }
+  };
 
   // Build the singleton class for a Ruby (non class) Object.
   //
   // @param [RubyObject] object
   // @return [RubyClass]
   //
-  function build_object_singleton_class(object) {
+  Opal.build_object_singleton_class = function(object) {
     var orig_class = object.$$class,
         class_id   = "#<Class:#<" + orig_class.$$name + ":" + orig_class.$$id + ">>";
 
@@ -536,10 +533,10 @@
     meta.$$singleton_of = object;
 
     return object.$$meta = meta;
-  }
+  };
 
   // Bridges a single method.
-  function bridge_method(target, from, name, body) {
+  Opal.bridge_method = function(target, from, name, body) {
     var ancestors, i, ancestor, length;
 
     ancestors = target.$$bridge.$ancestors();
@@ -563,10 +560,10 @@
       }
     }
 
-  }
+  };
 
   // Bridges from *donator* to a *target*.
-  function _bridge(target, donator) {
+  Opal._bridge = function(target, donator) {
     var id, methods, method, i, bridged;
 
     if (typeof(target) === "function") {
@@ -576,7 +573,7 @@
       for (i = methods.length - 1; i >= 0; i--) {
         method = '$' + methods[i];
 
-        bridge_method(target, donator, method, donator.$$proto[method]);
+        Opal.bridge_method(target, donator, method, donator.$$proto[method]);
       }
 
       if (!bridges[id]) {
@@ -590,13 +587,13 @@
 
       if (bridged) {
         for (i = bridged.length - 1; i >= 0; i--) {
-          _bridge(bridged[i], donator);
+          Opal._bridge(bridged[i], donator);
         }
 
         bridges[donator.$__id__()] = bridged.slice();
       }
     }
-  }
+  };
 
   // The actual inclusion of a module into a class.
   //
@@ -629,7 +626,7 @@
 
     klass.$$inc.push(module);
     module.$$dep.push(klass);
-    _bridge(klass, module);
+    Opal._bridge(klass, module);
 
     // iclass
     iclass = {
@@ -662,11 +659,11 @@
       prototype[id].$$donated = module;
     }
 
-    donate_constants(module, klass);
+    Opal.donate_constants(module, klass);
   };
 
   // Boot a base class (makes instances).
-  function boot_class_alloc(id, constructor, superclass) {
+  Opal.boot_class_alloc = function(id, constructor, superclass) {
     if (superclass) {
       var alloc_proxy = function() {};
       alloc_proxy.prototype  = superclass.$$proto || superclass.prototype;
@@ -680,7 +677,7 @@
     constructor.prototype.constructor = constructor;
 
     return constructor;
-  }
+  };
 
   // Builds the class object for core classes:
   // - make the class object have a singleton class
@@ -690,7 +687,7 @@
   // @param alloc      [Function]    the constructor for the core class instances
   // @param superclass [Class alloc] the constructor of the superclass
   //
-  function boot_core_class_object(id, alloc, superclass) {
+  Opal.boot_core_class_object = function(id, alloc, superclass) {
     var superclass_constructor = function() {};
         superclass_constructor.prototype = superclass.prototype;
 
@@ -702,7 +699,7 @@
     // the singleton_class acts as the class object constructor
     var klass = new singleton_class();
 
-    setup_module_or_class_object(klass, singleton_class, superclass, alloc.prototype);
+    Opal.setup_module_or_class_object(klass, singleton_class, superclass, alloc.prototype);
 
     klass.$$alloc     = alloc;
     klass.$$name      = id;
@@ -715,7 +712,7 @@
     Opal.constants.push(id);
 
     return klass;
-  }
+  };
 
   // For performance, some core Ruby classes are toll-free bridged to their
   // native JavaScript counterparts (e.g. a Ruby Array is a JavaScript Array).
@@ -749,7 +746,7 @@
     // order important here, we have to bridge from the last ancestor to the
     // bridged class
     for (var i = ancestors.length - 1; i >= 0; i--) {
-      _bridge(constructor, ancestors[i]);
+      Opal._bridge(constructor, ancestors[i]);
     }
 
     for (var name in BasicObject_alloc.prototype) {
@@ -761,12 +758,12 @@
     }
 
     return klass;
-  }
+  };
 
   // When a source module is included into the target module, we must also copy
   // its constants to the target.
   //
-  function donate_constants(source_mod, target_mod) {
+  Opal.donate_constants = function(source_mod, target_mod) {
     var source_constants = source_mod.$$scope.constants,
         target_scope     = target_mod.$$scope,
         target_constants = target_scope.constants;
@@ -778,7 +775,7 @@
   };
 
   // Donate methods for a module.
-  function donate(module, jsid) {
+  Opal.donate = function(module, jsid) {
     var included_in = module.$$dep,
         body = module.$$proto[jsid],
         i, length, includee, dest, current,
@@ -824,7 +821,7 @@
       }
 
       if (includee.$$dep) {
-        donate(includee, jsid);
+        Opal.donate(includee, jsid);
       }
     }
   };
@@ -844,7 +841,7 @@
     }
 
     return result;
-  }
+  };
 
 
   // Method Missing
@@ -885,7 +882,7 @@
 
     for (i = 0; i < ilength; i++) {
       method_name = stubs[i];
-      stub = stub_for(method_name);
+      stub = Opal.stub_for(method_name);
 
       for (j = 0; j < jlength; j++) {
         subscriber = subscribers[j];
@@ -910,15 +907,15 @@
   // @param [String] stub stub name to add (e.g. "$foo")
   //
   Opal.add_stub_for = function(prototype, stub) {
-    var method_missing_stub = stub_for(stub);
+    var method_missing_stub = Opal.stub_for(stub);
     prototype[stub] = method_missing_stub;
-  }
+  };
 
   // Generate the method_missing stub for a given method name.
   //
   // @param [String] method_name The js-name of the method to stub (e.g. "$foo")
   //
-  function stub_for(method_name) {
+  Opal.stub_for = function(method_name) {
     function method_missing_stub() {
       // Copy any given block onto the method_missing dispatcher
       this.$method_missing.$$p = method_missing_stub.$$p;
@@ -933,7 +930,7 @@
     method_missing_stub.$$stub = true;
 
     return method_missing_stub;
-  }
+  };
 
 
   // Methods
@@ -970,7 +967,7 @@
         dispatcher = obj.$$super;
       }
       else {
-        dispatcher = find_obj_super_dispatcher(obj, jsid, current_func);
+        dispatcher = Opal.find_obj_super_dispatcher(obj, jsid, current_func);
       }
     }
 
@@ -990,7 +987,7 @@
     }
   };
 
-  function find_obj_super_dispatcher(obj, jsid, current_func) {
+  Opal.find_obj_super_dispatcher = function(obj, jsid, current_func) {
     var klass = obj.$$meta || obj.$$class;
     jsid = '$' + jsid;
 
@@ -1272,7 +1269,7 @@
     obj.$$proto[jsid] = body;
 
     if (obj.$$is_module) {
-      donate(obj, jsid);
+      Opal.donate(obj, jsid);
 
       if (obj.$$module_function) {
         Opal.defs(obj, jsid, body);
@@ -1284,7 +1281,7 @@
 
       if (bridged) {
         for (var i = bridged.length - 1; i >= 0; i--) {
-          bridge_method(bridged[i], obj, jsid, body);
+          Opal.bridge_method(bridged[i], obj, jsid, body);
         }
       }
     }
@@ -1718,7 +1715,7 @@
   Opal.current_dir     = '.'
   Opal.require_table   = {'corelib/runtime': true};
 
-  function normalize(path) {
+  Opal.normalize = function(path) {
     var parts, part, new_parts = [], SEPARATOR = '/';
 
     if (Opal.current_dir !== '.') {
@@ -1735,13 +1732,13 @@
     }
 
     return new_parts.join(SEPARATOR);
-  }
+  };
 
   Opal.loaded = function(paths) {
     var i, l, path;
 
     for (i = 0, l = paths.length; i < l; i++) {
-      path = normalize(paths[i]);
+      path = Opal.normalize(paths[i]);
 
       if (Opal.require_table[path]) {
         return;
@@ -1750,10 +1747,10 @@
       Opal.loaded_features.push(path);
       Opal.require_table[path] = true;
     }
-  }
+  };
 
   Opal.load = function(path) {
-    path = normalize(path);
+    path = Opal.normalize(path);
 
     Opal.loaded([path]);
 
@@ -1775,33 +1772,33 @@
     }
 
     return true;
-  }
+  };
 
   Opal.require = function(path) {
-    path = normalize(path);
+    path = Opal.normalize(path);
 
     if (Opal.require_table[path]) {
       return false;
     }
 
     return Opal.load(path);
-  }
+  };
 
 
   // Initialization
   // --------------
 
   // Constructors for *instances* of core objects
-  boot_class_alloc('BasicObject', BasicObject_alloc);
-  boot_class_alloc('Object',      Object_alloc,       BasicObject_alloc);
-  boot_class_alloc('Module',      Module_alloc,       Object_alloc);
-  boot_class_alloc('Class',       Class_alloc,        Module_alloc);
+  Opal.boot_class_alloc('BasicObject', BasicObject_alloc);
+  Opal.boot_class_alloc('Object',      Object_alloc,       BasicObject_alloc);
+  Opal.boot_class_alloc('Module',      Module_alloc,       Object_alloc);
+  Opal.boot_class_alloc('Class',       Class_alloc,        Module_alloc);
 
   // Constructors for *classes* of core objects
-  BasicObject = boot_core_class_object('BasicObject', BasicObject_alloc, Class_alloc);
-  _Object     = boot_core_class_object('Object',      Object_alloc,      BasicObject.constructor);
-  Module      = boot_core_class_object('Module',      Module_alloc,      _Object.constructor);
-  Class       = boot_core_class_object('Class',       Class_alloc,       Module.constructor);
+  BasicObject = Opal.boot_core_class_object('BasicObject', BasicObject_alloc, Class_alloc);
+  _Object     = Opal.boot_core_class_object('Object',      Object_alloc,      BasicObject.constructor);
+  Module      = Opal.boot_core_class_object('Module',      Module_alloc,      _Object.constructor);
+  Class       = Opal.boot_core_class_object('Class',       Class_alloc,       Module.constructor);
 
   // Fix booted classes to use their metaclass
   BasicObject.$$class = Class;

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -322,19 +322,20 @@
   Opal.boot_class_object = function(id, superclass, alloc) {
     // Grab the superclass prototype and use it to build an intermediary object
     // in the prototype chain.
-    function Superclass_alloc_proxy() {};
-    Superclass_alloc_proxy.prototype = superclass.constructor.prototype;
-    function SingletonClass_alloc() {}
-    SingletonClass_alloc.prototype = new Superclass_alloc_proxy();
+    var superclass_alloc_proxy = function() {};
+        superclass_alloc_proxy.prototype = superclass.constructor.prototype;
+        superclass_alloc_proxy.displayName = superclass.$$name;
 
-    if (id) {
-      SingletonClass_alloc.displayName = "SingletonClass_alloc("+id+")";
-    }
+    var singleton_class_alloc = function() {}
+        singleton_class_alloc.prototype = new superclass_alloc_proxy();
 
     // The built class is the only instance of its singleton_class
-    var klass = new SingletonClass_alloc();
+    var klass = new singleton_class_alloc();
 
-    Opal.setup_class_object(klass, SingletonClass_alloc, superclass, alloc.prototype);
+    Opal.setup_class_object(klass, singleton_class_alloc, superclass, alloc.prototype);
+
+    // Set a displayName for the singleton_class
+    singleton_class_alloc.displayName = "#<Class:"+(id || ("#<Class:"+klass.$$id+">"))+">";
 
     // @property $$alloc This is the constructor of instances of the current
     //                   class. Its prototype will be used for method lookup
@@ -466,6 +467,9 @@
     // @property $$id Each class is assigned a unique `id` that helps
     //                comparation and implementation of `#object_id`
     module.$$id = Opal.uid();
+
+    // Set the display name of the singleton prototype holder
+    module_constructor.displayName = "#<Class:#<Module:"+module.$$id+">>"
 
     // @property $$proto This is the prototype on which methods will be defined
     module.$$proto = module_prototype;
@@ -745,7 +749,6 @@
 
     klass.$$alloc     = alloc;
     klass.$$name      = id;
-    klass.displayName = id;
 
     // Give all instances a ref to their class
     alloc.prototype.$$class = klass;

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -182,7 +182,14 @@
     return scope[name] = value;
   };
 
-  // constant decl
+  // Constant declaration
+  //
+  // @example
+  //   FOO = :bar
+  //
+  // @param base_scope [$$scope] the current scope
+  // @param name       [String] the name of the constant
+  // @param value      [Object] the value of the constant
   Opal.cdecl = function(base_scope, name, value) {
     if ((value.$$is_class || value.$$is_module) && value.$$orig_scope == null) {
       value.$$name = name;

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -275,18 +275,8 @@
     // Create the class object (instance of Class)
     klass = Opal.boot_class_object(id, superclass, alloc);
 
-    // Name the class
-    klass.$$name = id;
-    klass.displayName = id;
-
-    // Mark the object as a class
-    klass.$$is_class = true;
-
     // Every class gets its own constant scope, inherited from current scope
     Opal.create_scope(base.$$scope, klass, id);
-
-    // Name new class directly onto current scope (Opal.Foo.Baz = klass)
-    base[id] = base.$$scope[id] = klass;
 
     if (bridged) {
       Opal.bridge(klass, alloc);

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -296,13 +296,6 @@
     return klass;
   };
 
-  // Create generic class with given superclass.
-  Opal.boot_class = function(superclass, constructor) {
-    var alloc = Opal.boot_class_alloc(null, constructor, superclass)
-
-    return Opal.boot_class_object(null, superclass, alloc);
-  };
-
   // The class object itself (as in `Class.new`)
   //
   // @param superclass [(Opal) Class] Another class object (as in `Class.new`)
@@ -563,18 +556,19 @@
     var orig_class = object.$$class,
         class_id   = "#<Class:#<" + orig_class.$$name + ":" + orig_class.$$id + ">>";
 
-    var Singleton = function() {};
-    var meta = Opal.boot_class(orig_class, Singleton);
-    meta.$$name   = class_id;
+    var singleton_alloc = Opal.boot_class_alloc(class_id, function(){}, orig_class)
+    var singleton_class = Opal.boot_class_object(null, orig_class, singleton_alloc);
 
-    meta.$$proto  = object;
-    meta.$$class  = orig_class.$$class;
-    meta.$$scope  = orig_class.$$scope;
-    meta.$$parent = orig_class;
-    meta.$$is_singleton = true;
-    meta.$$singleton_of = object;
+    singleton_class.$$name   = class_id;
 
-    return object.$$meta = meta;
+    singleton_class.$$proto  = object;
+    singleton_class.$$class  = orig_class.$$class;
+    singleton_class.$$scope  = orig_class.$$scope;
+    singleton_class.$$parent = orig_class;
+    singleton_class.$$is_singleton = true;
+    singleton_class.$$singleton_of = object;
+
+    return object.$$meta = singleton_class;
   };
 
   // Bridges a single method.

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -731,24 +731,6 @@
     return constructor;
   };
 
-  // Builds the class object for core classes:
-  // - make the class object have a singleton class
-  // - make the singleton class inherit from its parent singleton class
-  //
-  // @param id         [String]      the name of the class
-  // @param alloc      [Function]    the constructor for the core class instances
-  // @param superclass [Class alloc] the constructor of the superclass
-  //
-  Opal.boot_core_class_object = function(name, alloc, superclass_name, superclass_alloc) {
-    var superclass_name = null;
-    var klass = Opal.setup_class_object(name, alloc, superclass_name, superclass_alloc)
-
-    Opal[name] = klass;
-    Opal.constants.push(name);
-
-    return klass;
-  };
-
   // For performance, some core Ruby classes are toll-free bridged to their
   // native JavaScript counterparts (e.g. a Ruby Array is a JavaScript Array).
   //
@@ -1830,10 +1812,15 @@
   Opal.boot_class_alloc('Class',       Class_alloc,        Module_alloc);
 
   // Constructors for *classes* of core objects
-  BasicObject = Opal.boot_core_class_object('BasicObject', BasicObject_alloc, 'Class',       Class_alloc);
-  _Object     = Opal.boot_core_class_object('Object',      Object_alloc,      'BasicObject', BasicObject.constructor);
-  Module      = Opal.boot_core_class_object('Module',      Module_alloc,      'Object',      _Object.constructor);
-  Class       = Opal.boot_core_class_object('Class',       Class_alloc,       'Module',      Module.constructor);
+  Opal.BasicObject = BasicObject = Opal.setup_class_object('BasicObject', BasicObject_alloc, 'Class',       Class_alloc);
+  Opal.Object      = _Object     = Opal.setup_class_object('Object',      Object_alloc,      'BasicObject', BasicObject.constructor);
+  Opal.Module      = Module      = Opal.setup_class_object('Module',      Module_alloc,      'Object',      _Object.constructor);
+  Opal.Class       = Class       = Opal.setup_class_object('Class',       Class_alloc,       'Module',      Module.constructor);
+
+  Opal.constants.push("BasicObject");
+  Opal.constants.push("Object");
+  Opal.constants.push("Module");
+  Opal.constants.push("Class");
 
   // Fix booted classes to use their metaclass
   BasicObject.$$class = Class;

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -230,7 +230,7 @@
   //
   // @return new [Class]  or existing ruby class
   //
-  Opal.klass = function(base, superclass, id, constructor) {
+  Opal.klass = function(base, superclass, name, constructor) {
     var klass, bridged, alloc;
 
     // If base is an object, use its class
@@ -245,18 +245,18 @@
     }
 
     // Try to find the class in the current scope
-    klass = base.$$scope[id];
+    klass = base.$$scope[name];
 
     // If the class exists in the scope, then we must use that
     if (klass && klass.$$orig_scope === base.$$scope) {
       // Make sure the existing constant is a class, or raise error
       if (!klass.$$is_class) {
-        throw Opal.TypeError.$new(id + " is not a class");
+        throw Opal.TypeError.$new(name + " is not a class");
       }
 
       // Make sure existing class has same superclass
       if (superclass && klass.$$super !== superclass) {
-        throw Opal.TypeError.$new("superclass mismatch for class " + id);
+        throw Opal.TypeError.$new("superclass mismatch for class " + name);
       }
 
       return klass;
@@ -270,13 +270,13 @@
     }
 
     // If bridged the JS class will also be the alloc function
-    alloc = bridged || Opal.boot_class_alloc(id, constructor, superclass);
+    alloc = bridged || Opal.boot_class_alloc(name, constructor, superclass);
 
     // Create the class object (instance of Class)
-    klass = Opal.boot_class_object(id, superclass, alloc);
+    klass = Opal.boot_class_object(name, superclass, alloc);
 
     // Every class gets its own constant scope, inherited from current scope
-    Opal.create_scope(base.$$scope, klass, id);
+    Opal.create_scope(base.$$scope, klass, name);
 
     if (bridged) {
       Opal.bridge(klass, alloc);
@@ -410,23 +410,23 @@
   // @param  id [String] the name of the new (or existing) module
   // @return [Module]
   //
-  Opal.module = function(base, id) {
+  Opal.module = function(base, name) {
     var module;
 
     if (!base.$$is_class && !base.$$is_module) {
       base = base.$$class;
     }
 
-    if ($hasOwn.call(base.$$scope, id)) {
-      module = base.$$scope[id];
+    if ($hasOwn.call(base.$$scope, name)) {
+      module = base.$$scope[name];
 
       if (!module.$$is_module && module !== _Object) {
-        throw Opal.TypeError.$new(id + " is not a module");
+        throw Opal.TypeError.$new(name + " is not a module");
       }
     }
     else {
       module = Opal.module_allocate();
-      Opal.create_scope(base.$$scope, module, id);
+      Opal.create_scope(base.$$scope, module, name);
     }
 
     return module;
@@ -705,15 +705,15 @@
   };
 
   // Boot a base class (makes instances).
-  Opal.boot_class_alloc = function(id, constructor, superclass) {
+  Opal.boot_class_alloc = function(name, constructor, superclass) {
     if (superclass) {
       var alloc_proxy = function() {};
       alloc_proxy.prototype  = superclass.$$proto || superclass.prototype;
       constructor.prototype = new alloc_proxy();
     }
 
-    if (id) {
-      constructor.displayName = id+'_alloc';
+    if (name) {
+      constructor.displayName = name+'_alloc';
     }
 
     constructor.prototype.constructor = constructor;

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -310,6 +310,28 @@
     return klass;
   };
 
+  // Boot a base class (makes instances).
+  //
+  // @param name [String,null] the class name
+  // @param constructor [JS.Function] the class' instances constructor/alloc function
+  // @param superclass  [Class,null] the superclass object
+  // @return [JS.Function] the consturctor holding the prototype for the class' instances
+  Opal.boot_class_alloc = function(name, constructor, superclass) {
+    if (superclass) {
+      var alloc_proxy = function() {};
+      alloc_proxy.prototype  = superclass.$$proto || superclass.prototype;
+      constructor.prototype = new alloc_proxy();
+    }
+
+    if (name) {
+      constructor.displayName = name+'_alloc';
+    }
+
+    constructor.prototype.constructor = constructor;
+
+    return constructor;
+  };
+
   // The class object itself (as in `Class.new`)
   //
   // @param superclass [Class] Another class object (as in `Class.new`)
@@ -708,28 +730,6 @@
     }
 
     Opal.donate_constants(module, klass);
-  };
-
-  // Boot a base class (makes instances).
-  //
-  // @param name [String,null] the class name
-  // @param constructor [JS.Function] the class' instances constructor/alloc function
-  // @param superclass  [Class,null] the superclass object
-  // @return [JS.Function] the consturctor holding the prototype for the class' instances
-  Opal.boot_class_alloc = function(name, constructor, superclass) {
-    if (superclass) {
-      var alloc_proxy = function() {};
-      alloc_proxy.prototype  = superclass.$$proto || superclass.prototype;
-      constructor.prototype = new alloc_proxy();
-    }
-
-    if (name) {
-      constructor.displayName = name+'_alloc';
-    }
-
-    constructor.prototype.constructor = constructor;
-
-    return constructor;
   };
 
   // For performance, some core Ruby classes are toll-free bridged to their

--- a/opal/corelib/string.rb
+++ b/opal/corelib/string.rb
@@ -533,16 +533,11 @@ class String < `String`
 
   def include?(other)
     %x{
-      if (other.$$is_string) {
-        return self.indexOf(other) !== -1;
+      if (!other.$$is_string) {
+        #{other = Opal.coerce_to(other, String, :to_str)}
       }
+      return self.indexOf(other) !== -1;
     }
-
-    unless other.respond_to? :to_str
-      raise TypeError, "no implicit conversion of #{other.class} into String"
-    end
-
-    `self.indexOf(#{other.to_str}) !== -1`
   end
 
   def index(search, offset = undefined)


### PR DESCRIPTION
_**DO NOT MERGE YET** Would like to merge this after 0.9 is out, but maybe I'll cherry-pick single commits before that._

The main idea is to cleanup module and class creation and also improve the debugging experience (e.g. using `displayName`). **`Module.new` is already implemented in terms of `.allocate` + `#initialize`,** and the runtime helper `Opal.module()` uses the same code path. `Class.new` needs more preparatory work tho.

_**Side note:** even if all the functions in the runtime are now all available they're still considered internal, I switched style just to simplify refactoring and reading._



