### PR TITLE
Fix Module#name when constant was created using Opal.cdecl (constant declare) like ChildClass = Class.new(BaseClass).

### DIFF
--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -208,6 +208,9 @@
     if ((value.$$is_class || value.$$is_module) && value.$$orig_scope == null) {
       value.$$name = name;
       value.$$orig_scope = base_scope;
+      // Here we should explicitly set a base module
+      // (a module where the constant was initially defined)
+      value.$$base_module = base_scope.base;
       base_scope.constructor[name] = value;
     }
 

--- a/spec/opal/core/module/name_spec.rb
+++ b/spec/opal/core/module/name_spec.rb
@@ -5,6 +5,8 @@ module ModuleNameSpec
     class B
     end
   end
+
+  Subclass = Class.new(Hash)
 end
 
 describe "Module#name" do
@@ -31,5 +33,9 @@ describe "Module#name" do
   it "should join nested classes using '::'" do
     ModuleNameSpec::A.name.should == "ModuleNameSpec::A"
     ModuleNameSpec::A::B.name.should == "ModuleNameSpec::A::B"
+  end
+
+  it 'returns correct constant name when created using Const = Class.new(Superclass)' do
+    ModuleNameSpec::Subclass.name.should == "ModuleNameSpec::Subclass"
   end
 end


### PR DESCRIPTION
Fixes #1257