### PR TITLE
Replace gsub! with gsub

### DIFF
--- a/lib/opal/builder.rb
+++ b/lib/opal/builder.rb
@@ -119,7 +119,7 @@ module Opal
     end
 
     def process_require(filename, options)
-      filename.gsub!(/\.(rb|js|opal)#{REGEXP_END}/, '')
+      filename = filename.gsub(/\.(rb|js|opal)#{REGEXP_END}/, '')
       return if prerequired.include?(filename)
       return if already_processed.include?(filename)
       already_processed << filename


### PR DESCRIPTION
`gsub!` doesn't work in a JavaScript environment. To be able to generate `opal-builder.js`, we need to replace `gsub!` with `gsub`.

Related to #1292