### PR TITLE
Optimize Opal.ancestors

### DIFF
--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -882,12 +882,17 @@
   // The Array of ancestors for a given module/class
   Opal.ancestors = function(module_or_class) {
     var parent = module_or_class,
-        result = [];
+        result = [],
+        modules;
 
     while (parent) {
       result.push(parent);
       for (var i=0; i < parent.$$inc.length; i++) {
-        result = result.concat(Opal.ancestors(parent.$$inc[i]));
+        modules = Opal.ancestors(parent.$$inc[i]);
+
+        for(var j = 0; j < modules.length; j++) {
+          result.push(modules[j]);
+        }
       }
 
       parent = parent.$$is_class ? parent.$$super : null;


### PR DESCRIPTION
With `grand_central`, handling dispatched actions generally relies on heavy usage of `case` statements, which uses `===`, and since `Class#===` depends on `is_a?` and occurs for every single `when`, calculating ancestors becomes a hot path.

Before this PR, `Opal.ancestors` was creating a new array for every tier of inheritance while checking which modules were included. While profiling one of my apps after upgrading Opal, I noticed it was the function with the highest "self" runtime. This patch sped it up by 30-35x for this particular app and reduced memory usage and GC pressure by almost 30%.

The effects of this PR are only this drastic for apps that use `grand_central` and dispatch dozens of times per second. Most apps that don't will likely only see marginal gains in performance.