### PR TITLE
`A, B = 1, 2` does not work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Whitespace conventions:
 - Fix `Enumerator#with_index` to return the result of the previously called method.
 - Improved `Date.parse` to cover most date formatting cases.
 - Fixed `Module#const_get` for dynamically created constants.
+- Fixed multiple assignment for constants, i.e., allowing `A, B = 1, 2`.
 
 
 

--- a/lib/opal/nodes/masgn.rb
+++ b/lib/opal/nodes/masgn.rb
@@ -3,7 +3,6 @@ require 'opal/nodes/base'
 module Opal
   module Nodes
     class MassAssignNode < Base
-      # TODO: does this work for cvars?? constants??
       SIMPLE_ASSIGNMENT = [:lasgn, :iasgn, :lvar, :gasgn, :cdecl]
 
       handle :masgn

--- a/lib/opal/nodes/masgn.rb
+++ b/lib/opal/nodes/masgn.rb
@@ -4,7 +4,7 @@ module Opal
   module Nodes
     class MassAssignNode < Base
       # TODO: does this work for cvars?? constants??
-      SIMPLE_ASSIGNMENT = [:lasgn, :iasgn, :lvar, :gasgn]
+      SIMPLE_ASSIGNMENT = [:lasgn, :iasgn, :lvar, :gasgn, :cdecl]
 
       handle :masgn
       children :lhs, :rhs


### PR DESCRIPTION
Hello,

Opal fails to compile multiple assignment to constants:

~~~~
 opal -e 'A, B = 1, 2'
/home/mame/local/lib/ruby/gems/2.3.0/gems/opal-0.9.2/lib/opal/nodes/masgn.rb:103:in `compile_assignment': An error occurred while compiling: -e (RuntimeError)
Bad child node in masgn LHS: (:cdecl, :A). LHS: (:array, (:cdecl, :A), (:cdecl, :B))
*snip*
~~~~

Though I'm unsure if my patch is right, it fixes this error anyway.  Could you please review it?