### PR TITLE
Allow promises to have multiple then/rescue/always

### DIFF
--- a/spec/opal/stdlib/promise/always_spec.rb
+++ b/spec/opal/stdlib/promise/always_spec.rb
@@ -19,12 +19,23 @@ describe 'Promise#always' do
     x.should == 3
   end
 
-  it 'raises an exception when the promise has already been chained' do
+  it 'can be called multiple times on resolved promises' do
     p = Promise.value(2)
-    p.then {}
+    x = 1
+    p.then { x += 1 }
+    p.fail { x += 2 }
+    p.always { x += 3 }
 
-    proc {
-      p.always {}
-    }.should raise_error(ArgumentError)
+    x.should == 5
+  end
+
+  it 'can be called multiple times on rejected promises' do
+    p = Promise.error(2)
+    x = 1
+    p.then { x += 1 }
+    p.fail { x += 2 }
+    p.always { x += 3 }
+
+    x.should == 6
   end
 end

--- a/spec/opal/stdlib/promise/always_spec.rb
+++ b/spec/opal/stdlib/promise/always_spec.rb
@@ -38,4 +38,12 @@ describe 'Promise#always' do
 
     x.should == 6
   end
+
+  it 'raises with always! if a promise has already been chained' do
+    p = Promise.new
+
+    p.then! {}
+
+    proc { p.always! {} }.should raise_error(ArgumentError)
+  end
 end

--- a/spec/opal/stdlib/promise/rescue_spec.rb
+++ b/spec/opal/stdlib/promise/rescue_spec.rb
@@ -33,12 +33,13 @@ describe 'Promise#rescue' do
     x.should == 23
   end
 
-  it 'raises an exception when the promise has already been chained' do
-    p = Promise.value(2)
-    p.then {}
+  it 'can be called multiple times on the same promise' do
+    p = Promise.error(2)
+    x = 1
+    p.then { x += 1 }
+    p.rescue { x += 3 }
+    p.rescue { x += 3 }
 
-    proc {
-      p.rescue {}
-    }.should raise_error(ArgumentError)
+    x.should == 7
   end
 end

--- a/spec/opal/stdlib/promise/rescue_spec.rb
+++ b/spec/opal/stdlib/promise/rescue_spec.rb
@@ -42,4 +42,12 @@ describe 'Promise#rescue' do
 
     x.should == 7
   end
+
+  it 'raises with rescue! if a promise has already been chained' do
+    p = Promise.new
+
+    p.then! {}
+
+    proc { p.rescue! {} }.should raise_error(ArgumentError)
+  end
 end

--- a/spec/opal/stdlib/promise/then_spec.rb
+++ b/spec/opal/stdlib/promise/then_spec.rb
@@ -61,6 +61,14 @@ describe 'Promise#then' do
     x.should == 3
   end
 
+  it 'raises with then! if a promise has already been chained' do
+    p = Promise.new
+
+    p.then! {}
+
+    proc { p.then! {} }.should raise_error(ArgumentError)
+  end
+
   it 'should pass a delayed falsy value' do
     p = Promise.new.resolve(5).then { nil }
 

--- a/spec/opal/stdlib/promise/then_spec.rb
+++ b/spec/opal/stdlib/promise/then_spec.rb
@@ -52,13 +52,13 @@ describe 'Promise#then' do
     x.should be_kind_of(RuntimeError)
   end
 
-  it 'raises an exception when the promise has already been chained' do
+  it 'allows then to be called multiple times' do
     p = Promise.value(2)
-    p.then {}
+    x = 1
+    p.then { x += 1 }
+    p.then { x += 1 }
 
-    proc {
-      p.then {}
-    }.should raise_error(ArgumentError)
+    x.should == 3
   end
 
   it 'should pass a delayed falsy value' do

--- a/spec/opal/stdlib/promise/trace_spec.rb
+++ b/spec/opal/stdlib/promise/trace_spec.rb
@@ -40,4 +40,12 @@ describe 'Promise#trace' do
 
     x.should == 6
   end
+
+  it 'raises with trace! if a promise has already been chained' do
+    p = Promise.new
+
+    p.then! {}
+
+    proc { p.trace! {} }.should raise_error(ArgumentError)
+  end
 end

--- a/spec/opal/stdlib/promise/trace_spec.rb
+++ b/spec/opal/stdlib/promise/trace_spec.rb
@@ -40,13 +40,4 @@ describe 'Promise#trace' do
 
     x.should == 6
   end
-
-  it 'raises an exception when the promise has already been chained' do
-    p = Promise.value(2)
-    p.then {}
-
-    proc {
-      p.trace {}
-    }.should raise_error(ArgumentError)
-  end
 end

--- a/stdlib/promise.rb
+++ b/stdlib/promise.rb
@@ -268,24 +268,55 @@ class Promise
     self ^ Promise.new(success: block)
   end
 
+  def then!(&block)
+    there_can_be_only_one!
+    self.then(&block)
+  end
+
   alias do then
+  alias do! then!
 
   def fail(&block)
     self ^ Promise.new(failure: block)
   end
 
+  def fail!(&block)
+    there_can_be_only_one!
+    fail(&block)
+  end
+
   alias rescue fail
   alias catch fail
+  alias rescue! fail!
+  alias catch! fail!
 
   def always(&block)
     self ^ Promise.new(always: block)
   end
 
+  def always!(&block)
+    there_can_be_only_one!
+    always(&block)
+  end
+
   alias finally always
   alias ensure always
+  alias finally! always!
+  alias ensure! always!
 
   def trace(depth = nil, &block)
     self ^ Trace.new(depth, block)
+  end
+
+  def trace!(*args, &block)
+    there_can_be_only_one!
+    trace(*args, &block)
+  end
+
+  def there_can_be_only_one!
+    if @next.any?
+      raise ArgumentError, 'a promise has already been chained'
+    end
   end
 
   def inspect


### PR DESCRIPTION
According to the A+ promise specification, ["`then` may be called multiple times on the same promise"](https://promisesaplus.com/#point-36). Since `fail` and `always` are just `then` with different success/failure semantics, I added the same functionality to them, as well.

@wied03, @meh, and I spoke about supporting this in the past. Last I heard, @meh was still contemplating the change. I probably should've put this in before the 0.9 release, but this PR is backwards-compatible with the current release.