### PR TITLE
More super fixes

### DIFF
--- a/lib/opal/nodes/def.rb
+++ b/lib/opal/nodes/def.rb
@@ -71,17 +71,8 @@ module Opal
             add_local '$zuper_length'
 
             line "$zuper = [];"
-            # If a block was included, this shouldn't be included in the args we pass, breaks arity check
-            # since blocks are passed a special way
-            if block_arg
-              # Just because a block arg exists in the formal parameters doesn't mean one was actually passed
-              line "$zuper_length = #{block_arg[1]} != nil ? arguments.length - 1 : arguments.length;"
-            else
-              line "$zuper_length = arguments.length;"
-            end
-
             line
-            line "for($zuper_index = 0; $zuper_index < $zuper_length; $zuper_index++) {"
+            line "for($zuper_index = 0; $zuper_index < arguments.length; $zuper_index++) {"
             line "  $zuper[$zuper_index] = arguments[$zuper_index];"
             line "}"
           end

--- a/lib/opal/nodes/iter.rb
+++ b/lib/opal/nodes/iter.rb
@@ -9,10 +9,6 @@ module Opal
 
       attr_accessor :block_arg
 
-      def contains_defined_call?
-        body_sexp[0] == :defined
-      end
-
       def compile
         params = nil
         extract_block_arg

--- a/lib/opal/nodes/scope.rb
+++ b/lib/opal/nodes/scope.rb
@@ -254,38 +254,6 @@ module Opal
         nil
       end
 
-      def inside_anon_class?
-        call_matches? do |call_node|
-          receiver = call_node[1]
-          method = call_node[2]
-          receiver && receiver[0] == :const && receiver[1] == :Class && method == :new
-        end
-      end
-
-      def inside_define_method_call?
-        call_matches? do |call_node|
-          method = call_node[2]
-          method == :define_method
-        end
-      end
-
-      def call_matches?
-        get_inclusive_chain.any? do |scope_check|
-          call_node = scope_check.children.find { |node| node && node.is_a?(Sexp) && node.type == :call }
-          yield(call_node) if call_node
-        end
-      end
-
-      def get_inclusive_chain
-        chain = []
-        scope_check = self
-        chain << scope_check
-        while scope_check = scope_check.parent
-          chain << scope_check
-        end
-        chain
-      end
-
       def get_super_chain
         chain, scope, defn, mid = [], self, 'null', 'null'
 

--- a/opal/corelib/module.rb
+++ b/opal/corelib/module.rb
@@ -338,9 +338,10 @@ class Module
     %x{
       var id = '$' + name;
 
-      block.$$jsid = name;
-      block.$$s    = null;
-      block.$$def  = block;
+      block.$$jsid        = name;
+      block.$$s           = null;
+      block.$$def         = block;
+      block.$$define_meth = true;
 
       Opal.defn(self, id, block);
 

--- a/spec/filters/bugs/language.rb
+++ b/spec/filters/bugs/language.rb
@@ -189,7 +189,6 @@ opal_filter "language" do
   fails "The super keyword calls the correct method when the method visibility is modified"
   fails "The super keyword passes along modified rest args when they were originally empty"
   fails "The super keyword passes along modified rest args when they weren't originally empty"
-  fails "The super keyword raises an error error when super method does not exist"
   fails "The super keyword sees the included version of a module a method is alias from"
   fails "The super keyword uses given block even if arguments are passed explicitly"
   fails "The super keyword without explicit arguments passes arguments and rest arguments including any modifications"

--- a/spec/lib/compiler/call_spec.rb
+++ b/spec/lib/compiler/call_spec.rb
@@ -16,13 +16,13 @@ describe Opal::Compiler do
 
     context 'outside block' do
       context 'method missing on' do
-        it { is_expected.to include "return (!(Opal.find_super_dispatcher(self, 'some_method', TMP_1).$$stub) ? \"super\" : nil);" }
+        it { is_expected.to include "return (!(Opal.find_super_dispatcher(self, 'some_method', TMP_1, true).$$stub) ? \"super\" : nil);" }
       end
 
       context 'method missing off' do
         let(:compiler) { Opal::Compiler.new(method, method_missing: false) }
 
-        it { is_expected.to include "return ((Opal.find_super_dispatcher(self, 'some_method', TMP_1)) != null ? \"super\" : nil);" }
+        it { is_expected.to include "return ((Opal.find_super_dispatcher(self, 'some_method', TMP_1, true)) != null ? \"super\" : nil);" }
       end
     end
 
@@ -30,13 +30,13 @@ describe Opal::Compiler do
       context 'implicit' do
         let(:method) { 'lambda { defined? super }' }
 
-        it { is_expected.to include "return (!(Opal.find_iter_super_dispatcher(self, null, (TMP_1.$$def || null)).$$stub) ? \"super\" : nil)}, TMP_1.$$s = self, TMP_1), $a).call($b)" }
+        it { is_expected.to include "return (!(Opal.find_iter_super_dispatcher(self, null, (TMP_1.$$def || null), true, false).$$stub) ? \"super\" : nil)}, TMP_1.$$s = self, TMP_1), $a).call($b)" }
       end
 
       context 'explicit' do
         let(:method) { 'lambda { defined? super() }' }
 
-        it { is_expected.to include "return (!(Opal.find_iter_super_dispatcher(self, null, (TMP_1.$$def || null)).$$stub) ? \"super\" : nil)}, TMP_1.$$s = self, TMP_1), $a).call($b)" }
+        it { is_expected.to include "return (!(Opal.find_iter_super_dispatcher(self, null, (TMP_1.$$def || null), true, false).$$stub) ? \"super\" : nil)}, TMP_1.$$s = self, TMP_1), $a).call($b)" }
       end
     end
   end
@@ -223,14 +223,14 @@ if (a == null) a = nil;
             context 'no arguments' do
               let(:invocation) { 'super()' }
 
-              it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1)), $a.$$p = null, $a).call($b);" }
+              it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1, false)), $a.$$p = null, $a).call($b);" }
             end
 
             context 'implicit arguments' do
               let(:invocation) { 'super' }
 
               context 'no block' do
-                it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1)), $a.$$p = $iter, $a).apply($b, $zuper);" }
+                it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1, false)), $a.$$p = $iter, $a).apply($b, $zuper);" }
               end
 
               context 'block' do
@@ -244,8 +244,7 @@ if (a == null) a = nil;
                   CODE
                 end
 
-                it { is_expected.to include "$zuper_length = bar != nil ? arguments.length - 1 : arguments.length;" }
-                it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1)), $a.$$p = $iter, $a).apply($b, $zuper);" }
+                it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1, false)), $a.$$p = $iter, $a).apply($b, $zuper);" }
               end
             end
           end
@@ -269,7 +268,7 @@ if (a == null) a = nil;
 
                     it do
                       is_expected.to include <<-CODE
-    return ($a = ($b = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1)), $a.$$p = (TMP_2 = function(a){var self = TMP_2.$$s || this;
+    return ($a = ($b = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1, false)), $a.$$p = (TMP_2 = function(a){var self = TMP_2.$$s || this;
 if (a == null) a = nil;
       return self.$foobar()}, TMP_2.$$s = self, TMP_2), $a).apply($b, Opal.to_a(stuff));
                       CODE
@@ -279,7 +278,7 @@ if (a == null) a = nil;
                   context 'via reference' do
                     let(:invocation) { 'super *stuff, &block2' }
 
-                    it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1)), $a.$$p = block2.$to_proc(), $a).apply($b, Opal.to_a(stuff));" }
+                    it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1, false)), $a.$$p = block2.$to_proc(), $a).apply($b, Opal.to_a(stuff));" }
                   end
                 end
               end
@@ -291,7 +290,7 @@ if (a == null) a = nil;
 
                     it do
                       is_expected.to include <<-CODE
-    return ($a = ($b = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1)), $a.$$p = (TMP_2 = function(a){var self = TMP_2.$$s || this;
+    return ($a = ($b = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1, false)), $a.$$p = (TMP_2 = function(a){var self = TMP_2.$$s || this;
 if (a == null) a = nil;
       return self.$foobar()}, TMP_2.$$s = self, TMP_2), $a).apply($b, $zuper);
                       CODE
@@ -301,7 +300,7 @@ if (a == null) a = nil;
                   context 'via reference' do
                     let(:invocation) { 'super &block2' }
 
-                    it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1)), $a.$$p = block2.$to_proc(), $a).call($b);" }
+                    it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1, false)), $a.$$p = block2.$to_proc(), $a).call($b);" }
                   end
                 end
               end
@@ -309,7 +308,7 @@ if (a == null) a = nil;
               context 'no arguments' do
                 let(:invocation) { 'super()' }
 
-                it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1)), $a.$$p = null, $a).call($b);" }
+                it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1, false)), $a.$$p = null, $a).call($b);" }
               end
             end
 
@@ -331,7 +330,7 @@ if (a == null) a = nil;
 
                     it do
                       is_expected.to include <<-CODE
-      return ($a = ($b = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1)), $a.$$p = (TMP_2 = function(a){var self = TMP_2.$$s || this;
+      return ($a = ($b = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1, false)), $a.$$p = (TMP_2 = function(a){var self = TMP_2.$$s || this;
 if (a == null) a = nil;
       return self.$foobar()}, TMP_2.$$s = self, TMP_2), $a).apply($b, Opal.to_a(stuff));
                       CODE
@@ -341,7 +340,7 @@ if (a == null) a = nil;
                   context 'via reference' do
                     let(:invocation) { 'super *stuff, &block2' }
 
-                    it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1)), $a.$$p = self.$block2().$to_proc(), $a).apply($b, Opal.to_a(stuff));" }
+                    it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1, false)), $a.$$p = self.$block2().$to_proc(), $a).apply($b, Opal.to_a(stuff));" }
                   end
                 end
               end
@@ -353,7 +352,7 @@ if (a == null) a = nil;
 
                     it do
                       is_expected.to include <<-CODE
-      return ($a = ($b = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1)), $a.$$p = (TMP_2 = function(a){var self = TMP_2.$$s || this;
+      return ($a = ($b = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1, false)), $a.$$p = (TMP_2 = function(a){var self = TMP_2.$$s || this;
 if (a == null) a = nil;
       return self.$foobar()}, TMP_2.$$s = self, TMP_2), $a).apply($b, $zuper);
       CODE
@@ -363,7 +362,7 @@ if (a == null) a = nil;
                   context 'via reference' do
                     let(:invocation) { 'super &block2' }
 
-                    it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1)), $a.$$p = self.$block2().$to_proc(), $a).call($b);" }
+                    it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1, false)), $a.$$p = self.$block2().$to_proc(), $a).call($b);" }
                   end
                 end
               end
@@ -371,7 +370,7 @@ if (a == null) a = nil;
               context 'no arguments' do
                 let(:invocation) { 'super()' }
 
-                it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1)), $a.$$p = null, $a).call($b);" }
+                it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1, false)), $a.$$p = null, $a).call($b);" }
               end
             end
           end
@@ -391,14 +390,14 @@ if (a == null) a = nil;
           context 'no splat' do
             let(:invocation) { 'super(42)' }
 
-            it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'regular_method', TMP_1)), $a.$$p = null, $a).call($b, 42);" }
+            it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'regular_method', TMP_1, false)), $a.$$p = null, $a).call($b, 42);" }
           end
 
           context 'splat' do
             context 'with no block' do
               let(:invocation) { "args=[1,2,3]\nsuper(*args)" }
 
-              it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'regular_method', TMP_1)), $a.$$p = null, $a).apply($b, Opal.to_a(args));" }
+              it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'regular_method', TMP_1, false)), $a.$$p = null, $a).apply($b, Opal.to_a(args));" }
             end
 
             context 'with block' do
@@ -407,7 +406,7 @@ if (a == null) a = nil;
 
                 it do
                   is_expected.to include <<-CODE
-      return ($a = ($b = self, Opal.find_super_dispatcher(self, 'regular_method', TMP_1)), $a.$$p = (TMP_2 = function(b){var self = TMP_2.$$s || this;
+      return ($a = ($b = self, Opal.find_super_dispatcher(self, 'regular_method', TMP_1, false)), $a.$$p = (TMP_2 = function(b){var self = TMP_2.$$s || this;
 if (b == null) b = nil;
       return self.$foobar()}, TMP_2.$$s = self, TMP_2), $a).apply($b, Opal.to_a(self.$args()));
                   CODE
@@ -417,7 +416,7 @@ if (b == null) b = nil;
               context 'via reference' do
                 let(:invocation) { 'super(*args, &block2)' }
 
-                it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'regular_method', TMP_1)), $a.$$p = self.$block2().$to_proc(), $a).apply($b, Opal.to_a(self.$args()));" }
+                it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'regular_method', TMP_1, false)), $a.$$p = self.$block2().$to_proc(), $a).apply($b, Opal.to_a(self.$args()));" }
               end
             end
           end
@@ -428,7 +427,7 @@ if (b == null) b = nil;
 
               it do
                 is_expected.to include <<-CODE
-      return ($a = ($b = self, Opal.find_super_dispatcher(self, 'regular_method', TMP_1)), $a.$$p = (TMP_2 = function(b){var self = TMP_2.$$s || this;
+      return ($a = ($b = self, Opal.find_super_dispatcher(self, 'regular_method', TMP_1, false)), $a.$$p = (TMP_2 = function(b){var self = TMP_2.$$s || this;
 if (b == null) b = nil;
       return self.$foobar()}, TMP_2.$$s = self, TMP_2), $a).apply($b, $zuper);
                 CODE
@@ -438,14 +437,14 @@ if (b == null) b = nil;
             context 'via reference' do
               let(:invocation) { 'super(&block)' }
 
-              it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'regular_method', TMP_1)), $a.$$p = self.$block().$to_proc(), $a).call($b);" }
+              it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'regular_method', TMP_1, false)), $a.$$p = self.$block().$to_proc(), $a).call($b);" }
             end
           end
 
           context 'no arguments' do
             let(:invocation) { 'super()' }
 
-            it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'regular_method', TMP_1)), $a.$$p = null, $a).call($b);" }
+            it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'regular_method', TMP_1, false)), $a.$$p = null, $a).call($b);" }
           end
         end
       end
@@ -453,19 +452,61 @@ if (b == null) b = nil;
       context 'block' do
         let(:method) { 'stuff = lambda { super }'}
 
-        it { is_expected.to include "return ($c = ($d = self, self.$raise('super called outside of method')), $c.$$p = $iter, $c).apply($d)}, TMP_1.$$s = self, TMP_1), $a).call($b)" }
+        it { is_expected.to include "return ($c = ($d = self, Opal.find_iter_super_dispatcher(self, null, (TMP_1.$$def || null), false, true)), $c.$$p = $iter, $c).apply($d)}, TMP_1.$$s = self, TMP_1), $a).call($b)" }
       end
 
       context 'block inside method' do
-        let(:method) do
-          <<-CODE
-          def in_method
-            foo { super }
+        context 'first node' do
+          let(:method) do
+            <<-CODE
+            def in_method
+              foo { super }
+            end
+            CODE
           end
-          CODE
+
+          it { is_expected.to include "return ($c = ($d = self, Opal.find_iter_super_dispatcher(self, 'in_method', (TMP_1.$$def || TMP_2), false, true)), $c.$$p = $iter, $c).apply($d, $zuper)}, TMP_1.$$s = self, TMP_1), $a).call($b);" }
         end
 
-        it { is_expected.to include "return ($c = ($d = self, Opal.find_super_dispatcher(self, 'in_method', TMP_2)), $c.$$p = $iter, $c).apply($d, $zuper)}, TMP_1.$$s = self, TMP_1), $a).call($b);" }
+        context 'not first node' do
+          let(:method) do
+            <<-CODE
+            module Foo
+              def foo
+                foobar
+                fetch { return super }
+              end
+            end
+            CODE
+          end
+
+          it { is_expected.to include "Opal.ret(($c = ($d = self, Opal.find_iter_super_dispatcher(self, 'foo', (TMP_1.$$def || TMP_2), false, true)), $c.$$p = $iter, $c).apply($d, $zuper))}, TMP_1.$$s = self, TMP_1), $a).call($b);" }
+        end
+
+        context 'right method is called, IS THIS A NEW CASE??' do
+          let(:method) do
+            <<-CODE
+            class Bar
+              def m
+                :abc
+              end
+            end
+
+            class Foo < Bar
+              def self.do_defining(name, &body)
+                define_method(name, &body)
+              end
+
+              def self.setup
+                do_defining(:m) { |*args| super(*args) }
+              end
+            end
+            CODE
+          end
+
+          # runtime if (current_func.$$def) code should take care of locating the correct method here
+          it { is_expected.to include "return ($c = ($d = self, Opal.find_iter_super_dispatcher(self, 'setup', (TMP_2.$$def || TMP_3), false, false)), $c.$$p = null, $c).apply($d, Opal.to_a(args))}, TMP_2.$$s = self, TMP_2), $a).call($b, \"m\");" }
+        end
       end
 
       context 'define_method' do
@@ -480,7 +521,7 @@ if (b == null) b = nil;
         context 'implicit' do
           let(:invocation) { 'define_method(:wilma) { super }' }
 
-          it { is_expected.to include "return ($c = ($d = self, self.$raise('implicit argument passing of super from method defined by define_method() is not supported. Specify all arguments explicitly')), $c.$$p = $iter, $c).apply($d)}, TMP_1.$$s = self, TMP_1), $a).call($b, \"wilma\")" }
+          it { is_expected.to include "return ($c = ($d = self, Opal.find_iter_super_dispatcher(self, null, (TMP_1.$$def || null), false, true)), $c.$$p = $iter, $c).apply($d)}, TMP_1.$$s = self, TMP_1), $a).call($b, \"wilma\")" }
         end
 
         context 'module' do
@@ -496,23 +537,116 @@ if (b == null) b = nil;
             is_expected.to include <<-CODE
     ($a = ($b = self).$define_method, $a.$$p = (TMP_1 = function(){var self = TMP_1.$$s || this, $c, $d;
 
-    return ($c = ($d = self, Opal.find_iter_super_dispatcher(self, null, (TMP_1.$$def || null))), $c.$$p = null, $c).call($d)}, TMP_1.$$s = self, TMP_1), $a).call($b, "wilma")
+    return ($c = ($d = self, Opal.find_iter_super_dispatcher(self, null, (TMP_1.$$def || null), false, false)), $c.$$p = null, $c).call($d)}, TMP_1.$$s = self, TMP_1), $a).call($b, "wilma")
             CODE
           end
         end
 
         context 'anonymous class' do
+          context 'not nested, only item in class' do
+            let(:method) do
+              <<-CODE
+              Class.new do
+                define_method :foo do
+                  super()
+                end
+              end
+              CODE
+            end
+
+            it { is_expected.to include "return ($e = ($f = self, Opal.find_iter_super_dispatcher(self, null, (TMP_2.$$def || TMP_1.$$def || null), false, false)), $e.$$p = null, $e).call($f)}, TMP_2.$$s = self, TMP_2), $c).call($d, \"foo\")}, TMP_1.$$s = self, TMP_1), $a).call($b)" }
+          end
+
+          context 'alongside def''d method' do
+            let(:method) do
+              <<-CODE
+              sup = Class.new do
+                def a
+                  :abc
+                end
+              end
+
+              Class.new(sup) do
+                def fetch(&block)
+                  block.call
+                end
+
+                define_method(:a) { fetch { super(&nil)} }
+              end
+              CODE
+            end
+
+            it { is_expected.to include "return ($h = ($i = self, Opal.find_iter_super_dispatcher(self, null, (TMP_5.$$def || TMP_4.$$def || TMP_2.$$def || null), false, false)), $h.$$p = nil.$to_proc(), $h).call($i)}, TMP_5.$$s = self, TMP_5), $f).call($g)}, TMP_4.$$s = self, TMP_4), $d).call($e, \"a\");}, TMP_2.$$s = self, TMP_2), $a).call($c, sup);" }
+          end
+
+          context 'alongside another define_method' do
+            let(:method) do
+              <<-CODE
+              sup = Class.new do
+                def a
+                  :abc
+                end
+              end
+
+              Class.new(sup) do
+                define_method(:fetch) do |&block|
+                  block.call
+                end
+
+                define_method(:a) { fetch { super(&nil)} }
+              end
+              CODE
+            end
+
+            it { is_expected.to include "return ($i = ($j = self, Opal.find_iter_super_dispatcher(self, null, (TMP_5.$$def || TMP_4.$$def || TMP_2.$$def || null), false, false)), $i.$$p = nil.$to_proc(), $i).call($j)}, TMP_5.$$s = self, TMP_5), $g).call($h)}, TMP_4.$$s = self, TMP_4), $d).call($f, \"a\");}, TMP_2.$$s = self, TMP_2), $a).call($c, sup);" }
+          end
+
+          context 'not last method in class' do
+            let(:method) do
+              <<-CODE
+              sup = Class.new do
+                def a
+                  :abc
+                end
+              end
+
+              Class.new(sup) do
+                define_method(:a) { fetch { super(&nil)} }
+
+                def fetch(&block)
+                  block.call
+                end
+              end
+              CODE
+            end
+
+            it { is_expected.to include "return ($h = ($i = self, Opal.find_iter_super_dispatcher(self, null, (TMP_4.$$def || TMP_3.$$def || TMP_2.$$def || null), false, false)), $h.$$p = nil.$to_proc(), $h).call($i)}, TMP_4.$$s = self, TMP_4), $f).call($g)}, TMP_3.$$s = self, TMP_3), $d).call($e, \"a\");" }
+          end
+        end
+
+        context 'inside a method' do
           let(:method) do
             <<-CODE
-            Class.new do
-              define_method :foo do
-                super()
+            module Bar
+              def fetch
+              end
+
+              def foo
+                some_call
+
+                if some_arg
+                  block2 = lambda { the_block }
+                  define_method(:a) { fetch { super(some_arg, &block2)} }
+                else
+                  define_method(:a) { fetch { super(&nil)} }
+                end
               end
             end
             CODE
           end
 
-          it { is_expected.to include "return ($e = ($f = self, Opal.find_iter_super_dispatcher(self, null, (TMP_2.$$def || TMP_1.$$def || null))), $e.$$p = null, $e).call($f)}, TMP_2.$$s = self, TMP_2), $c).call($d, \"foo\")}, TMP_1.$$s = self, TMP_1), $a).call($b)" }
+          it { is_expected.to include "return ($f = ($g = self, Opal.find_iter_super_dispatcher(self, 'foo', (TMP_3.$$def || TMP_2.$$def || TMP_4), false, false)), $f.$$p = block2.$to_proc(), $f).call($g, self.$some_arg())}, TMP_3.$$s = self, TMP_3), $d).call($e)}, TMP_2.$$s = self, TMP_2), $a).call($c, \"a\");" }
+          it { is_expected.to include "return ($g = ($h = self, Opal.find_iter_super_dispatcher(self, 'foo', (TMP_6.$$def || TMP_5.$$def || TMP_4), false, false)), $g.$$p = nil.$to_proc(), $g).call($h)}, TMP_6.$$s = self, TMP_6), $e).call($f)}, TMP_5.$$s = self, TMP_5), $a).call($d, \"a\")" }
         end
 
         context 'explicit' do
@@ -522,9 +656,29 @@ if (b == null) b = nil;
             is_expected.to include <<-CODE
     return ($a = ($b = self).$define_method, $a.$$p = (TMP_1 = function(){var self = TMP_1.$$s || this, $c, $d;
 
-    return ($c = ($d = self, Opal.find_iter_super_dispatcher(self, null, (TMP_1.$$def || null))), $c.$$p = null, $c).call($d)}, TMP_1.$$s = self, TMP_1), $a).call($b, "wilma")
+    return ($c = ($d = self, Opal.find_iter_super_dispatcher(self, null, (TMP_1.$$def || null), false, false)), $c.$$p = null, $c).call($d)}, TMP_1.$$s = self, TMP_1), $a).call($b, "wilma")
             CODE
           end
+        end
+
+        context 'invalid case alongside other valid super cases' do
+          let(:method) do
+            <<-CODE
+            Class.new do
+              define_method(:foo) { super }
+
+              Class.new(c1) do
+                def m
+                  other_method { super }
+                end
+              end
+            end
+            CODE
+          end
+
+          it { is_expected.to include "return ($e = ($f = self, Opal.find_iter_super_dispatcher(self, null, (TMP_2.$$def || TMP_1.$$def || null), false, true)), $e.$$p = $iter, $e).apply($f)}, TMP_2.$$s = self, TMP_2), $c).call($d, \"foo\");" }
+
+          it { is_expected.to include "return ($c = ($d = self, Opal.find_iter_super_dispatcher(self, 'm', (TMP_5.$$def || TMP_6), false, true)), $c.$$p = $iter, $c).apply($d, $zuper)}, TMP_5.$$s = self, TMP_5), $a).call($b);" }
         end
       end
 
@@ -539,7 +693,7 @@ if (b == null) b = nil;
           CODE
         end
 
-        it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1, $Foobar)), $a.$$p = $iter, $a).apply($b, $zuper);" }
+        it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1, false, $Foobar)), $a.$$p = $iter, $a).apply($b, $zuper);" }
       end
     end
   end


### PR DESCRIPTION
Transition error handling to runtime (too difficult and error prone to do it on the compiler side), fix method_missing error handling , case, added missing test cases, DRY find_iter_super_dispatcher

This gets opal-rspec in the neighborhood again