### PR TITLE
Optimize restarg according to #1096.

### DIFF
--- a/lib/opal/nodes/args/restarg.rb
+++ b/lib/opal/nodes/args/restarg.rb
@@ -25,7 +25,12 @@ module Opal
           # inline restarg case
           offset = @sexp.meta[:offset]
           # restarg value should be taken directly from parameters
-          line "#{var_name} = $slice.call(arguments, #{offset}, arguments.length);"
+          line "var $args_len = arguments.length, $rest_len = $args_len - #{offset};"
+          line "if ($rest_len < 0) { $rest_len = 0; }"
+          line "#{var_name} = new Array($rest_len);"
+          line "for (var $arg_idx = #{offset}; $arg_idx < $args_len; $arg_idx++) {"
+          line "  #{var_name}[$arg_idx - #{offset}] = arguments[$arg_idx];"
+          line "}"
         end
       end
     end


### PR DESCRIPTION
From what I see locally `ruby/spec` test suite is now 10% faster :smile: 
Closes https://github.com/opal/opal/issues/1343.