### PR TITLE
Allow for cli-runners extensibility

### DIFF
--- a/lib/opal/cli.rb
+++ b/lib/opal/cli.rb
@@ -71,14 +71,12 @@ module Opal
     end
 
     def runner
-      @runner ||= case @runner_type
-                  when :server;      CliRunners::Server.new(output, port)
-                  when :nodejs;      CliRunners::Nodejs.new(output)
-                  when :phantomjs;   CliRunners::Phantomjs.new(output)
-                  when :applescript; CliRunners::AppleScript.new(output)
-                  when :nashorn;     CliRunners::Nashorn.new(output)
-                  else raise ArgumentError, @runner_type.inspect
-                  end
+      @runner ||= begin
+        const_name = @runner_type.to_s.capitalize
+        CliRunners.const_defined?(const_name) or
+          raise ArgumentError, "unknown runner: #{@runner_type.inspect}"
+        CliRunners.const_get(const_name).new(output: output, port: port)
+      end
     end
 
     def run_code

--- a/lib/opal/cli_runners.rb
+++ b/lib/opal/cli_runners.rb
@@ -1,4 +1,17 @@
 module Opal
+  # `Opal::CliRunners` is the namespace in which JavaScript runners can be
+  # defined for use by `Opal::CLI`. The API for classes defined under
+  # `CliRunners` is the following.
+  #
+  # - The #initialize method takes an `Hash` containing an `output:` object.
+  #   Additional keys can be safely ignored and can be specific to a particular
+  #   runner, e.g. the `CliRunners::Server` runner will accepts a `port:`
+  #   option.
+  # - The runner instance will then be called via `#run(compiled_source, argv)`:
+  #   - `compiled_source` is a string of JavaScript code
+  #   - `argv` is the arguments vector coming from the CLI that is being
+  #     forwarded to the program
+  #
   module CliRunners
     class RunnerError < StandardError
     end

--- a/lib/opal/cli_runners.rb
+++ b/lib/opal/cli_runners.rb
@@ -5,7 +5,7 @@ module Opal
   end
 end
 
-require 'opal/cli_runners/apple_script'
+require 'opal/cli_runners/applescript'
 require 'opal/cli_runners/phantomjs'
 require 'opal/cli_runners/nodejs'
 require 'opal/cli_runners/server'

--- a/lib/opal/cli_runners/applescript.rb
+++ b/lib/opal/cli_runners/applescript.rb
@@ -3,7 +3,7 @@ require 'opal/cli_runners'
 module Opal
   module CliRunners
     class Applescript
-      def initialize(output)
+      def initialize(output:, **)
         unless system('which osalang > /dev/null')
           raise MissingJavaScriptSupport, 'JavaScript Automation is only supported by OS X Yosemite and above.'
         end

--- a/lib/opal/cli_runners/applescript.rb
+++ b/lib/opal/cli_runners/applescript.rb
@@ -2,7 +2,7 @@ require 'opal/cli_runners'
 
 module Opal
   module CliRunners
-    class AppleScript
+    class Applescript
       def initialize(output)
         unless system('which osalang > /dev/null')
           raise MissingJavaScriptSupport, 'JavaScript Automation is only supported by OS X Yosemite and above.'

--- a/lib/opal/cli_runners/nashorn.rb
+++ b/lib/opal/cli_runners/nashorn.rb
@@ -4,7 +4,7 @@ require 'opal/paths'
 module Opal
   module CliRunners
     class Nashorn
-      def initialize(output)
+      def initialize(output:, **)
         @output ||= output
       end
       attr_reader :output, :exit_status

--- a/lib/opal/cli_runners/nodejs.rb
+++ b/lib/opal/cli_runners/nodejs.rb
@@ -4,7 +4,7 @@ require 'opal/paths'
 module Opal
   module CliRunners
     class Nodejs
-      def initialize(output)
+      def initialize(output:, **)
         @output ||= output
       end
       attr_reader :output, :exit_status

--- a/lib/opal/cli_runners/phantomjs.rb
+++ b/lib/opal/cli_runners/phantomjs.rb
@@ -3,6 +3,8 @@ require 'shellwords'
 module Opal
   module CliRunners
     class Phantomjs
+      SCRIPT_PATH = File.expand_path('../phantom.js', __FILE__)
+
       def initialize(output = $stdout)
         @output = output
       end
@@ -20,8 +22,7 @@ module Opal
       end
 
       def command
-        script_path = File.expand_path('../phantom.js', __FILE__)
-        "phantomjs #{script_path.shellescape}"
+        "phantomjs #{SCRIPT_PATH.shellescape}"
       end
     end
   end

--- a/lib/opal/cli_runners/phantomjs.rb
+++ b/lib/opal/cli_runners/phantomjs.rb
@@ -5,7 +5,7 @@ module Opal
     class Phantomjs
       SCRIPT_PATH = File.expand_path('../phantom.js', __FILE__)
 
-      def initialize(output = $stdout)
+      def initialize(output: $stdout, **)
         @output = output
       end
       attr_reader :output, :exit_status

--- a/lib/opal/cli_runners/server.rb
+++ b/lib/opal/cli_runners/server.rb
@@ -3,7 +3,7 @@ require 'opal/cli_runners'
 module Opal
   module CliRunners
     class Server
-      def initialize(output, port)
+      def initialize(output:, port: 3000, **)
         @output ||= output || $stdout
         @port = port
       end


### PR DESCRIPTION
This should allow 3rd party to define additional runners. E.g opal-chakra
could implement a runner based on Microsoft Edge JavaScript engine.

Maybe in the future a rack-like `#call` based API and a register of runners
could make sense to allow for super-easy runner definition (e.g. a `Proc`).

I'll merge if the CI is green, any code-review is appreciated though. :)