### PR TITLE
Resolves #1281, do not generate source block when module option is specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Whitespace conventions:
 - Add Rack v2 ccompatibility (#1260)
 - Newly compliant with RubySpec:
     * `Array#slice!`
+- Add -M --module option to compile only the code of the module (#1281)
 
 
 ### Fixed

--- a/lib/opal/cli.rb
+++ b/lib/opal/cli.rb
@@ -7,7 +7,7 @@ module Opal
   class CLI
     attr_reader :options, :file, :compiler_options, :evals, :load_paths, :argv,
                 :output, :requires, :gems, :stubs, :verbose, :port, :preload,
-                :filename, :debug, :no_exit
+                :filename, :debug, :no_exit, :module_only
 
     def compile?
       @compile
@@ -32,22 +32,23 @@ module Opal
       @runner_type = options.delete(:runner)    || :nodejs
       @port       = options.delete(:port)       || 3000
 
-      @options    = options
-      @compile    = !!options.delete(:compile)
-      @sexp       = options.delete(:sexp)
-      @file       = options.delete(:file)
-      @no_exit    = options.delete(:no_exit)
-      @argv       = options.delete(:argv)       || []
-      @evals      = options.delete(:evals)      || []
-      @requires   = options.delete(:requires)   || []
-      @load_paths = options.delete(:load_paths) || []
-      @gems       = options.delete(:gems)       || []
-      @stubs      = options.delete(:stubs)      || []
-      @preload    = options.delete(:preload)    || []
-      @output     = options.delete(:output)     || self.class.stdout || $stdout
-      @verbose    = options.fetch(:verbose, false); options.delete(:verbose)
-      @debug      = options.fetch(:debug, false);   options.delete(:debug)
-      @filename   = options.fetch(:filename) { @file && @file.path }; options.delete(:filename)
+      @options     = options
+      @compile     = !!options.delete(:compile)
+      @sexp        = options.delete(:sexp)
+      @file        = options.delete(:file)
+      @no_exit     = options.delete(:no_exit)
+      @module_only = options.delete(:module_only)
+      @argv        = options.delete(:argv)       || []
+      @evals       = options.delete(:evals)      || []
+      @requires    = options.delete(:requires)   || []
+      @load_paths  = options.delete(:load_paths) || []
+      @gems        = options.delete(:gems)       || []
+      @stubs       = options.delete(:stubs)      || []
+      @preload     = options.delete(:preload)    || []
+      @output      = options.delete(:output)     || self.class.stdout || $stdout
+      @verbose     = options.fetch(:verbose, false); options.delete(:verbose)
+      @debug       = options.fetch(:debug, false);   options.delete(:debug)
+      @filename    = options.fetch(:filename) { @file && @file.path }; options.delete(:filename)
       @skip_opal_require = options.delete(:skip_opal_require)
       @compiler_options = Hash[
         *compiler_option_names.map do |option|
@@ -104,8 +105,10 @@ module Opal
         builder.build(local_require)
       end
 
-      evals_or_file do |contents, filename|
-        builder.build_str(contents, filename)
+      unless module_only
+        evals_or_file do |contents, filename|
+          builder.build_str(contents, filename)
+        end
       end
 
       builder.build_str 'Kernel.exit', '(exit)' unless no_exit

--- a/lib/opal/cli_options.rb
+++ b/lib/opal/cli_options.rb
@@ -97,6 +97,9 @@ module Opal
         options[:no_exit] = true
       end
 
+      on('-M', '--module', 'Generate only the code of module. Omit [programfile]') do |no_exit|
+        options[:module_only] = true
+      end
 
       section 'Compilation Options:'
 

--- a/spec/lib/cli_spec.rb
+++ b/spec/lib/cli_spec.rb
@@ -56,6 +56,22 @@ describe Opal::CLI do
     end
   end
 
+  describe ':module_only option' do
+    context 'when false' do
+      let(:options) { {module_only: false, compile: true, evals: [''], skip_opal_require: true, no_exit: true} }
+      it 'appends an empty code block at the end of the source' do
+        expect_output_of{ subject.run }.to include("function(Opal)")
+      end
+    end
+
+    context 'when true' do
+      let(:options) { {module_only: true, compile: true, evals: [''], skip_opal_require: true, no_exit: true} }
+      it 'does not append code block at the end of the source' do
+        expect_output_of{ subject.run }.to eq("\n")
+      end
+    end
+  end
+
   describe ':requires options' do
     context 'with an absolute path' do
       let(:options) { {:requires => [file], :evals => ['']} }


### PR DESCRIPTION
@elia I didn't find out how to put the code of the module inside an Opal module... in Asciidoctor.js we're using `Opal::Environment` but this is now deprecated. Maybe it's better to leave as it is (no need to manually require the module) ? Wdyt ?