### PR TITLE
Return original value if it cannot be nativized

### DIFF
--- a/spec/opal/stdlib/native/hash_spec.rb
+++ b/spec/opal/stdlib/native/hash_spec.rb
@@ -40,5 +40,12 @@ describe Hash do
       native = obj.to_n
       `#{native}.a_key.key`.should == 1
     end
+
+    it 'passes Ruby objects that cannot be converted' do
+      object = Object.new
+      hash = { foo: object }
+      native = hash.to_n
+      expect(`#{native}.foo`).to eq object
+    end
   end
 end

--- a/stdlib/native.rb
+++ b/stdlib/native.rb
@@ -24,7 +24,7 @@ module Native
     }
   end
 
-  def self.try_convert(value)
+  def self.try_convert(value, default=nil)
     %x{
       if (#{native?(value)}) {
         return #{value};
@@ -33,7 +33,7 @@ module Native
         return #{value.to_n};
       }
       else {
-        return value;
+        return #{default};
       }
     }
   end
@@ -472,7 +472,7 @@ class Struct
     result = `{}`
 
     each_pair {|name, value|
-      `#{result}[#{name}] = #{Native.try_convert(value)}`
+      `#{result}[#{name}] = #{Native.try_convert(value, value)}`
     }
 
     result
@@ -488,7 +488,7 @@ class Array
       for (var i = 0, length = self.length; i < length; i++) {
         var obj = self[i];
 
-        result.push(#{Native.try_convert(`obj`)});
+        result.push(#{Native.try_convert(`obj`, `obj`)});
       }
 
       return result;
@@ -574,7 +574,7 @@ class Hash
           value = key.value;
         }
 
-        result[key] = #{Native.try_convert(`value`)};
+        result[key] = #{Native.try_convert(`value`, `value`)};
       }
 
       return result;

--- a/stdlib/native.rb
+++ b/stdlib/native.rb
@@ -33,7 +33,7 @@ module Native
         return #{value.to_n};
       }
       else {
-        return nil;
+        return value;
       }
     }
   end


### PR DESCRIPTION
Prior to #1249, `{ foo: MyObject.new }.to_n` returned the object value, but now it returns `nil` if `MyObject#to_n` is not defined. This occurred because of the move to `Native.try_convert` for the conversion (which just lets native JS objects pass through).

I think using that method was a great move, but I don't think `nil` as a return value for arbitrary Ruby objects makes sense. If I understand the intent correctly, the idea is to always return a native JS value. The original Ruby object may be closer to the JS object you want than `nil`. That is, I can think of a lot of ways to use the original Ruby object from JS, but if I get `nil` in JS, I probably actually wanted `null`.