### PR TITLE
Fixed setting mlhs arg to nil when JS-falsey value is passed.

### DIFF
--- a/lib/opal/nodes/args/normarg.rb
+++ b/lib/opal/nodes/args/normarg.rb
@@ -14,11 +14,15 @@ module Opal
         arg_name = @sexp[1].to_sym
         var_name = variable(arg_name)
 
-        default_value = scope.in_mlhs? ? "|| nil" : ""
-
         if @sexp.meta[:post]
           add_temp var_name
-          line "#{var_name} = #{scope.working_arguments}.splice(0,1)[0] #{default_value};"
+          line "#{var_name} = #{scope.working_arguments}.splice(0,1)[0];"
+        end
+
+        if scope.in_mlhs?
+          line "if (#{var_name} == null) {"
+          line "  #{var_name} = nil;"
+          line "}"
         end
       end
     end

--- a/spec/opal/core/language/arguments/mlhs_arg_spec.rb
+++ b/spec/opal/core/language/arguments/mlhs_arg_spec.rb
@@ -1,0 +1,19 @@
+# regression test
+describe 'mlhs argument' do
+  context 'when pased value is falsey in JS' do
+    it 'still returns it' do
+      p = ->((a)){ a }
+      p.call(false).should == false
+      p.call("").should == ""
+      p.call(0).should == 0
+    end
+  end
+
+  context 'when passed value == null' do
+    it 'replaces it with nil' do
+      p = ->((a)){ a }
+      p.call([`undefined`]).should == nil
+      p.call([`null`]).should == nil
+    end
+  end
+end


### PR DESCRIPTION
My regression, caused by https://github.com/opal/opal/pull/1395.
Can be easily reproduced with:
``` ruby
[[false], [""], [0]].each { |(a)| p a }
```