### PR TITLE
Struct fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Whitespace conventions:
 - Fix `Array#to_n`, `Hash#to_n`, `Struct#to_n` when the object contains native objects (#1249, #1256)
 - `break` semantics are now correct, except for the case in which a lambda containing a `break` is passed to a `yield` (#1250)
 - Avoid double "/" when `Opal::Sprockets.javascript_include_tag` receives a prefix with a trailing slash.
+- Fix `Struct.new` to be almost compatible with Rubyspec (#1251)
 
 
 

--- a/opal/corelib/helpers.rb
+++ b/opal/corelib/helpers.rb
@@ -113,4 +113,14 @@ module Opal
 
     name
   end
+
+  def self.const_name!(const_name)
+    const_name = Opal.coerce_to!(const_name, String, :to_str)
+
+    if const_name[0] != const_name[0].upcase
+      raise NameError, "wrong constant name #{const_name}"
+    end
+
+    const_name
+  end
 end

--- a/opal/corelib/module.rb
+++ b/opal/corelib/module.rb
@@ -456,7 +456,7 @@ class Module
           result;
 
       block.$$s = null;
-      result = block.call(self);
+      result = block.apply(self, [self]);
       block.$$s = old;
 
       return result;

--- a/opal/corelib/struct.rb
+++ b/opal/corelib/struct.rb
@@ -74,11 +74,11 @@ class Struct
   end
 
   def initialize(*args)
-    if args.length > members.length
+    if args.length > self.class.members.length
       raise ArgumentError, "struct size differs"
     end
 
-    members.each_with_index {|name, index|
+    self.class.members.each_with_index {|name, index|
       self[name] = args[index]
     }
   end
@@ -93,10 +93,10 @@ class Struct
 
   def [](name)
     if Integer === name
-      raise IndexError, "offset #{name} too small for struct(size:#{members.size})" if name < -members.size
-      raise IndexError, "offset #{name} too large for struct(size:#{members.size})" if name >= members.size
+      raise IndexError, "offset #{name} too small for struct(size:#{self.class.members.size})" if name < -self.class.members.size
+      raise IndexError, "offset #{name} too large for struct(size:#{self.class.members.size})" if name >= self.class.members.size
 
-      name = members[name]
+      name = self.class.members[name]
     elsif String === name
       %x{
         if(!self.$$data.hasOwnProperty(name)) {
@@ -113,12 +113,12 @@ class Struct
 
   def []=(name, value)
     if Integer === name
-      raise IndexError, "offset #{name} too small for struct(size:#{members.size})" if name < -members.size
-      raise IndexError, "offset #{name} too large for struct(size:#{members.size})" if name >= members.size
+      raise IndexError, "offset #{name} too small for struct(size:#{self.class.members.size})" if name < -self.class.members.size
+      raise IndexError, "offset #{name} too large for struct(size:#{self.class.members.size})" if name >= self.class.members.size
 
-      name = members[name]
+      name = self.class.members[name]
     elsif String === name
-      raise NameError.new("no member '#{name}' in struct", name) unless members.include?(name.to_sym)
+      raise NameError.new("no member '#{name}' in struct", name) unless self.class.members.include?(name.to_sym)
     else
       raise TypeError, "no implicit conversion of #{name.class} into Integer"
     end
@@ -202,25 +202,25 @@ class Struct
   def each
     return enum_for(:each){self.size} unless block_given?
 
-    members.each { |name| yield self[name] }
+    self.class.members.each { |name| yield self[name] }
     self
   end
 
   def each_pair
     return enum_for(:each_pair){self.size} unless block_given?
 
-    members.each { |name| yield [name, self[name]] }
+    self.class.members.each { |name| yield [name, self[name]] }
     self
   end
 
   def length
-    members.length
+    self.class.members.length
   end
 
   alias size length
 
   def to_a
-    members.map { |name| self[name] }
+    self.class.members.map { |name| self[name] }
   end
 
   alias values to_a
@@ -228,7 +228,7 @@ class Struct
   def inspect
     result = "#<struct "
 
-    if self.class == Struct
+    if Struct === self && self.class.name
       result += "#{self.class} "
     end
 
@@ -244,7 +244,7 @@ class Struct
   alias to_s inspect
 
   def to_h
-    members.inject({}) {|h, name| h[name] = self[name]; h}
+    self.class.members.inject({}) {|h, name| h[name] = self[name]; h}
   end
 
   def values_at(*args)

--- a/spec/filters/bugs/module.rb
+++ b/spec/filters/bugs/module.rb
@@ -161,7 +161,6 @@ opal_filter "Module" do
   fails "Module#module_eval converts non string eval-string to string using to_str"
   fails "Module#module_eval defines constants in the receiver's scope"
   fails "Module#module_eval evaluates a given string in the context of self"
-  fails "Module#module_eval passes the module as the first argument of the block"
   fails "Module#module_eval raises a TypeError when the given eval-string can't be converted to string using to_str"
   fails "Module#module_eval raises a TypeError when the given filename can't be converted to string using to_str"
   fails "Module#module_eval resolves constants in the caller scope ignoring send"

--- a/spec/filters/bugs/struct.rb
+++ b/spec/filters/bugs/struct.rb
@@ -3,5 +3,4 @@ opal_filter "Struct" do
   fails "Struct#initialize can be overriden"
   fails "Struct#inspect returns a string representation of some kind"
   fails "Struct#members does not override the instance accessor method"
-  fails "Struct.new with a block passes same struct class to the block"
 end

--- a/spec/filters/bugs/struct.rb
+++ b/spec/filters/bugs/struct.rb
@@ -3,13 +3,5 @@ opal_filter "Struct" do
   fails "Struct#initialize can be overriden"
   fails "Struct#inspect returns a string representation of some kind"
   fails "Struct#members does not override the instance accessor method"
-  fails "Struct.new calls to_str on its first argument (constant name)"
-  fails "Struct.new creates a new anonymous class with nil first argument"
-  fails "Struct.new does not create a constant with symbol as first argument"
-  fails "Struct.new fails with invalid constant name as first argument"
-  fails "Struct.new on subclasses creates a constant in subclass' namespace"
-  fails "Struct.new on subclasses fails with too many arguments"
-  fails "Struct.new raises a TypeError if object doesn't respond to to_sym"
-  fails "Struct.new raises a TypeError if object is not a Symbol"
   fails "Struct.new with a block passes same struct class to the block"
 end

--- a/spec/filters/bugs/struct.rb
+++ b/spec/filters/bugs/struct.rb
@@ -1,6 +1,4 @@
 opal_filter "Struct" do
   fails "Struct#hash returns the same fixnum for structs with the same content"
-  fails "Struct#initialize can be overriden"
   fails "Struct#inspect returns a string representation of some kind"
-  fails "Struct#members does not override the instance accessor method"
 end

--- a/spec/filters/unsupported/struct.rb
+++ b/spec/filters/unsupported/struct.rb
@@ -1,3 +1,6 @@
 opal_filter "Struct" do
   fails "Struct#initialize is private"
+  fails "Struct.new does not create a constant with symbol as first argument"
+  fails "Struct.new fails with invalid constant name as first argument" # this invalid name gets interpreted as a struct member
+  fails "Struct.new raises a TypeError if object is not a Symbol"
 end


### PR DESCRIPTION
There's a difference between `Struct` implementation in opal and MRI:
``` ruby
A = Struct.new(:a, :b)
puts A.new

B = Struct.new('a', :b)
puts B.new
```
For opal:
```
#<struct Struct::A a=nil, b=nil>
#<struct Struct::B a=nil, b=nil>
```
For MRI
```
#<struct A a=nil, b=nil>
test.rb:4:in `new': identifier a needs to be constant (NameError)
```
When the first argument of `Struct.new` is a String, MRI *always* tries to "convert" it to a constant name. In opal we have no difference between `String`/`Symbol`.