### PR TITLE
Fixed parsing of %I{} lists. Fixed parsing of %{} lists when item contains same brackets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@ Whitespace conventions:
 - Fixed parsing of unicode constants.
 - Fixed parsing of quoted heredoc identifier.
 - Fixed parsing of mass assignment of method call without parentheses.
+- Fixed parsing of `%I{}` lists.
+- Fixed parsing of `%{}` lists when list item contains same brackets.
 
 
 

--- a/spec/filters/unsupported/symbol.rb
+++ b/spec/filters/unsupported/symbol.rb
@@ -5,4 +5,10 @@ opal_filter "Symbol" do
   fails "The throw keyword does not convert strings to a symbol"
   fails "Module#const_get raises a NameError if a Symbol has a toplevel scope qualifier"
   fails "Module#const_get raises a NameError if a Symbol is a scoped constant name"
+  fails "A Symbol literal is a ':' followed by any number of valid characters"
+  fails "A Symbol literal is a ':' followed by a single- or double-quoted string that may contain otherwise invalid characters"
+  fails "A Symbol literal is converted to a literal, unquoted representation if the symbol contains only valid characters"
+  fails "A Symbol literal can be created by the %s-delimited expression"
+  fails "A Symbol literal can contain null in the string"
+  fails "A Symbol literal can be an empty string"
 end

--- a/spec/ruby_specs
+++ b/spec/ruby_specs
@@ -104,7 +104,6 @@ ruby/language
 !ruby/language/return_spec
 !ruby/language/send_spec
 !ruby/language/string_spec
-!ruby/language/symbol_spec
 !ruby/language/yield_spec
 
 ruby/library/bigdecimal


### PR DESCRIPTION
Added `rubyspec/language/symbol_spec` to the test suite.
Closes #1321 