### PR TITLE
Experiment with adding programmatic line/file context info

### DIFF
--- a/lib/opal/nodes/def.rb
+++ b/lib/opal/nodes/def.rb
@@ -118,6 +118,12 @@ module Opal
           push ')'
         elsif scope.top?
           unshift "Opal.defn(Opal.Object, '$#{mid}', "
+          # TODO: Compiler config, default of false
+          include_source_in_code = true
+          if include_source_in_code
+            file_path = File.expand_path("#{compiler.file}.rb")
+            push ", {line: #{@sexp.line}, column: #{@sexp.column}, file: '#{file_path}'}"
+          end
           push ')'
         else
           raise "Unsupported use of `def`; please file a bug at https://github.com/opal/opal reporting this message."

--- a/lib/opal/nodes/def.rb
+++ b/lib/opal/nodes/def.rb
@@ -122,7 +122,7 @@ module Opal
           include_source_in_code = true
           if include_source_in_code
             file_path = File.expand_path("#{compiler.file}.rb")
-            push ", {line: #{@sexp.line}, column: #{@sexp.column}, file: '#{file_path}'}"
+            push ", {line: #{@sexp.line}, column: #{@sexp.column}, file: '#{file_path}', method: '#{function_name.strip}'}"
           end
           push ')'
         else

--- a/lib/opal/nodes/iter.rb
+++ b/lib/opal/nodes/iter.rb
@@ -44,6 +44,12 @@ module Opal
           unshift "(#{identity} = function(){"
         end
         push "}, #{identity}.$$s = self,"
+        # TODO: Compiler config, default of false
+        include_source_in_code = true
+        if include_source_in_code
+          file_path = File.expand_path("#{compiler.file}.rb")
+          push " #{identity}.$$sourcemap = {line: #{body_sexp.line}, column: #{body_sexp.column}, file: '#{file_path}'},"
+        end
         push " #{identity}.$$brk = $brk," if compiler.has_break?
         push " #{identity})"
       end


### PR DESCRIPTION
This is kind of a rehash of https://github.com/opal/opal/issues/105 but I think it still might be relevant for other libraries like opal-rspec (not for humans).

Source maps are great for exceptions and debugging. Exceptions slow down the code a lot though when you want code location info **outside of an exception**.

This would be an opt in compiler flag that adds this context to each block (included in this PR) and each method body (either via compiler trickery or in this rough sketch via the `defn` function in runtime, but I didn't go very far).

This could be used to implement `caller` in a more performant way or it could just be simple thing where code can access `functionObject.$$sourcemap` of a block/method to get its location.

Thoughts?

FYI, This would make https://github.com/opal/opal-rspec/issues/57 possible