### PR TITLE
Limit rack version to 1.6.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 gemspec
 
 tilt_version = ENV['TILT_VERSION']
-rack_version = ENV['RACK_VERSION']
+rack_version = ENV['RACK_VERSION'] || '~> 1.6.4'
 
 # Stick with older racc until
 # https://github.com/tenderlove/racc/issues/22
@@ -14,7 +14,7 @@ gem 'rubysl', platform: :rbx
 # thin requires rack < 2
 gem 'thin', platform: :mri if !rack_version || (rack_version < '2')
 
-gem 'rack', rack_version if rack_version
+gem 'rack', rack_version
 gem 'tilt', tilt_version if tilt_version
 
 group :repl do


### PR DESCRIPTION
Rack file names were changed in >= 2.0.0.alpha. https://github.com/rack/rack/commit/857641dab255dbec490fead1d3a0f1ff999b2137. Resulted in the following error:

```
opal-0.8.0/lib/opal/sprockets/server.rb:7:in `require': cannot load such file -- rack/showexceptions (LoadError)
```