### PR TITLE
Fix compiler error handling for bootstrap case / run compiler specs on Opal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ Whitespace conventions:
 
 ### Fixed
 
+- `SourceMap::VLQ` patch (#1075)
 - `Regexp::new` no longer throws error when the expression ends in \\\\
 - `super` works properly with overwritten alias methods (#1384)
 - `NoMethodError` does not need a name to be instantiated

--- a/lib/opal/compiler.rb
+++ b/lib/opal/compiler.rb
@@ -154,7 +154,7 @@ module Opal
       @fragments = process(@sexp).flatten
 
       @result = @fragments.map(&:code).join('')
-    rescue => error
+    rescue Exception => error
       message = "An error occurred while compiling: #{self.file}\n#{error.message}"
       raise error.class, message, error.backtrace
     end

--- a/spec/filters/bugs/compiler_opal.rb
+++ b/spec/filters/bugs/compiler_opal.rb
@@ -1,0 +1,6 @@
+opal_filter "compiler (opal)" do
+  fails 'Opal::Compiler should compile undef calls'
+  fails 'Opal::Compiler method names when function name is reserved generates a valid named function for method'
+  fails 'Opal::Compiler pre-processing require-ish methods #require_relative parses and resolve #require_relative argument'
+  fails 'Opal::Compiler pre-processing require-ish methods #require_tree parses and resolve #require argument'
+end

--- a/spec/lib/compiler_spec.rb
+++ b/spec/lib/compiler_spec.rb
@@ -1,4 +1,5 @@
 require 'lib/spec_helper'
+require 'support/match_helpers'
 
 describe Opal::Compiler do
   describe 'requiring' do
@@ -18,6 +19,10 @@ describe Opal::Compiler do
       expect_compiled("", options).to include('Opal.modules["pippo"] = function(Opal) {')
       expect_compiled("", options).to end_with("};\n")
     end
+  end
+
+  it 'raises syntax errors properly' do
+    expect(lambda {Opal::Compiler.new('def foo').compile}).to raise_error Exception, /An error occurred while compiling:.*false/m
   end
 
   it "should compile simple ruby values" do
@@ -143,9 +148,10 @@ describe Opal::Compiler do
 
     describe '#require_tree' do
       require 'pathname'
-      let(:file) { Pathname(__FILE__).join('../fixtures/require_tree_test.rb') }
 
       it 'parses and resolve #require argument' do
+        file = Pathname(__FILE__).join('../fixtures/require_tree_test.rb')
+
         compiler = compiler_for(file.read)
         expect(compiler.required_trees).to eq(['../fixtures/required_tree_test'])
       end

--- a/spec/opal/stdlib/source_map_spec.rb
+++ b/spec/opal/stdlib/source_map_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+require 'source_map'
+
+describe 'SourceMap::VLQ' do
+  it 'encodes properly' do
+    SourceMap::VLQ.encode([0]).should == 'A'
+  end
+end

--- a/spec/support/match_helpers.rb
+++ b/spec/support/match_helpers.rb
@@ -1,0 +1,57 @@
+module MatchHelpers
+  class MatchMatcher
+    def initialize(expected)
+      fail "Expected #{expected} to be a Regexp!" unless expected.is_a?(Regexp)
+      @expected = expected
+    end
+
+    def matches?(actual)
+      @actual = actual
+      @expected.match(@actual)
+    end
+
+    def failure_message
+      ["Expected #{@actual.inspect} (#{@actual.class})",
+       "to match #{@expected}"]
+    end
+
+    def negative_failure_message
+      ["Expected #{@actual.inspect} (#{@actual.class})",
+       "not to match #{@expected}"]
+    end
+  end
+
+  class EndWithHelper
+    def initialize(expected)
+      @expected = expected
+    end
+
+    def matches?(actual)
+      @actual = actual
+      @actual.end_with?(@expected)
+    end
+
+    def failure_message
+      ["Expected #{@actual.inspect} (#{@actual.class})",
+       "to end with #{@expected}"]
+    end
+
+    def negative_failure_message
+      ["Expected #{@actual.inspect} (#{@actual.class})",
+       "not to end with #{@expected}"]
+    end
+  end
+end
+
+if !defined? RSpec
+  class Object
+    def match(expected)
+      MatchHelpers::MatchMatcher.new(expected)
+    end
+
+    def end_with(expected)
+      MatchHelpers::EndWithHelper.new(expected)
+    end
+  end
+end
+

--- a/spec/support/mspec_rspec_adapter.rb
+++ b/spec/support/mspec_rspec_adapter.rb
@@ -23,7 +23,7 @@ module MSpecRSpecAdapter
       end
     end
 
-    def not_to
+    def not_to(expectation)
       apply_expectation(:should_not, expectation)
     end
     alias to_not not_to

--- a/stdlib/source_map/vlq.rb
+++ b/stdlib/source_map/vlq.rb
@@ -28,12 +28,13 @@ module SourceMap
       result = []
       ary.each do |n|
         vlq = n < 0 ? ((-n) << 1) + 1 : n << 1
-        begin
+        loop do
           digit  = vlq & VLQ_BASE_MASK
           vlq  >>= VLQ_BASE_SHIFT
           digit |= VLQ_CONTINUATION_BIT if vlq > 0
           result << BASE64_DIGITS[digit]
-        end while vlq > 0
+          break unless vlq > 0
+        end
       end
       result.join
     end

--- a/tasks/testing.rake
+++ b/tasks/testing.rake
@@ -18,6 +18,7 @@ module Testing
       mspec/guards/block_device
       mspec/guards/endian
       a_file
+      lib/spec_helper
     ]
   end
 
@@ -35,7 +36,7 @@ module Testing
       File.directory?(path) ? Dir[path+'/*.rb'] : "#{path}.rb"
     end - excepting
 
-    opalspecs = Dir['spec/{opal,lib/parser}/**/*_spec.rb'] + ['spec/lib/lexer_spec.rb']
+    opalspecs = Dir['spec/{opal,lib/parser}/**/*_spec.rb'] + ['spec/lib/lexer_spec.rb', 'spec/lib/compiler_spec.rb']
     userspecs = Dir[pattern] if pattern
     userspecs &= rubyspecs if whitelist_pattern
 


### PR DESCRIPTION
The exception started slipping through the rescue in compiler.rb

Ultimately that needs to be fixed (along with validating whether SyntaxError or RuntimeError should be what's raised). For now, make the compiler specs runnable in Opal and filter what does not currently
pass (regex, `__FILE__` issues)

Add matchers to fill in for RSpec, stub out RSpec helper, fix not_to bridge