### PR TITLE
`File.dirname` should return a String instead of Array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Whitespace conventions:
 - Fix `Enumerator#with_index` to return the result of the previously called method.
 - Improved `Date.parse` to cover most date formatting cases.
 - Fixed `Module#const_get` for dynamically created constants.
+- Fixed `File.dirname` to return joined String instead of Array.
 
 
 

--- a/opal/corelib/file.rb
+++ b/opal/corelib/file.rb
@@ -23,7 +23,7 @@ class File < IO
     alias realpath expand_path
 
     def dirname(path)
-      split(path)[0..-2]
+      split(path)[0..-2].join(SEPARATOR)
     end
 
     def basename(path)


### PR DESCRIPTION
Hello,

`File.dirname` should return a joined path instead of an array of each directory name.

Before:

~~~~
$ opal -e 'p File.dirname("foo/bar/baz")'
["foo", "bar"]
~~~~

After:

~~~~
$ bundle exec opal -e 'p File.dirname("foo/bar/baz")'
"foo/bar"
~~~~

Thank you,