### PR TITLE
Merge pull request #1194 from iliabylich/fix-opal-is-a

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Whitespace conventions:
 - `break` semantics are now correct, except for the case in which a lambda containing a `break` is passed to a `yield` (#1250)
 - Avoid double "/" when `Opal::Sprockets.javascript_include_tag` receives a prefix with a trailing slash.
 - Fixed context of evaluation for `Kernel#eval` and `BasicObject#instance_eval`
+- Fix `Module#===` to use all ancestors of the passed object (#1284)
 
 
 

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -1148,20 +1148,20 @@
       return true;
     }
 
-    var search = object.$$class;
+    var i, length, ancestors = Opal.ancestors(object.$$class);
 
-    while (search) {
-      if (search === klass) {
+    for (i = 0, length = ancestors.length; i < length; i++) {
+      if (ancestors[i] === klass) {
         return true;
       }
+    }
 
-      for (var i = 0, length = search.$$inc.length; i < length; i++) {
-        if (search.$$inc[i] === klass) {
-          return true;
-        }
+    ancestors = Opal.ancestors(object.$$meta);
+
+    for (i = 0, length = ancestors.length; i < length; i++) {
+      if (ancestors[i] === klass) {
+        return true;
       }
-
-      search = search.$$super;
     }
 
     return false;

--- a/spec/filters/bugs/module.rb
+++ b/spec/filters/bugs/module.rb
@@ -1,5 +1,4 @@
 opal_filter "Module" do
-  fails "Module#=== returns true when the given Object's class includes self or when the given Object is extended by self"
   fails "Module#alias_method can call a method with super aliased twice"
   fails "Module#alias_method preserves the arguments information of the original methods"
   fails "Module#alias_method raises a TypeError when the given name can't be converted using to_str"


### PR DESCRIPTION
Fixed Opal.is_a to use Opal.ancestors of passed object and object's metaclass.