### PR TITLE
Rename `module only` option to `library only`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Whitespace conventions:
 - Add Rack v2 ccompatibility (#1260)
 - Newly compliant with RubySpec:
     * `Array#slice!`
-- Add `-M` / `--module` option to compile only the code of the module (#1281)
+- Add `-L` / `--library` option to compile only the code of the library (#1281)
 
 
 ### Fixed

--- a/lib/opal/cli.rb
+++ b/lib/opal/cli.rb
@@ -7,7 +7,7 @@ module Opal
   class CLI
     attr_reader :options, :file, :compiler_options, :evals, :load_paths, :argv,
                 :output, :requires, :gems, :stubs, :verbose, :port, :preload,
-                :filename, :debug, :no_exit, :module_only
+                :filename, :debug, :no_exit, :lib_only
 
     def compile?
       @compile
@@ -37,7 +37,7 @@ module Opal
       @sexp        = options.delete(:sexp)
       @file        = options.delete(:file)
       @no_exit     = options.delete(:no_exit)
-      @module_only = options.delete(:module_only)
+      @lib_only    = options.delete(:lib_only)
       @argv        = options.delete(:argv)       || []
       @evals       = options.delete(:evals)      || []
       @requires    = options.delete(:requires)   || []
@@ -59,8 +59,8 @@ module Opal
         end.compact.flatten
       ]
 
-      raise ArgumentError, "no runnable code provided (evals or file)" if @evals.empty? and @file.nil? and not(@module_only)
-      raise ArgumentError, "can't accept evals or file in 'module only` mode" if (@evals.any? or @file) and @module_only
+      raise ArgumentError, "no runnable code provided (evals or file)" if @evals.empty? and @file.nil? and not(@lib_only)
+      raise ArgumentError, "can't accept evals or file in `library only` mode" if (@evals.any? or @file) and @lib_only
       raise ArgumentError, "unknown options: #{options.inspect}" unless @options.empty?
     end
 
@@ -106,7 +106,7 @@ module Opal
         builder.build(local_require)
       end
 
-      unless module_only
+      unless lib_only
         evals_or_file do |contents, filename|
           builder.build_str(contents, filename)
         end

--- a/lib/opal/cli_options.rb
+++ b/lib/opal/cli_options.rb
@@ -97,8 +97,8 @@ module Opal
         options[:no_exit] = true
       end
 
-      on('--module', 'Generate only the code of module. Omit [programfile] and [-e]') do |no_exit|
-        options[:module_only] = true
+      on('-L', '--library', 'Generate only the code of the library. Omit [programfile] and [-e]') do |no_exit|
+        options[:lib_only] = true
       end
 
       section 'Compilation Options:'

--- a/spec/lib/cli_spec.rb
+++ b/spec/lib/cli_spec.rb
@@ -15,8 +15,8 @@ describe Opal::CLI do
       expect_output_of{ subject.run }.to eq("hi from opal!\n")
     end
 
-    context 'with module_only: true' do
-      let(:options) { super().merge module_only: true }
+    context 'with lib_only: true' do
+      let(:options) { super().merge lib_only: true }
 
       it 'raises ArgumentError' do
         expect{subject.run}.to raise_error(ArgumentError)
@@ -30,8 +30,8 @@ describe Opal::CLI do
         expect { subject.run }.to raise_error(ArgumentError)
       end
 
-      context 'with module_only: true' do
-        let(:options) { super().merge module_only: true }
+      context 'with lib_only: true' do
+        let(:options) { super().merge lib_only: true }
 
         it 'does not raise an error' do
           expect{subject.run}.not_to raise_error
@@ -46,8 +46,8 @@ describe Opal::CLI do
         expect_output_of{ subject.run }.to eq("hello\n")
       end
 
-      context 'with module_only: true' do
-        let(:options) { super().merge module_only: true }
+      context 'with lib_only: true' do
+        let(:options) { super().merge lib_only: true }
 
         it 'raises ArgumentError' do
           expect{subject.run}.to raise_error(ArgumentError)
@@ -80,16 +80,16 @@ describe Opal::CLI do
     end
   end
 
-  describe ':module_only option' do
+  describe ':lib_only option' do
     context 'when false' do
-      let(:options) { {module_only: false, compile: true, evals: [''], skip_opal_require: true, no_exit: true} }
+      let(:options) { {lib_only: false, compile: true, evals: [''], skip_opal_require: true, no_exit: true} }
       it 'appends an empty code block at the end of the source' do
         expect_output_of{ subject.run }.to include("function(Opal)")
       end
     end
 
     context 'when true' do
-      let(:options) { {module_only: true, compile: true, skip_opal_require: true, no_exit: true} }
+      let(:options) { {lib_only: true, compile: true, skip_opal_require: true, no_exit: true} }
 
       it 'does not append code block at the end of the source' do
         expect_output_of{ subject.run }.to eq("\n")


### PR DESCRIPTION
See discussion here: https://github.com/opal/opal/commit/a43acd268f9c10da0e1a1c0f37f0271a5bb55815#commitcomment-15494448