### PR TITLE
Resolves #1296, File.expand_path('.') should return the current directory

### DIFF
--- a/opal/corelib/file.rb
+++ b/opal/corelib/file.rb
@@ -9,6 +9,7 @@ class File < IO
       parts = path.split(SEPARATOR)
       new_parts = []
       parts[0] = Dir.home if parts.first == '~'
+      parts[0] = Dir.pwd if parts.first == '.'
 
       parts.each do |part|
         if part == '..'


### PR DESCRIPTION
I've done some tests but `pwd` method is not overridden by the Node.js implementation. I'm pretty sure I'm doing something wrong but I can't figure out what...

To reproduce this issue:
```
$ bundle exec rake dist
$ cat build/nodejs.js >> build/opal.js
$ echo "Opal.require('nodejs');\nconsole.log(Opal.get('File').\$expand_path('.'));" >> build/opal.js
$ node build/opal.js
.
```

Apart from this "issue" (or misuse) this is working as expected and I get the current directory when running Node.js and "." when running in Browser.

fixes #1296 