### PR TITLE
Raise an error when both literal block and an object as block are passed to the method call.

### DIFF
--- a/lib/opal/parser.rb
+++ b/lib/opal/parser.rb
@@ -423,6 +423,20 @@ module Opal
       s(:kwsplat, hash)
     end
 
+    def new_method_call_with_block(method_call, block_arg)
+      receiver, method_name, call_args = *method_call.children
+
+      if call_args && block_arg
+        last_arg = call_args.last
+
+        if Sexp === last_arg && last_arg.type == :block_pass
+          raise 'both block argument and literal block are passed'
+        end
+      end
+
+      method_call << block_arg
+    end
+
     def new_block_arg_splat(rest)
       if rest
         r = rest.to_s[1..-1].to_sym

--- a/lib/opal/parser/grammar.rb
+++ b/lib/opal/parser/grammar.rb
@@ -4604,8 +4604,7 @@ end
 # reduce 303 omitted
 
 def _reduce_304(val, _values, result)
-                      val[0] << val[1]
-                      result = val[0]
+                      result = new_method_call_with_block(val[0], val[1])
                     
     result
 end

--- a/lib/opal/parser/grammar.y
+++ b/lib/opal/parser/grammar.y
@@ -867,8 +867,7 @@ rule
                 | method_call
                 | method_call brace_block
                     {
-                      val[0] << val[1]
-                      result = val[0]
+                      result = new_method_call_with_block(val[0], val[1])
                     }
                 | tLAMBDA lambda
                     {

--- a/spec/filters/bugs/language.rb
+++ b/spec/filters/bugs/language.rb
@@ -298,4 +298,10 @@ opal_filter "language" do
   fails "An instance method with a default argument shadows an existing method with the same name as the local"
   fails "A nested method definition creates a method in the surrounding context when evaluated in a def expr.method"
   fails "The def keyword within a closure looks outside the closure for the visibility"
+  fails "Invoking a method allows []= with *args in the [] expanded to individual arguments"
+  fails "Invoking a method allows []= with multiple *args and does not unwrap the last splat"
+  fails "Invoking a method allows []= with multiple *args"
+  fails "Invoking a method allows []= with a *args and multiple rhs args"
+  fails "Invoking a method does not expand final array arguments after a splat expansion"
+  fails "Invoking a private getter method does not permit self as a receiver"
 end

--- a/spec/ruby_specs
+++ b/spec/ruby_specs
@@ -103,7 +103,6 @@ ruby/language
 !ruby/language/hash_spec
 !ruby/language/next_spec
 !ruby/language/return_spec
-!ruby/language/send_spec
 !ruby/language/yield_spec
 
 ruby/library/base64


### PR DESCRIPTION
Add spec/ruby/language/send_spec.rb to the test suite (it contains spec for this bug).
Closes #1369
