### PR TITLE
`(-1)[1]` should return 1 instead of 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Whitespace conventions:
 - Fixed `Module#const_get` for dynamically created constants.
 - Fixed `File.dirname` to return joined String instead of Array.
 - Fixed multiple assignment for constants, i.e., allowing `A, B = 1, 2`.
+- Fixed `Number#[]` with negative number. Now `(-1)[1]` returns 1.
 
 
 

--- a/opal/corelib/number.rb
+++ b/opal/corelib/number.rb
@@ -214,7 +214,7 @@ class Number < Numeric
       }
 
       if (self < 0) {
-        return (((~self) + 1) >> #{bit}) % 2;
+        return 1 - ((~self) >> #{bit}) % 2;
       }
       else {
         return (self >> #{bit}) % 2;

--- a/opal/corelib/number.rb
+++ b/opal/corelib/number.rb
@@ -209,16 +209,13 @@ class Number < Numeric
     bit = Opal.coerce_to! bit, Integer, :to_int
 
     %x{
-      if (#{bit} < #{Integer::MIN} || #{bit} > #{Integer::MAX}) {
+      if (#{bit} < 0) {
         return 0;
       }
-
-      if (self < 0) {
-        return 1 - ((~self) >> #{bit}) % 2;
+      if (#{bit} >= 32) {
+        return #{ self } < 0 ? 1 : 0;
       }
-      else {
-        return (self >> #{bit}) % 2;
-      }
+      return (self >> #{bit}) & 1;
     }
   end
 


### PR DESCRIPTION
Hello,

`Number#[]` returns a wrong result when it picks a high bit of negative number.

~~~~
$ opal -ve 'p (-1)[1]'
Opal v0.9.2
0
~~~~

It should return 1 because -1 is represented by an integer whose bits are all 1.  Other Ruby implementations including MRI do so.

Thank you,