### PR TITLE
Enable CRuby tests again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,9 @@ matrix:
       env: RUN=mspec_ruby_sprockets_phantomjs
 
     - rvm: 2.3.0
+      env: RUN=minitest
+
+    - rvm: 2.3.0
       env: RUN=rspec RACK_VERSION='2.0.0.alpha' CHECK_COVERAGE=true
 
     - rvm: ruby-head


### PR DESCRIPTION
(can catch some things ruby specs do not test yet).

Also remove the minitest task since all it did was call the CRuby tests.
This way it's more clear in Travis what's going on.