### PR TITLE
Fix parsing issues with complex heredoc identifiers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@ Whitespace conventions:
 - Fixed `File.dirname` to return joined String instead of Array.
 - Fixed multiple assignment for constants, i.e., allowing `A, B = 1, 2`.
 - Fixed `Number#[]` with negative number. Now `(-1)[1]` returns 1.
-
+- Fixed parsing of quoted heredoc identifier.
 
 
 


### PR DESCRIPTION
Allows to parse the code like:
``` ruby
module_eval(<<'...end ruby23.y/module_eval...', 'ruby23.y', 2771)

  def version
    23
  end

  def default_encoding
    Encoding::UTF_8
  end
...end ruby23.y/module_eval...
```
(Which is required to parse generated parser from https://github.com/whitequark/parser/blob/master/lib/parser/ruby23.y)

Also it covers all cases specified in https://github.com/ruby/spec/blob/ce8d46b35a291bca68d61e552016a03ddfe2cea8/language/string_spec.rb#L134-L177 (unfortunately, there are some other parsing issues, so we still can't include this file into the test suite)