### PR TITLE
RFC/experiment: Skipping defs for unused methods

### DIFF
--- a/lib/opal/compiler.rb
+++ b/lib/opal/compiler.rb
@@ -118,6 +118,8 @@ module Opal
 
     compiler_option :eval, false, as: :eval?
 
+    compiler_option :calls, nil
+
     # @return [String] The compiled ruby code
     attr_reader :result
 

--- a/lib/opal/nodes/def.rb
+++ b/lib/opal/nodes/def.rb
@@ -38,6 +38,8 @@ module Opal
       end
 
       def compile
+        return if compiler.calls && !compiler.calls.include?(:mid)
+
         params = nil
         scope_name = nil
 


### PR DESCRIPTION
```ruby
require "opal"
puts Opal::Compiler.new("def foo; bar; end", calls: [:baz]).compile
```

    /* Generated by Opal 0.10.0.dev */
    (function(Opal) {
      Opal.dynamic_require_severity = "error";
      var OPAL_CONFIG = { method_missing: true, arity_check: false, freezing: true, tainting: true };
      var self = Opal.top, $scope = Opal, nil = Opal.nil, $breaker = Opal.breaker, $slice = Opal.slice;

      return
    })(Opal);


cc @meh @vais