### PR TITLE
Fix underlying ancestor issue that caused case compare regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Whitespace conventions:
 
 ### Fixed
 
+- `Module#ancestors` and shared code like `====` and `is_a?` deal with singleton class modules better (#1449)
 - `Pathname#absolute?` and `Pathname#relative?` now work properly
 - `File::dirname` and `File::basename` are now Rubyspec compliant
 - `SourceMap::VLQ` patch (#1075)

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -904,7 +904,14 @@
         }
       }
 
-      parent = parent.$$is_class ? parent.$$super : null;
+      // only the actual singleton class gets included in its ancestry
+      // after that, traverse the normal class hierarchy
+      if (parent.$$is_singleton && parent.$$singleton_of.$$is_module) {
+        parent = parent.$$singleton_of.$$super;
+      }
+      else {
+        parent = parent.$$is_class ? parent.$$super : null;
+      }
     }
 
     return result;

--- a/spec/ruby_specs
+++ b/spec/ruby_specs
@@ -2,6 +2,7 @@ ruby/core/array
 ruby/core/basicobject
 ruby/core/builtin_constants
 ruby/core/class
+!ruby/core/class/to_s_spec
 ruby/core/comparable
 
 ruby/core/complex


### PR DESCRIPTION
When a singleton class for a module is used, don't traverse the class hierarchy

https://github.com/ruby/spec/pull/245 should cover this one fairly well (and Opal will pass all of them when it's merged)

Fixes https://github.com/opal/opal/issues/1449
