### PR TITLE
Add support for "squiggly" heredoc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Whitespace conventions:
 - Added support for keyword arguments as lambda parameters.
 - Super works with define_method blocks
 - Added support for kwsplats.
+- Added support for squiggly heredoc.
 
 
 ### Changed

--- a/spec/opal/core/language/heredoc_spec.rb
+++ b/spec/opal/core/language/heredoc_spec.rb
@@ -1,0 +1,42 @@
+describe "'Squiggly' heredoc" do
+  context "when heredoc is blank" do
+    it "returns a blank string" do
+      heredoc = <<~HERE
+      HERE
+
+      heredoc.should == ""
+    end
+  end
+
+  context "when heredoc contains multiple lines" do
+    it "selects a least-indented line and removes its indentation from all the lines" do
+      heredoc = <<~HERE
+        a
+          b
+           c
+      HERE
+
+      heredoc.should == "a\n  b\n   c\n"
+    end
+  end
+
+  it "supports escaped heredoc identifier" do
+    <<~"HERE".should == ""
+    HERE
+
+    <<~'HERE'.should == ""
+    HERE
+  end
+
+  it "doesn't allow <<-~ syntax" do
+    lambda {
+      eval("<<-~HERE\nHERE")
+    }.should raise_error
+  end
+
+  it "doesn't allow <<~- syntax" do
+    lambda {
+      eval("<<~-HERE\nHERE")
+    }.should raise_error
+  end
+end


### PR DESCRIPTION
Closes #1359.

(Couldn't find any related specs in `spec/ruby`, so I'm like 97% sure that this implementation is correct)