### PR TITLE
Initialize $ScratchPad = []

### DIFF
--- a/spec/opal/core/runtime/rescue_spec.rb
+++ b/spec/opal/core/runtime/rescue_spec.rb
@@ -46,6 +46,7 @@ describe "The rescue keyword" do
   end
 
   it 'Fix using more than two "rescue" in sequence #1269' do
+    $ScratchPad = []
     # As a statement
     begin
       raise IOError, 'foo'


### PR DESCRIPTION
On my machine, `bundle exec rake` fails.

~~~
1)
The rescue keyword Fix using more than two "rescue" in sequence #1269 ERROR
NoMethodError: undefined method `<<' for nil
<<: undefined method `<<' for nil
*snip*
~~~

Looks the initialization of $ScratchPad was forgotten.  (I'm unsure why this was overlooked.)