### PR TITLE
inline block

### DIFF
--- a/lib/opal/compiler.rb
+++ b/lib/opal/compiler.rb
@@ -228,16 +228,25 @@ module Opal
       self.helpers << name
     end
 
+    def indent!
+      previous = @indent
+      @indent += INDENT
+      @space = "\n#@indent"
+      previous
+    end
+
+    def outdent!(previous)
+      @indent = previous
+      @space = "\n#@indent"
+    end
+
     # To keep code blocks nicely indented, this will yield a block after
     # adding an extra layer of indent, and then returning the resulting
     # code after reverting the indent.
     def indent(&block)
-      indent = @indent
-      @indent += INDENT
-      @space = "\n#@indent"
+      previous = indent!
       res = yield
-      @indent = indent
-      @space = "\n#@indent"
+      outdent! previous
       res
     end
 
@@ -349,7 +358,7 @@ module Opal
       when :undef
         last = sexp.pop
         sexp << returns(last)
-      when :break, :next, :redo
+      when :break, :next, :redo, :returnable_yield
         sexp
       when :yield
         sexp[0] = :returnable_yield

--- a/lib/opal/nodes/arglist.rb
+++ b/lib/opal/nodes/arglist.rb
@@ -10,6 +10,7 @@ module Opal
         code, work = [], []
 
         children.each do |current|
+          next unless current
           splat = current.first == :splat
           arg = expr(current)
 

--- a/lib/opal/nodes/helpers.rb
+++ b/lib/opal/nodes/helpers.rb
@@ -93,6 +93,11 @@ module Opal
         push(*strs)
       end
 
+      def unshift_line(*strs)
+        unshift(*strs)
+        unshift "\n#{current_indent}"
+      end
+
       def empty_line
         push "\n"
       end
@@ -125,15 +130,15 @@ module Opal
         if sexp.type == :call
           mid = sexp[2]
           receiver_handler_class = (receiver = sexp[1]) && compiler.handlers[receiver.type]
-          
+
           # Only operator calls on the truthy_optimize? node classes should be optimized.
           # Monkey patch method calls might return 'self'/aka a bridged instance and need
           # the nil check - see discussion at https://github.com/opal/opal/pull/1097
           allow_optimization_on_type = Compiler::COMPARE.include?(mid.to_s) &&
             receiver_handler_class &&
             receiver_handler_class.truthy_optimize?
-          
-          if allow_optimization_on_type || 
+
+          if allow_optimization_on_type ||
             mid == :block_given? ||
             mid == :"=="
             expr(sexp)

--- a/lib/opal/nodes/logic.rb
+++ b/lib/opal/nodes/logic.rb
@@ -220,6 +220,7 @@ module Opal
       children :value
 
       def compile
+        push 'Opal.block, '
         push expr(s(:call, value, :to_proc, s(:arglist)))
       end
     end

--- a/lib/opal/nodes/scope.rb
+++ b/lib/opal/nodes/scope.rb
@@ -11,7 +11,7 @@ module Opal
       attr_accessor :name
 
       # The given block name for a def scope
-      attr_accessor :block_name
+      attr_accessor :block_name, :block_var
 
       attr_reader :scope_name
       attr_reader :locals
@@ -225,7 +225,6 @@ module Opal
           @parent.uses_block!
         else
           @uses_block = true
-          identify!
         end
       end
 

--- a/lib/opal/nodes/super.rb
+++ b/lib/opal/nodes/super.rb
@@ -9,26 +9,28 @@ module Opal
       children :arglist, :iter
 
       def compile_dispatcher
+        iter = nil
         if arglist or iter
           iter = expr(iter_sexp)
         else
           scope.uses_block!
           iter = '$iter'
         end
+
         if scope.def?
           scope.uses_block!
           scope_name = scope.identify!
           class_name = scope.parent.name ? "$#{scope.parent.name}" : 'self.$$class.$$proto'
 
-          if scope.defs
-            push "Opal.find_super_dispatcher(self, '#{scope.mid.to_s}', #{scope_name}, "
+          push "Opal.find_super_dispatcher(self, '#{scope.mid.to_s}', #{scope_name}"
+
+          if iter
+            push ", "
             push iter
-            push ", #{class_name})"
-          else
-            push "Opal.find_super_dispatcher(self, '#{scope.mid.to_s}', #{scope_name}, "
-            push iter
-            push ")"
           end
+          push ", #{class_name}" if scope.defs
+          push ")"
+
         elsif scope.iter?
           chain, cur_defn, mid = scope.get_super_chain
           trys = chain.map { |c| "#{c}.$$def" }.join(' || ')

--- a/opal/corelib/basic_object.rb
+++ b/opal/corelib/basic_object.rb
@@ -20,16 +20,12 @@ class BasicObject
     %x{
       var func = self['$' + symbol]
 
-      if (func) {
-        if (block !== nil) {
-          func.$$p = block;
-        }
-
-        return func.apply(self, args);
+      if (block !== nil) {
+        args = args.concat([Opal.block, block]);
       }
 
-      if (block !== nil) {
-        self.$method_missing.$$p = block;
+      if (func) {
+        return func.apply(self, args);
       }
 
       return self.$method_missing.apply(self, [symbol].concat(args));

--- a/opal/corelib/class.rb
+++ b/opal/corelib/class.rb
@@ -37,9 +37,7 @@ class Class
   def new(*args, &block)
     %x{
       var obj = #{allocate};
-
-      obj.$initialize.$$p = block;
-      obj.$initialize.apply(obj, args);
+      obj.$initialize.apply(obj, args.concat([Opal.block, block]));
       return obj;
     }
   end

--- a/opal/corelib/enumerable.rb
+++ b/opal/corelib/enumerable.rb
@@ -70,7 +70,7 @@ module Enumerable
           }
         }
 
-        self.$each.$$p = function(value) {
+        self.$each(Opal.block, function(value) {
           var key = Opal.yield1(block, value);
 
           if (key === nil) {
@@ -87,9 +87,7 @@ module Enumerable
 
             previous = key;
           }
-        }
-
-        self.$each();
+        });
 
         releaseAccumulate();
       }
@@ -102,13 +100,11 @@ module Enumerable
     %x{
       var result = [];
 
-      self.$each.$$p = function() {
+      self.$each(Opal.block, function() {
         var value = Opal.yieldX(block, arguments);
 
         result.push(value);
-      };
-
-      self.$each();
+      });
 
       return result;
     }
@@ -132,15 +128,13 @@ module Enumerable
         block = function() { return true; };
       }
 
-      self.$each.$$p = function() {
+      self.$each(Opal.block, function() {
         var value = Opal.yieldX(block, arguments);
 
         if (#{Opal.truthy?(`value`)}) {
           result++;
         }
-      }
-
-      self.$each();
+      });
 
       return result;
     }
@@ -166,14 +160,12 @@ module Enumerable
       var result,
           all = [], i, length, value;
 
-      self.$each.$$p = function() {
+      self.$each(Opal.block, function() {
         var param = #{Opal.destructure(`arguments`)},
             value = Opal.yield1(block, param);
 
         all.push(param);
-      }
-
-      self.$each();
+      });
 
       if (result !== undefined) {
         return result;
@@ -239,15 +231,13 @@ module Enumerable
       var result  = [],
           current = 0;
 
-      self.$each.$$p = function() {
+      self.$each(Opal.block, function() {
         if (number <= current) {
           result.push(#{Opal.destructure(`arguments`)});
         }
 
         current++;
-      };
-
-      self.$each()
+      });
 
       return result;
     }
@@ -260,7 +250,7 @@ module Enumerable
       var result   = [],
           dropping = true;
 
-      self.$each.$$p = function() {
+      self.$each(Opal.block, function() {
         var param = #{Opal.destructure(`arguments`)};
 
         if (dropping) {
@@ -274,9 +264,7 @@ module Enumerable
         else {
           result.push(param);
         }
-      };
-
-      self.$each();
+      });
 
       return result;
     }
@@ -309,7 +297,7 @@ module Enumerable
     %x{
       var buffer = [], result = nil;
 
-      self.$each.$$p = function() {
+      self.$each(Opal.block, function() {
         var element = #{Opal.destructure(`arguments`)};
         buffer.push(element);
         if (buffer.length > n) {
@@ -318,9 +306,7 @@ module Enumerable
         if (buffer.length == n) {
           Opal.yield1(block, buffer.slice(0, n));
         }
-      }
-
-      self.$each();
+      });
 
       return result;
     }
@@ -332,13 +318,11 @@ module Enumerable
     end
 
     %x{
-      self.$each.$$p = function() {
+      self.$each.apply(self, data.concat([Opal.block, function() {
         var item = #{Opal.destructure(`arguments`)};
 
         Opal.yield1(block, item);
-      }
-
-      self.$each.apply(self, data);
+      }]));
 
       return self;
     }
@@ -357,7 +341,7 @@ module Enumerable
       var result,
           slice = []
 
-      self.$each.$$p = function() {
+      self.$each(Opal.block, function() {
         var param = #{Opal.destructure(`arguments`)};
 
         slice.push(param);
@@ -366,9 +350,7 @@ module Enumerable
           Opal.yield1(block, slice);
           slice = [];
         }
-      };
-
-      self.$each();
+      });
 
       if (result !== undefined) {
         return result;
@@ -390,15 +372,13 @@ module Enumerable
       var result,
           index = 0;
 
-      self.$each.$$p = function() {
+      self.$each.apply(self, args.concat([Opal.block, function() {
         var param = #{Opal.destructure(`arguments`)};
 
         block(param, index);
 
         index++;
-      };
-
-      self.$each.apply(self, args);
+      }]));
 
       if (result !== undefined) {
         return result;
@@ -414,13 +394,11 @@ module Enumerable
     %x{
       var result;
 
-      self.$each.$$p = function() {
+      self.$each(Opal.block, function() {
         var param = #{Opal.destructure(`arguments`)};
 
         block(param, object);
-      };
-
-      self.$each();
+      });
 
       if (result !== undefined) {
         return result;
@@ -434,11 +412,9 @@ module Enumerable
     %x{
       var result = [];
 
-      self.$each.$$p = function() {
+      self.$each.apply(self, args.concat([Opal.block, function() {
         result.push(#{Opal.destructure(`arguments`)});
-      };
-
-      self.$each.apply(self, args);
+      }]));
 
       return result;
     }
@@ -452,16 +428,14 @@ module Enumerable
     %x{
       var result = [];
 
-      self.$each.$$p = function() {
+      self.$each(Opal.block, function() {
         var param = #{Opal.destructure(`arguments`)},
             value = Opal.yield1(block, param);
 
         if (#{Opal.truthy?(`value`)}) {
           result.push(param);
         }
-      };
-
-      self.$each();
+      });
 
       return result;
     }
@@ -533,10 +507,10 @@ module Enumerable
 
   def grep(pattern, &block)
     %x{
-      var result = [];
+      var result = [], wrapper;
 
       if (block !== nil) {
-        self.$each.$$p = function() {
+        wrapper = function() {
           var param = #{Opal.destructure(`arguments`)},
               value = #{pattern === `param`};
 
@@ -548,7 +522,7 @@ module Enumerable
         };
       }
       else {
-        self.$each.$$p = function() {
+        wrapper = function() {
           var param = #{Opal.destructure(`arguments`)},
               value = #{pattern === `param`};
 
@@ -558,7 +532,7 @@ module Enumerable
         };
       }
 
-      self.$each();
+      self.$each(Opal.block, wrapper);
 
       return result;
     }
@@ -572,14 +546,12 @@ module Enumerable
     %x{
       var result;
 
-      self.$each.$$p = function() {
+      self.$each(Opal.block, function() {
         var param = #{Opal.destructure(`arguments`)},
             value = Opal.yield1(block, param);
 
         #{(hash[`value`] ||= []) << `param`};
-      }
-
-      self.$each();
+      });
 
       if (result !== undefined) {
         return result;
@@ -603,10 +575,10 @@ module Enumerable
 
   def inject(object = undefined, sym = undefined, &block)
     %x{
-      var result = object;
+      var result = object, wrapper;
 
       if (block !== nil && sym === undefined) {
-        self.$each.$$p = function() {
+        wrapper = function() {
           var value = #{Opal.destructure(`arguments`)};
 
           if (result === undefined) {
@@ -629,7 +601,7 @@ module Enumerable
           result = undefined;
         }
 
-        self.$each.$$p = function() {
+        wrapper = function() {
           var value = #{Opal.destructure(`arguments`)};
 
           if (result === undefined) {
@@ -641,7 +613,7 @@ module Enumerable
         };
       }
 
-      self.$each();
+      self.$each(Opal.block, wrapper);
 
       return result == undefined ? nil : result;
     }
@@ -664,7 +636,7 @@ module Enumerable
       if (n === undefined || n === nil) {
         var result, value;
 
-        self.$each.$$p = function() {
+        self.$each(Opal.block, function() {
           var item = #{Opal.destructure(`arguments`)};
 
           if (result === undefined) {
@@ -685,9 +657,7 @@ module Enumerable
           if (value > 0) {
             result = item;
           }
-        }
-
-        self.$each();
+        });
 
         if (result === undefined) {
           return nil;
@@ -709,7 +679,7 @@ module Enumerable
       var result,
           by;
 
-      self.$each.$$p = function() {
+      self.$each(Opal.block, function() {
         var param = #{Opal.destructure(`arguments`)},
             value = Opal.yield1(block, param);
 
@@ -723,9 +693,7 @@ module Enumerable
           result = param
           by     = value;
         }
-      };
-
-      self.$each();
+      });
 
       return result === undefined ? nil : result;
     }
@@ -735,10 +703,10 @@ module Enumerable
 
   def min(&block)
     %x{
-      var result;
+      var result, wrapper;
 
       if (block !== nil) {
-        self.$each.$$p = function() {
+        wrapper = function() {
           var param = #{Opal.destructure(`arguments`)};
 
           if (result === undefined) {
@@ -758,7 +726,7 @@ module Enumerable
         };
       }
       else {
-        self.$each.$$p = function() {
+        wrapper = function() {
           var param = #{Opal.destructure(`arguments`)};
 
           if (result === undefined) {
@@ -772,7 +740,7 @@ module Enumerable
         };
       }
 
-      self.$each();
+      self.$each(Opal.block, wrapper);
 
       return result === undefined ? nil : result;
     }
@@ -785,7 +753,7 @@ module Enumerable
       var result,
           by;
 
-      self.$each.$$p = function() {
+      self.$each(Opal.block, function() {
         var param = #{Opal.destructure(`arguments`)},
             value = Opal.yield1(block, param);
 
@@ -799,9 +767,7 @@ module Enumerable
           result = param
           by     = value;
         }
-      };
-
-      self.$each();
+      });
 
       return result === undefined ? nil : result;
     }
@@ -813,7 +779,7 @@ module Enumerable
     %x{
       var min = nil, max = nil, first_time = true;
 
-      self.$each.$$p = function() {
+      self.$each(Opal.block, function() {
         var element = #{Opal.destructure(`arguments`)};
         if (first_time) {
           min = max = element;
@@ -835,9 +801,7 @@ module Enumerable
             max = element;
           }
         }
-      }
-
-      self.$each();
+      });
 
       return [min, max];
     }
@@ -913,7 +877,7 @@ module Enumerable
     %x{
       var truthy = [], falsy = [], result;
 
-      self.$each.$$p = function() {
+      self.$each(Opal.block, function() {
         var param = #{Opal.destructure(`arguments`)},
             value = Opal.yield1(block, param);
 
@@ -923,9 +887,7 @@ module Enumerable
         else {
           falsy.push(param);
         }
-      };
-
-      self.$each();
+      });
 
       return [truthy, falsy];
     }
@@ -939,16 +901,14 @@ module Enumerable
     %x{
       var result = [];
 
-      self.$each.$$p = function() {
+      self.$each(Opal.block, function() {
         var param = #{Opal.destructure(`arguments`)},
             value = Opal.yield1(block, param);
 
         if (#{Opal.falsy?(`value`)}) {
           result.push(param);
         }
-      };
-
-      self.$each();
+      });
 
       return result;
     }
@@ -960,11 +920,9 @@ module Enumerable
     %x{
       var result = [];
 
-      self.$each.$$p = function() {
+      self.$each(Opal.block, function() {
         result.push(arguments);
-      };
-
-      self.$each();
+      });
 
       for (var i = result.length - 1; i >= 0; i--) {
         Opal.yieldX(block, result[i]);
@@ -983,11 +941,11 @@ module Enumerable
 
     Enumerator.new {|e|
       %x{
-        var slice = [];
+        var slice = [], wrapper;
 
         if (block !== nil) {
           if (pattern === undefined) {
-            self.$each.$$p = function() {
+            wrapper = function() {
               var param = #{Opal.destructure(`arguments`)},
                   value = Opal.yield1(block, param);
 
@@ -1000,7 +958,7 @@ module Enumerable
             };
           }
           else {
-            self.$each.$$p = function() {
+            wrapper = function() {
               var param = #{Opal.destructure(`arguments`)},
                   value = block(param, #{pattern.dup});
 
@@ -1014,7 +972,7 @@ module Enumerable
           }
         }
         else {
-          self.$each.$$p = function() {
+          wrapper = function() {
             var param = #{Opal.destructure(`arguments`)},
                 value = #{pattern === `param`};
 
@@ -1027,7 +985,7 @@ module Enumerable
           };
         }
 
-        self.$each();
+        self.$each(Opal.block, wrapper);
 
         if (slice.length > 0) {
           #{e << `slice`};

--- a/opal/corelib/enumerator.rb
+++ b/opal/corelib/enumerator.rb
@@ -63,16 +63,14 @@ class Enumerator
     %x{
       var result, index = offset;
 
-      self.$each.$$p = function() {
+      self.$each(Opal.block, function() {
         var param = #{Opal.destructure(`arguments`)},
             value = block(param, index);
 
         index++;
 
         return value;
-      }
-
-      self.$each();
+      });
 
       if (result !== undefined) {
         return result;

--- a/opal/corelib/method.rb
+++ b/opal/corelib/method.rb
@@ -14,7 +14,7 @@ class Method
 
   def call(*args, &block)
     %x{
-      #@method.$$p = block;
+      args = args.concat([Opal.block, block]);
 
       return #@method.apply(#@receiver, args);
     }

--- a/opal/corelib/proc.rb
+++ b/opal/corelib/proc.rb
@@ -13,7 +13,7 @@ class Proc < `Function`
   def call(*args, &block)
     %x{
       if (block !== nil) {
-        self.$$p = block;
+        args = args.concat([Opal.block, block]);
       }
 
       var result, $brk = self.$$brk;

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -960,12 +960,6 @@
   // @return [undefined]
   Opal.stub_for = function(method_name) {
     function method_missing_stub() {
-      // Copy any given block onto the method_missing dispatcher
-      this.$method_missing.$$p = method_missing_stub.$$p;
-
-      // Set block property to null ready for the next call (stop false-positives)
-      method_missing_stub.$$p = null;
-
       // call method missing with correct args (remove '$' prefix on method name)
       return this.$method_missing.apply(this, [method_name.slice(1)].concat($slice.call(arguments)));
     }
@@ -1015,7 +1009,6 @@
     }
 
     dispatcher = dispatcher['$' + jsid];
-    dispatcher.$$p = iter;
 
     return dispatcher;
   };
@@ -1273,11 +1266,10 @@
   };
 
   Opal.block_send = function(recv, mid, block) {
-    var args = $slice.call(arguments, 3),
+    var args = $slice.call(arguments, 3).concat([Opal.block, block]),
         func = recv['$' + mid];
 
     if (func) {
-      func.$$p = block;
       return func.apply(recv, args);
     }
 
@@ -1437,6 +1429,9 @@
 
     return obj;
   };
+
+  // A unique object acting as the block flag
+  Opal.block = new Object;
 
   Opal.alias_native = function(obj, name, native_name) {
     var id   = '$' + name,


### PR DESCRIPTION
replacing this:

```js
var array = [1,2,3];
array.$$p = function(element){ console.log(element) };
array.each();
```

```js
var array = [1,2,3];
array.each(Opal.block, function(element){ console.log(element) });
```

---

### Current status:

this works:

```
$ bundle exec bin/opal -O -ropal/mini -rcorelib/io -e 'p :ciao'
"ciao"
```