### PR TITLE
Wrap begin;rescue;end into a function when there's a method call on returning value.

### DIFF
--- a/spec/opal/core/language/rescue_spec.rb
+++ b/spec/opal/core/language/rescue_spec.rb
@@ -1,0 +1,18 @@
+describe 'rescue' do
+  it 'wraps a try{}catch{} to a function when there is a method call on returning value' do
+    begin
+      1 + 1
+    rescue
+    end.should == 2
+  end
+
+  it 'explicitely adds return to the rescue part when there is ensure statement' do
+    begin
+      1 + 1
+    rescue
+      3
+    ensure
+      4
+    end.should == 2
+  end
+end


### PR DESCRIPTION
Prepend rescue statement with js_return when it has ensure.
Fixes #1305.