### PR TITLE
Fix nodejs/yaml

### DIFF
--- a/stdlib/nodejs/yaml.rb
+++ b/stdlib/nodejs/yaml.rb
@@ -1,10 +1,9 @@
-require 'native'
-
 module YAML
-  `var __yaml__ = OpalNode.node_require('js-yaml')`
+  @__yaml__ = node_require 'js-yaml'
+  `var __yaml__ = #{@__yaml__}`
 
   def self.load_path path
-    loaded = `__yaml__.yaml.safeLoad(#{File.__fs__}.readFileSync(#{path}, 'utf8'))`
+    loaded = `__yaml__.safeLoad(#{File}.__fs__.readFileSync(#{path}, 'utf8'))`
     loaded = Hash.new(loaded) if native?(loaded)
     loaded
   end

--- a/stdlib/nodejs/yaml.rb
+++ b/stdlib/nodejs/yaml.rb
@@ -1,3 +1,5 @@
+require 'native'
+
 module YAML
   @__yaml__ = node_require 'js-yaml'
   `var __yaml__ = #{@__yaml__}`


### PR DESCRIPTION
nodejs/yaml was throwing errors upon usage as it relied on OpalNode.node_require instead of Kernel#node_require like the nodejs/file class.