### PR TITLE
Add require_dependency alias for require

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Whitespace conventions:
 - Super works with define_method blocks
 - Added support for kwsplats.
 - Added support for squiggly heredoc.
+- Added `require_dependency` alias for `require` that eases code sharing with Rails/server side
 
 
 ### Changed

--- a/lib/opal/nodes/call.rb
+++ b/lib/opal/nodes/call.rb
@@ -232,6 +232,16 @@ module Opal
         push fragment('')
       end
 
+      # allows making require_dependency an alias that will work with Rails autoload
+      add_special :require_dependency do
+        file = compiler.file
+        str = DependencyResolver.new(compiler, arglist[1]).resolve
+        compiler.requires << str unless str.nil?
+        push fragment("self.$require(")
+        push process(arglist)
+        push fragment(')')
+      end
+
       add_special :require_relative do
         arg = arglist[1]
         file = compiler.file

--- a/spec/lib/compiler_spec.rb
+++ b/spec/lib/compiler_spec.rb
@@ -5,6 +5,10 @@ describe Opal::Compiler do
     it 'calls #require' do
       expect_compiled("require 'pippo'").to include('self.$require("pippo")')
     end
+
+    it 'calls #require_dependency' do
+      expect_compiled("require_dependency 'pippo'").to include('self.$require("pippo")')
+    end
   end
 
   describe 'requirable' do
@@ -118,6 +122,13 @@ describe Opal::Compiler do
     describe '#require' do
       it 'parses and resolve #require argument' do
         compiler = compiler_for(%Q{require "#{__FILE__}"})
+        expect(compiler.requires).to eq([__FILE__])
+      end
+    end
+
+    describe '#require_dependency' do
+      it 'parses and resolve #require argument' do
+        compiler = compiler_for(%Q{require_dependency "#{__FILE__}"})
         expect(compiler.requires).to eq([__FILE__])
       end
     end


### PR DESCRIPTION
When sharing code between Opal and Rails, server side, Rails autoload does not like `require`, but will work OK if you 'require_dependency'. Added alias that treats require_dependency just like require