### PR TITLE
Fix Regexp.new edge case with trailing escaped backslashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ Whitespace conventions:
 
 ### Fixed
 
+- `Regexp::new` no longer throws error when the expression ends in \\\\
 - `super` works properly with overwritten alias methods (#1384)
 - `NoMethodError` does not need a name to be instantiated
 - `method_added` fix for singleton class cases

--- a/opal/corelib/regexp.rb
+++ b/opal/corelib/regexp.rb
@@ -80,7 +80,7 @@ class Regexp < `RegExp`
 
         regexp = #{Opal.coerce_to!(regexp, String, :to_str)};
 
-        if (regexp.charAt(regexp.length - 1) === '\\') {
+        if (regexp.charAt(regexp.length - 1) === '\\' && regexp.charAt(regexp.length - 2) !== '\\') {
           #{raise RegexpError, "too short escape sequence: /#{regexp}/"}
         }
 

--- a/spec/filters/bugs/regexp.rb
+++ b/spec/filters/bugs/regexp.rb
@@ -137,6 +137,7 @@ opal_filter "regular_expressions" do
   fails "Regexp.compile given a String with escaped characters interprets a digit following a three-digit octal value as a character"
   fails "Regexp.compile given a String with escaped characters interprets a digit following a two-digit hexadecimal value as a character"
   fails "Regexp.compile given a String with escaped characters raises a Regexp error if there is a trailing backslash"
+  fails "Regexp.compile given a String with escaped characters does not raise a Regexp error if there is an escaped trailing backslash"
   fails "Regexp.compile given a String with escaped characters raises a RegexpError if \\x is not followed by any hexadecimal digits"
   fails "Regexp.compile given a String with escaped characters raises a RegexpError if less than four digits are given for \\uHHHH"
   fails "Regexp.compile given a String with escaped characters raises a RegexpError if more than six hexadecimal digits are given"


### PR DESCRIPTION
Ruby specs for this

https://github.com/ruby/spec/pull/227

With that new rubyspec, the (as of yet) unimplemented compile method fails with these reused specs, go ahead and exclude that