### PR TITLE
Fix JS Truthy Optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.9.1 (unreleased)
 
 * Backport rack2 compatibility from #1260
+* Fixed issue with JS nil return paths being treated as true (#1274)
 
 
 ## 0.9.0 2015-12-20

--- a/lib/opal/nodes/base.rb
+++ b/lib/opal/nodes/base.rb
@@ -22,6 +22,10 @@ module Opal
           end
         end
       end
+      
+      def self.truthy_optimize?
+        false
+      end
 
       attr_reader :compiler, :type
 

--- a/lib/opal/nodes/helpers.rb
+++ b/lib/opal/nodes/helpers.rb
@@ -113,12 +113,17 @@ module Opal
       def js_truthy_optimize(sexp)
         if sexp.type == :call
           mid = sexp[2]
-
-          if mid == :block_given?
-            expr(sexp)
-          elsif Compiler::COMPARE.include? mid.to_s
-            expr(sexp)
-          elsif mid == :"=="
+          call_type = (call = sexp[1]) && call.type
+          
+          # TODO: Put this in a constant array somewhere?
+          optimize_call_types = [:true, :false, :int, :float]
+          
+          operator_based_call = Compiler::COMPARE.include? mid.to_s
+          
+          # Method calls on 'optimize_call_types' should never be optimized
+          if (optimize_call_types.include?(call_type) && operator_based_call) || 
+            mid == :block_given? ||
+            mid == :"=="
             expr(sexp)
           end
         elsif [:lvar, :self].include? sexp.type

--- a/lib/opal/nodes/helpers.rb
+++ b/lib/opal/nodes/helpers.rb
@@ -113,15 +113,15 @@ module Opal
       def js_truthy_optimize(sexp)
         if sexp.type == :call
           mid = sexp[2]
-          call_type = (call = sexp[1]) && call.type
+          call_handler = (call = sexp[1]) && compiler.handlers[call.type]
           
-          # TODO: Put this in a constant array somewhere?
-          optimize_call_types = [:true, :false, :int, :float]
+          # TODO: Other option is to put a truthy_optimize? method on the base node that returns false and override it in ValueNode/NumericNode as true
+          optimize_call_handlers = [ValueNode, NumericNode]
           
           operator_based_call = Compiler::COMPARE.include? mid.to_s
           
-          # Method calls on 'optimize_call_types' should never be optimized
-          if (optimize_call_types.include?(call_type) && operator_based_call) || 
+          # Method calls on 'optimize_call_handlers' should never be optimized
+          if (optimize_call_handlers.include?(call_handler) && operator_based_call) || 
             mid == :block_given? ||
             mid == :"=="
             expr(sexp)

--- a/lib/opal/nodes/helpers.rb
+++ b/lib/opal/nodes/helpers.rb
@@ -121,7 +121,7 @@ module Opal
           operator_based_call = Compiler::COMPARE.include? mid.to_s
           
           # Method calls on 'optimize_call_handlers' should never be optimized
-          if (optimize_call_handlers.include?(call_handler) && operator_based_call) || 
+          if (operator_based_call && optimize_call_handlers.include?(call_handler)) || 
             mid == :block_given? ||
             mid == :"=="
             expr(sexp)

--- a/lib/opal/nodes/literal.rb
+++ b/lib/opal/nodes/literal.rb
@@ -8,6 +8,10 @@ module Opal
       def compile
         push type.to_s
       end
+      
+      def self.truthy_optimize?
+        true
+      end
     end
 
     class NumericNode < Base
@@ -18,6 +22,10 @@ module Opal
       def compile
         push value.to_s
         wrap '(', ')' if recv?
+      end
+      
+      def self.truthy_optimize?
+        true
       end
     end
 

--- a/spec/lib/compiler_spec.rb
+++ b/spec/lib/compiler_spec.rb
@@ -136,7 +136,7 @@ describe Opal::Compiler do
   
   describe 'truthy check' do
     context 'no parentheses' do
-      context 'with operators in expression' do
+      context 'with operators' do
         it 'excludes nil check for primitives' do
           expect_compiled('foo = 42 if 2 > 3').to include('if ($rb_gt(2, 3))')
           expect_compiled('foo = 42 if 2.5 > 3.5').to include('if ($rb_gt(2.5, 3.5))')
@@ -172,11 +172,15 @@ describe Opal::Compiler do
         end
       end
     
-      context 'without operators in expression' do
+      context 'without operators' do
         it 'adds nil check for primitives' do
           expect_compiled('foo = 42 if 2').to include('if ((($a = 2) !== nil && (!$a.$$is_boolean || $a == true)))')
           expect_compiled('foo = 42 if 2.5').to include('if ((($a = 2.5) !== nil && (!$a.$$is_boolean || $a == true)))')
           expect_compiled('foo = 42 if true').to include('if ((($a = true) !== nil && (!$a.$$is_boolean || $a == true)))')
+        end
+        
+        it 'adds nil check for boolean method calls' do
+          expect_compiled('foo = 42 if true.something').to include('if ((($a = true.$something()) !== nil && (!$a.$$is_boolean || $a == true)))')
         end
       
         it 'adds nil check for strings' do
@@ -194,7 +198,7 @@ describe Opal::Compiler do
     end
     
     context 'parentheses' do
-      context 'with operators in expression' do
+      context 'with operators' do
         it 'adds nil check for primitives' do
           expect_compiled('foo = 42 if (2 > 3)').to include('if ((($a = ($rb_gt(2, 3))) !== nil && (!$a.$$is_boolean || $a == true)))')
           expect_compiled('foo = 42 if (2.5 > 3.5)').to include('if ((($a = ($rb_gt(2.5, 3.5))) !== nil && (!$a.$$is_boolean || $a == true)))')
@@ -221,11 +225,15 @@ describe Opal::Compiler do
         end
       end
     
-      context 'without operators in expression' do
+      context 'without operators' do
         it 'adds nil check for primitives' do
           expect_compiled('foo = 42 if (2)').to include('if ((($a = (2)) !== nil && (!$a.$$is_boolean || $a == true)))')
           expect_compiled('foo = 42 if (2.5)').to include('if ((($a = (2.5)) !== nil && (!$a.$$is_boolean || $a == true)))')
           expect_compiled('foo = 42 if (true)').to include('if ((($a = (true)) !== nil && (!$a.$$is_boolean || $a == true)))')
+        end
+        
+        it 'adds nil check for boolean method calls' do
+          expect_compiled('foo = 42 if (true.something)').to include('if ((($a = (true.$something())) !== nil && (!$a.$$is_boolean || $a == true)))')
         end
       
         it 'adds nil check for strings' do

--- a/spec/lib/compiler_spec.rb
+++ b/spec/lib/compiler_spec.rb
@@ -148,7 +148,7 @@ describe Opal::Compiler do
         end
       
         it 'adds nil check for strings' do
-          expect_compiled('foo = 42 if "test" > "bar"').to include('we need a nil check!')        
+          expect_compiled('foo = 42 if "test" > "bar"').to include('if ((($a = $rb_gt("test", "bar")) !== nil && (!$a.$$is_boolean || $a == true)))')
         end
         
         it 'specifically == excludes nil check for strings' do
@@ -156,7 +156,7 @@ describe Opal::Compiler do
         end
       
         it 'adds nil check for lvars' do
-          expect_compiled("bar = 4\nfoo = 42 if bar > 5").to include('we need a nil check!')          
+          expect_compiled("bar = 4\nfoo = 42 if bar > 5").to include('if ((($a = $rb_gt(bar, 5)) !== nil && (!$a.$$is_boolean || $a == true)))')
         end
         
         it 'specifically == excludes nil check for lvars' do
@@ -164,7 +164,7 @@ describe Opal::Compiler do
         end
       
         it 'adds nil check for constants' do
-          expect_compiled("foo = 42 if Test > 4").to include('we need a nil check!')
+          expect_compiled("foo = 42 if Test > 4").to include("if ((($a = $rb_gt($scope.get('Test'), 4)) !== nil && (!$a.$$is_boolean || $a == true))) ")
         end
         
         it 'specifically == excludes nil check for constants' do
@@ -199,22 +199,25 @@ describe Opal::Compiler do
           expect_compiled('foo = 42 if (2 > 3)').to include('if ((($a = ($rb_gt(2, 3))) !== nil && (!$a.$$is_boolean || $a == true)))')
           expect_compiled('foo = 42 if (2.5 > 3.5)').to include('if ((($a = ($rb_gt(2.5, 3.5))) !== nil && (!$a.$$is_boolean || $a == true)))')
           expect_compiled('foo = 42 if (true > false)').to include('if ((($a = ($rb_gt(true, false))) !== nil && (!$a.$$is_boolean || $a == true)))')
-          fail 'add equals'
+          
+          expect_compiled('foo = 42 if (2 == 3)').to include("if ((($a = ((2)['$=='](3))) !== nil && (!$a.$$is_boolean || $a == true)))")
+          expect_compiled('foo = 42 if (2.5 == 3.5)').to include("if ((($a = ((2.5)['$=='](3.5))) !== nil && (!$a.$$is_boolean || $a == true)))")
+          expect_compiled('foo = 42 if (true == false)').to include("if ((($a = (true['$=='](false))) !== nil && (!$a.$$is_boolean || $a == true)))")
         end
       
         it 'adds nil check for strings' do
           expect_compiled('foo = 42 if ("test" > "bar")').to include('if ((($a = ($rb_gt("test", "bar"))) !== nil && (!$a.$$is_boolean || $a == true)))')
-          fail 'add equals'
+          expect_compiled('foo = 42 if ("test" == "bar")').to include("if ((($a = (\"test\"['$=='](\"bar\"))) !== nil && (!$a.$$is_boolean || $a == true)))")
         end
       
         it 'adds nil check for lvars' do
           expect_compiled("bar = 4\nfoo = 42 if (bar > 5)").to include('if ((($a = ($rb_gt(bar, 5))) !== nil && (!$a.$$is_boolean || $a == true)))')
-          fail 'add equals'
+          expect_compiled("bar = 4\nfoo = 42 if (bar == 5)").to include("if ((($a = (bar['$=='](5))) !== nil && (!$a.$$is_boolean || $a == true))) ")
         end
       
         it 'adds nil check for constants' do
           expect_compiled("foo = 42 if (Test > 4)").to include("if ((($a = ($rb_gt($scope.get('Test'), 4))) !== nil && (!$a.$$is_boolean || $a == true)))")
-          fail 'add equals'
+          expect_compiled("foo = 42 if (Test == 4)").to include("if ((($a = ($scope.get('Test')['$=='](4))) !== nil && (!$a.$$is_boolean || $a == true)))")
         end
       end
     

--- a/spec/lib/compiler_spec.rb
+++ b/spec/lib/compiler_spec.rb
@@ -141,18 +141,34 @@ describe Opal::Compiler do
           expect_compiled('foo = 42 if 2 > 3').to include('if ($rb_gt(2, 3))')
           expect_compiled('foo = 42 if 2.5 > 3.5').to include('if ($rb_gt(2.5, 3.5))')
           expect_compiled('foo = 42 if true > false').to include('if ($rb_gt(true, false))')
+          
+          expect_compiled('foo = 42 if 2 == 3').to include("if ((2)['$=='](3))")
+          expect_compiled('foo = 42 if 2.5 == 3.5').to include("if ((2.5)['$=='](3.5))")
+          expect_compiled('foo = 42 if true == false').to include("if (true['$=='](false))")
         end
       
         it 'adds nil check for strings' do
-          expect_compiled('foo = 42 if "test" > "bar"').to include('we need a nil check!')
+          expect_compiled('foo = 42 if "test" > "bar"').to include('we need a nil check!')        
+        end
+        
+        it 'specifically == excludes nil check for strings' do
+          expect_compiled('foo = 42 if "test" == "bar"').to include("if (\"test\"['$=='](\"bar\"))")
         end
       
         it 'adds nil check for lvars' do
-          expect_compiled("bar = 4\nfoo = 42 if bar > 5").to include('we need a nil check!')
+          expect_compiled("bar = 4\nfoo = 42 if bar > 5").to include('we need a nil check!')          
+        end
+        
+        it 'specifically == excludes nil check for lvars' do
+          expect_compiled("bar = 4\nfoo = 42 if bar == 5").to include("if (bar['$=='](5))")
         end
       
         it 'adds nil check for constants' do
           expect_compiled("foo = 42 if Test > 4").to include('we need a nil check!')
+        end
+        
+        it 'specifically == excludes nil check for constants' do
+          expect_compiled("foo = 42 if Test == 4").to include("if ($scope.get('Test')['$=='](4))")
         end
       end
     
@@ -183,18 +199,22 @@ describe Opal::Compiler do
           expect_compiled('foo = 42 if (2 > 3)').to include('if ((($a = ($rb_gt(2, 3))) !== nil && (!$a.$$is_boolean || $a == true)))')
           expect_compiled('foo = 42 if (2.5 > 3.5)').to include('if ((($a = ($rb_gt(2.5, 3.5))) !== nil && (!$a.$$is_boolean || $a == true)))')
           expect_compiled('foo = 42 if (true > false)').to include('if ((($a = ($rb_gt(true, false))) !== nil && (!$a.$$is_boolean || $a == true)))')
+          fail 'add equals'
         end
       
         it 'adds nil check for strings' do
           expect_compiled('foo = 42 if ("test" > "bar")').to include('if ((($a = ($rb_gt("test", "bar"))) !== nil && (!$a.$$is_boolean || $a == true)))')
+          fail 'add equals'
         end
       
         it 'adds nil check for lvars' do
           expect_compiled("bar = 4\nfoo = 42 if (bar > 5)").to include('if ((($a = ($rb_gt(bar, 5))) !== nil && (!$a.$$is_boolean || $a == true)))')
+          fail 'add equals'
         end
       
         it 'adds nil check for constants' do
           expect_compiled("foo = 42 if (Test > 4)").to include("if ((($a = ($rb_gt($scope.get('Test'), 4))) !== nil && (!$a.$$is_boolean || $a == true)))")
+          fail 'add equals'
         end
       end
     

--- a/spec/lib/compiler_spec.rb
+++ b/spec/lib/compiler_spec.rb
@@ -133,6 +133,92 @@ describe Opal::Compiler do
       end
     end
   end
+  
+  describe 'truthy check' do
+    context 'no parentheses' do
+      context 'with operators in expression' do
+        it 'excludes nil check for primitives' do
+          expect_compiled('foo = 42 if 2 > 3').to include('if ($rb_gt(2, 3))')
+          expect_compiled('foo = 42 if 2.5 > 3.5').to include('if ($rb_gt(2.5, 3.5))')
+          expect_compiled('foo = 42 if true > false').to include('if ($rb_gt(true, false))')
+        end
+      
+        it 'adds nil check for strings' do
+          expect_compiled('foo = 42 if "test" > "bar"').to include('we need a nil check!')
+        end
+      
+        it 'adds nil check for lvars' do
+          expect_compiled("bar = 4\nfoo = 42 if bar > 5").to include('we need a nil check!')
+        end
+      
+        it 'adds nil check for constants' do
+          expect_compiled("foo = 42 if Test > 4").to include('we need a nil check!')
+        end
+      end
+    
+      context 'without operators in expression' do
+        it 'adds nil check for primitives' do
+          expect_compiled('foo = 42 if 2').to include('if ((($a = 2) !== nil && (!$a.$$is_boolean || $a == true)))')
+          expect_compiled('foo = 42 if 2.5').to include('if ((($a = 2.5) !== nil && (!$a.$$is_boolean || $a == true)))')
+          expect_compiled('foo = 42 if true').to include('if ((($a = true) !== nil && (!$a.$$is_boolean || $a == true)))')
+        end
+      
+        it 'adds nil check for strings' do
+          expect_compiled('foo = 42 if "test"').to include('if ((($a = "test") !== nil && (!$a.$$is_boolean || $a == true)))')
+        end
+      
+        it 'adds nil check for lvars' do
+          expect_compiled("bar = 4\nfoo = 42 if bar").to include('if (bar !== false && bar !== nil)')
+        end
+      
+        it 'adds nil check for constants' do
+          expect_compiled("foo = 42 if Test").to include("if ((($a = $scope.get('Test')) !== nil && (!$a.$$is_boolean || $a == true)))")
+        end
+      end
+    end
+    
+    context 'parentheses' do
+      context 'with operators in expression' do
+        it 'adds nil check for primitives' do
+          expect_compiled('foo = 42 if (2 > 3)').to include('if ((($a = ($rb_gt(2, 3))) !== nil && (!$a.$$is_boolean || $a == true)))')
+          expect_compiled('foo = 42 if (2.5 > 3.5)').to include('if ((($a = ($rb_gt(2.5, 3.5))) !== nil && (!$a.$$is_boolean || $a == true)))')
+          expect_compiled('foo = 42 if (true > false)').to include('if ((($a = ($rb_gt(true, false))) !== nil && (!$a.$$is_boolean || $a == true)))')
+        end
+      
+        it 'adds nil check for strings' do
+          expect_compiled('foo = 42 if ("test" > "bar")').to include('if ((($a = ($rb_gt("test", "bar"))) !== nil && (!$a.$$is_boolean || $a == true)))')
+        end
+      
+        it 'adds nil check for lvars' do
+          expect_compiled("bar = 4\nfoo = 42 if (bar > 5)").to include('if ((($a = ($rb_gt(bar, 5))) !== nil && (!$a.$$is_boolean || $a == true)))')
+        end
+      
+        it 'adds nil check for constants' do
+          expect_compiled("foo = 42 if (Test > 4)").to include("if ((($a = ($rb_gt($scope.get('Test'), 4))) !== nil && (!$a.$$is_boolean || $a == true)))")
+        end
+      end
+    
+      context 'without operators in expression' do
+        it 'adds nil check for primitives' do
+          expect_compiled('foo = 42 if (2)').to include('if ((($a = (2)) !== nil && (!$a.$$is_boolean || $a == true)))')
+          expect_compiled('foo = 42 if (2.5)').to include('if ((($a = (2.5)) !== nil && (!$a.$$is_boolean || $a == true)))')
+          expect_compiled('foo = 42 if (true)').to include('if ((($a = (true)) !== nil && (!$a.$$is_boolean || $a == true)))')
+        end
+      
+        it 'adds nil check for strings' do
+          expect_compiled('foo = 42 if ("test")').to include('if ((($a = ("test")) !== nil && (!$a.$$is_boolean || $a == true)))')
+        end
+      
+        it 'adds nil check for lvars' do
+          expect_compiled("bar = 4\nfoo = 42 if (bar)").to include('if ((($a = (bar)) !== nil && (!$a.$$is_boolean || $a == true)))')
+        end
+      
+        it 'adds nil check for constants' do
+          expect_compiled("foo = 42 if (Test)").to include("if ((($a = ($scope.get('Test'))) !== nil && (!$a.$$is_boolean || $a == true)))")
+        end
+      end      
+    end
+  end
 
   def expect_compiled(*args)
     expect(Opal::Compiler.new(*args).compile)

--- a/spec/opal/core/runtime/truthy_spec.rb
+++ b/spec/opal/core/runtime/truthy_spec.rb
@@ -4,6 +4,14 @@ class Boolean
   end
 end
 
+class JsNil
+  def <(other)
+    %x{
+      return nil;
+    }
+  end
+end
+
 describe "Opal truthyness" do
   it "should evaluate to true using js `true` as an object" do
     if true.self_as_an_object
@@ -21,14 +29,9 @@ describe "Opal truthyness" do
     called.should be_nil
   end
   
-  it "should evaluate to false if js `nil` is used" do
-    input = `nil`
-    is_false = false
+  it "should evaluate to false if js `nil` is used with an operator" do
+    is_falsey = JsNil.new < 2 ? false : true
     
-    if input
-      is_false = true
-    end
-    
-    is_false.should be_true
+    is_falsey.should be_true
   end
 end

--- a/spec/opal/core/runtime/truthy_spec.rb
+++ b/spec/opal/core/runtime/truthy_spec.rb
@@ -20,4 +20,15 @@ describe "Opal truthyness" do
 
     called.should be_nil
   end
+  
+  it "should evaluate to false if js `nil` is used" do
+    input = `nil`
+    is_false = false
+    
+    if input
+      is_false = true
+    end
+    
+    is_false.should be_true
+  end
 end


### PR DESCRIPTION
Rather than using just an operator comparison to decide whether optimization can happen, look at the call type and only optimize operator based calls to ValueNode/NumericNode based types.

Should address https://github.com/opal/opal/issues/1274 in a way that preserves operator optimization (rg_gt, etc.) when possible.

Since no tests broke when I changed this, added compiler specs and also added a spot check at a higher level (opal mspec).

Can squash once approach is reviewed.