### PR TITLE
Resolves #1290, generate opal-builder.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Whitespace conventions:
 - if-conditions now support `null` and `undefined` as falsy values (#867)
 - Implement IO.read method for Node.js (#1332)
 - Implement IO.each_line method for Node.js (#1221)
+- Generate `opal-builder.js` to ease the compilation of Ruby library from JavaScript (#1290)
 
 
 ### Changed

--- a/stdlib/opal-builder.rb
+++ b/stdlib/opal-builder.rb
@@ -1,0 +1,1 @@
+require 'opal/builder'

--- a/tasks/building.rake
+++ b/tasks/building.rake
@@ -19,6 +19,10 @@ task :dist do
   Opal::Config.dynamic_require_severity = :warning
   env = Opal::Environment.new
 
+  # Hike gem is required to build opal-builder
+  # Without this linen the build throws an exception: "Sprockets::FileNotFound: couldn't find file 'hike' with type 'application/javascript'"
+  env.use_gem 'hike'
+
   build_dir = ENV['DIR'] || 'build'
   files     = ENV['FILES'] ? ENV['FILES'].split(',') :
               Dir['{opal,stdlib}/*.rb'].map { |lib| File.basename(lib, '.rb') }


### PR DESCRIPTION
I made some progress toward a 100% JavaScript to compile Ruby code to JavaScript :smile: 

Remaining things to do:
- [x] Implement `Pathname.expand_path` method (used in [Hike](https://github.com/sstephenson/hike/blob/v1.2.3/lib/hike/trail.rb#L49)) #1291
- [x] Implement `Kernel.open()` method (used in [Opal.PathReader](https://github.com/opal/opal/blob/master/lib/opal/path_reader.rb#L12)) #1218
- [x] Implement  `Pathname.join` method (used in [Hike](https://github.com/sstephenson/hike/blob/v1.2.3/lib/hike/paths.rb#L23)) #1301  
- [x] Incorrect type with splat operator in HikePathFinder with Opal.paths #1331 