### PR TITLE
Super/Aliasing Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ Whitespace conventions:
 
 ### Fixed
 
+- `super` works properly with overwritten alias methods (#1384)
 - `NoMethodError` does not need a name to be instantiated
 - `method_added` fix for singleton class cases
 - Super now works properly with blocks (#1237)

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -1070,9 +1070,10 @@
     var klass = obj.$$meta || obj.$$class;
     jsid = '$' + jsid;
 
+    // first we need to find the class/module current_func is defined/donated on
     while (klass) {
-      if (klass.$$proto[jsid] === current_func) {
-        // ok
+      // when a module has been included in a class, look for that
+      if ((klass.$$iclass && klass.$$module === current_func.$$owner) || klass === current_func.$$owner) {
         break;
       }
 
@@ -1086,7 +1087,7 @@
 
     klass = klass.$$parent;
 
-    // else, let's find the next one
+    // now we can find the super
     while (klass) {
       var working = klass.$$proto[jsid];
 
@@ -1358,6 +1359,8 @@
   //
   Opal.defn = function(obj, jsid, body) {
     obj.$$proto[jsid] = body;
+    // for super dispatcher, etc.
+    body.$$owner = obj;
 
     if (obj.$$is_module) {
       Opal.donate(obj, jsid);

--- a/spec/filters/bugs/enumerable.rb
+++ b/spec/filters/bugs/enumerable.rb
@@ -1,4 +1,5 @@
 opal_filter "Enumerable" do
+  fails "Enumerable#first returns a gathered array from yield parameters"
   fails "Enumerable#grep with a block calls the block with gathered array when yielded with multiple arguments"
   fails "Enumerable#max_by when called with an argument n when n is nil returns the maximum element"
   fails "Enumerable#max_by when called with an argument n with a block on a enumerable of length x where x < n returns an array containing the maximum n elements of length n"
@@ -32,6 +33,7 @@ opal_filter "Enumerable" do
   fails "Enumerable#slice_when when given a block returns an enumerator"
   fails "Enumerable#slice_when when given a block splits chunks between adjacent elements i and j where the block returns true"
   fails "Enumerable#slice_when when not given a block raises an ArgumentError"
+  fails "Enumerable#sort_by returns an array of elements when a block is supplied and #map returns an enumerable"
   fails "Enumerable#take_while calls the block with initial args when yielded with multiple arguments"
   fails "Enumerable#to_h calls #to_ary on contents"
   fails "Enumerable#to_h converts empty enumerable to empty hash"
@@ -43,4 +45,5 @@ opal_filter "Enumerable" do
   fails "Enumerable#zip converts arguments to enums using #to_enum"
   fails "Enumerable#zip gathers whole arrays as elements when each yields multiple"
   fails "Enumerable#zip passes each element of the result array to a block and return nil if a block is given"
+  fails "when an iterator method yields more than one value processes all yielded values"
 end

--- a/spec/filters/bugs/language.rb
+++ b/spec/filters/bugs/language.rb
@@ -177,6 +177,7 @@ opal_filter "language" do
   fails "The super keyword passes along modified rest args when they weren't originally empty"
   fails "The super keyword sees the included version of a module a method is alias from"
   fails "The super keyword uses given block even if arguments are passed explicitly"
+  fails "The super keyword when using keyword arguments passes any given keyword arguments including optional and required ones to the parent"
   fails "The super keyword without explicit arguments passes arguments and rest arguments including any modifications"
   fails "The super keyword without explicit arguments passes optional arguments that have a default value but were modified"
   fails "The super keyword without explicit arguments passes optional arguments that have a default value"

--- a/spec/filters/unsupported/thread.rb
+++ b/spec/filters/unsupported/thread.rb
@@ -2,4 +2,5 @@ opal_filter "Thread" do
   fails "StandardError is a superclass of ThreadError"
   fails "The throw keyword raises an ArgumentError if used to exit a thread"
   fails "The throw keyword clears the current exception"
+  fails "Module#autoload loads the registered constant even if the constant was already loaded by another thread"
 end


### PR DESCRIPTION
Fixes #1384. Another weird quirk of the Ruby language (if it's a weird corner, RSpec will find it). It still needs the following:
- Rubyspec built from the anon_mod.rb file *done*
- This is probably incomplete as it really needs to be something that also fixes the Rubyspec `Module#alias_method can call a method with super aliased twice` *save this for another PR*