### PR TITLE
Fix JS Truthy Optimization in Master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 
 * Fix Module#name when constant was created using Opal.cdecl (constant declare) like ChildClass = Class.new(BaseClass) (#1259)
 
+* Fix issue with JS nil return paths being treated as true (#1274)
+
 ## 0.9.0 2015-12-20
 
 * Fixed usage of JS keywords as instance variable names for:

--- a/lib/opal/nodes/base.rb
+++ b/lib/opal/nodes/base.rb
@@ -22,6 +22,10 @@ module Opal
           end
         end
       end
+      
+      def self.truthy_optimize?
+        false
+      end
 
       attr_reader :compiler, :type
 

--- a/lib/opal/nodes/literal.rb
+++ b/lib/opal/nodes/literal.rb
@@ -8,6 +8,10 @@ module Opal
       def compile
         push type.to_s
       end
+      
+      def self.truthy_optimize?
+        true
+      end
     end
 
     class NumericNode < Base
@@ -18,6 +22,10 @@ module Opal
       def compile
         push value.to_s
         wrap '(', ')' if recv?
+      end
+      
+      def self.truthy_optimize?
+        true
       end
     end
 

--- a/spec/lib/compiler_spec.rb
+++ b/spec/lib/compiler_spec.rb
@@ -133,6 +133,123 @@ describe Opal::Compiler do
       end
     end
   end
+  
+  describe 'truthy check' do
+    context 'no parentheses' do
+      context 'with operators' do
+        it 'excludes nil check for primitives' do
+          expect_compiled('foo = 42 if 2 > 3').to include('if ($rb_gt(2, 3))')
+          expect_compiled('foo = 42 if 2.5 > 3.5').to include('if ($rb_gt(2.5, 3.5))')
+          expect_compiled('foo = 42 if true > false').to include('if ($rb_gt(true, false))')
+          
+          expect_compiled('foo = 42 if 2 == 3').to include("if ((2)['$=='](3))")
+          expect_compiled('foo = 42 if 2.5 == 3.5').to include("if ((2.5)['$=='](3.5))")
+          expect_compiled('foo = 42 if true == false').to include("if (true['$=='](false))")
+        end
+      
+        it 'adds nil check for strings' do
+          expect_compiled('foo = 42 if "test" > "bar"').to include('if ((($a = $rb_gt("test", "bar")) !== nil && (!$a.$$is_boolean || $a == true)))')
+        end
+        
+        it 'specifically == excludes nil check for strings' do
+          expect_compiled('foo = 42 if "test" == "bar"').to include("if (\"test\"['$=='](\"bar\"))")
+        end
+      
+        it 'adds nil check for lvars' do
+          expect_compiled("bar = 4\nfoo = 42 if bar > 5").to include('if ((($a = $rb_gt(bar, 5)) !== nil && (!$a.$$is_boolean || $a == true)))')
+        end
+        
+        it 'specifically == excludes nil check for lvars' do
+          expect_compiled("bar = 4\nfoo = 42 if bar == 5").to include("if (bar['$=='](5))")
+        end
+      
+        it 'adds nil check for constants' do
+          expect_compiled("foo = 42 if Test > 4").to include("if ((($a = $rb_gt($scope.get('Test'), 4)) !== nil && (!$a.$$is_boolean || $a == true))) ")
+        end
+        
+        it 'specifically == excludes nil check for constants' do
+          expect_compiled("foo = 42 if Test == 4").to include("if ($scope.get('Test')['$=='](4))")
+        end
+      end
+    
+      context 'without operators' do
+        it 'adds nil check for primitives' do
+          expect_compiled('foo = 42 if 2').to include('if ((($a = 2) !== nil && (!$a.$$is_boolean || $a == true)))')
+          expect_compiled('foo = 42 if 2.5').to include('if ((($a = 2.5) !== nil && (!$a.$$is_boolean || $a == true)))')
+          expect_compiled('foo = 42 if true').to include('if ((($a = true) !== nil && (!$a.$$is_boolean || $a == true)))')
+        end
+        
+        it 'adds nil check for boolean method calls' do
+          expect_compiled('foo = 42 if true.something').to include('if ((($a = true.$something()) !== nil && (!$a.$$is_boolean || $a == true)))')
+        end
+      
+        it 'adds nil check for strings' do
+          expect_compiled('foo = 42 if "test"').to include('if ((($a = "test") !== nil && (!$a.$$is_boolean || $a == true)))')
+        end
+      
+        it 'adds nil check for lvars' do
+          expect_compiled("bar = 4\nfoo = 42 if bar").to include('if (bar !== false && bar !== nil)')
+        end
+      
+        it 'adds nil check for constants' do
+          expect_compiled("foo = 42 if Test").to include("if ((($a = $scope.get('Test')) !== nil && (!$a.$$is_boolean || $a == true)))")
+        end
+      end
+    end
+    
+    context 'parentheses' do
+      context 'with operators' do
+        it 'adds nil check for primitives' do
+          expect_compiled('foo = 42 if (2 > 3)').to include('if ((($a = ($rb_gt(2, 3))) !== nil && (!$a.$$is_boolean || $a == true)))')
+          expect_compiled('foo = 42 if (2.5 > 3.5)').to include('if ((($a = ($rb_gt(2.5, 3.5))) !== nil && (!$a.$$is_boolean || $a == true)))')
+          expect_compiled('foo = 42 if (true > false)').to include('if ((($a = ($rb_gt(true, false))) !== nil && (!$a.$$is_boolean || $a == true)))')
+          
+          expect_compiled('foo = 42 if (2 == 3)').to include("if ((($a = ((2)['$=='](3))) !== nil && (!$a.$$is_boolean || $a == true)))")
+          expect_compiled('foo = 42 if (2.5 == 3.5)').to include("if ((($a = ((2.5)['$=='](3.5))) !== nil && (!$a.$$is_boolean || $a == true)))")
+          expect_compiled('foo = 42 if (true == false)').to include("if ((($a = (true['$=='](false))) !== nil && (!$a.$$is_boolean || $a == true)))")
+        end
+      
+        it 'adds nil check for strings' do
+          expect_compiled('foo = 42 if ("test" > "bar")').to include('if ((($a = ($rb_gt("test", "bar"))) !== nil && (!$a.$$is_boolean || $a == true)))')
+          expect_compiled('foo = 42 if ("test" == "bar")').to include("if ((($a = (\"test\"['$=='](\"bar\"))) !== nil && (!$a.$$is_boolean || $a == true)))")
+        end
+      
+        it 'adds nil check for lvars' do
+          expect_compiled("bar = 4\nfoo = 42 if (bar > 5)").to include('if ((($a = ($rb_gt(bar, 5))) !== nil && (!$a.$$is_boolean || $a == true)))')
+          expect_compiled("bar = 4\nfoo = 42 if (bar == 5)").to include("if ((($a = (bar['$=='](5))) !== nil && (!$a.$$is_boolean || $a == true))) ")
+        end
+      
+        it 'adds nil check for constants' do
+          expect_compiled("foo = 42 if (Test > 4)").to include("if ((($a = ($rb_gt($scope.get('Test'), 4))) !== nil && (!$a.$$is_boolean || $a == true)))")
+          expect_compiled("foo = 42 if (Test == 4)").to include("if ((($a = ($scope.get('Test')['$=='](4))) !== nil && (!$a.$$is_boolean || $a == true)))")
+        end
+      end
+    
+      context 'without operators' do
+        it 'adds nil check for primitives' do
+          expect_compiled('foo = 42 if (2)').to include('if ((($a = (2)) !== nil && (!$a.$$is_boolean || $a == true)))')
+          expect_compiled('foo = 42 if (2.5)').to include('if ((($a = (2.5)) !== nil && (!$a.$$is_boolean || $a == true)))')
+          expect_compiled('foo = 42 if (true)').to include('if ((($a = (true)) !== nil && (!$a.$$is_boolean || $a == true)))')
+        end
+        
+        it 'adds nil check for boolean method calls' do
+          expect_compiled('foo = 42 if (true.something)').to include('if ((($a = (true.$something())) !== nil && (!$a.$$is_boolean || $a == true)))')
+        end
+      
+        it 'adds nil check for strings' do
+          expect_compiled('foo = 42 if ("test")').to include('if ((($a = ("test")) !== nil && (!$a.$$is_boolean || $a == true)))')
+        end
+      
+        it 'adds nil check for lvars' do
+          expect_compiled("bar = 4\nfoo = 42 if (bar)").to include('if ((($a = (bar)) !== nil && (!$a.$$is_boolean || $a == true)))')
+        end
+      
+        it 'adds nil check for constants' do
+          expect_compiled("foo = 42 if (Test)").to include("if ((($a = ($scope.get('Test'))) !== nil && (!$a.$$is_boolean || $a == true)))")
+        end
+      end      
+    end
+  end
 
   def expect_compiled(*args)
     expect(Opal::Compiler.new(*args).compile)

--- a/spec/opal/core/runtime/truthy_spec.rb
+++ b/spec/opal/core/runtime/truthy_spec.rb
@@ -4,6 +4,14 @@ class Boolean
   end
 end
 
+class JsNil
+  def <(other)
+    %x{
+      return nil;
+    }
+  end
+end
+
 describe "Opal truthyness" do
   it "should evaluate to true using js `true` as an object" do
     if true.self_as_an_object
@@ -19,5 +27,11 @@ describe "Opal truthyness" do
     end
 
     called.should be_nil
+  end
+  
+  it "should evaluate to false if js `nil` is used with an operator" do
+    is_falsey = JsNil.new < 2 ? false : true
+    
+    is_falsey.should be_true
   end
 end


### PR DESCRIPTION
Port of https://github.com/opal/opal/pull/1276 to master

Should address #1274 in a way that preserves operator optimization (rg_gt, etc.) when possible.

Rather than using just an operator comparison to decide whether optimization can happen, look at the call type and only optimize operator based calls to ValueNode/NumericNode based types.