### PR TITLE
Allow require to work with current directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ Whitespace conventions:
 
 - `Module#ancestors` and shared code like `====` and `is_a?` deal with singleton class modules better (#1449)
 - `Class#to_s` now shows correct names for singleton classes
+- `require` statements can now be used with './' and '../', relative to the directory Opal was run from (#1286)
 - `Pathname#absolute?` and `Pathname#relative?` now work properly
 - `File::dirname` and `File::basename` are now Rubyspec compliant
 - `SourceMap::VLQ` patch (#1075)

--- a/lib/opal/hike_path_finder.rb
+++ b/lib/opal/hike_path_finder.rb
@@ -16,6 +16,7 @@ module Opal
       super
     end
 
+    # Cover require './something' and require '../something' cases, which should use the current directory
     def find_relative_current_dir path
       # Hike is great, but doesn't seem to do very well when trying to deal with relative paths (.. in particular)
       basename = File.basename(path)
@@ -39,15 +40,11 @@ module Opal
     private
 
     def sort_matches(matches, basename)
-      aliases = []
-
       matches.sort_by do |match|
         extnames = match.sub(basename.to_s, '').to_s.scan(/\.[^.]+/)
         extnames.inject(0) do |sum, ext|
           if i = extensions.index(ext)
             sum + i + 1
-          elsif i = aliases.index(ext)
-            sum + i + 11
           else
             sum
           end

--- a/lib/opal/hike_path_finder.rb
+++ b/lib/opal/hike_path_finder.rb
@@ -35,6 +35,8 @@ module Opal
           return pathname.expand_path.to_s
         end
       end
+      # not found
+      nil
     end
 
     private

--- a/lib/opal/hike_path_finder.rb
+++ b/lib/opal/hike_path_finder.rb
@@ -14,5 +14,17 @@ module Opal
       return path if pathname.absolute? and pathname.exist?
       super
     end
+
+    def find_relative_current_dir path
+      current_dir_index.find path
+    end
+
+    private
+
+    def current_dir_index
+      @current_dir_index ||= begin
+        Hike::Index.new(Dir.pwd, [Dir.pwd], extensions, aliases)
+      end
+    end
   end
 end

--- a/lib/opal/hike_path_finder.rb
+++ b/lib/opal/hike_path_finder.rb
@@ -9,7 +9,7 @@ module Opal
       append_extensions '.js', '.js.rb', '.rb', '.opalerb'
     end
 
-    def find path
+    def find path, options={}
       pathname = Pathname(path)
       return path if pathname.absolute? and pathname.exist?
       super

--- a/lib/opal/hike_path_finder.rb
+++ b/lib/opal/hike_path_finder.rb
@@ -7,6 +7,7 @@ module Opal
       super()
       append_paths(*paths)
       append_extensions '.js', '.js.rb', '.rb', '.opalerb'
+      @patterns = {}
     end
 
     def find path, options={}
@@ -16,15 +17,52 @@ module Opal
     end
 
     def find_relative_current_dir path
-      current_dir_index.find path
+      # Hike is great, but doesn't seem to do very well when trying to deal with relative paths (.. in particular)
+      basename = File.basename(path)
+      dirname = Pathname(path).dirname
+      pattern = pattern_for basename
+      matches = entries(dirname)
+      matches = matches.select { |m| m.to_s =~ pattern }
+      sort_matches(matches, basename).each do |path|
+        pathname = dirname.join(path)
+
+        # Potential `stat` syscall
+        stat = stat(pathname)
+
+        # Exclude directories
+        if stat && stat.file?
+          return pathname.expand_path.to_s
+        end
+      end
     end
 
     private
 
-    def current_dir_index
-      @current_dir_index ||= begin
-        Hike::Index.new(Dir.pwd, [Dir.pwd], extensions, aliases)
+    def sort_matches(matches, basename)
+      aliases = []
+
+      matches.sort_by do |match|
+        extnames = match.sub(basename.to_s, '').to_s.scan(/\.[^.]+/)
+        extnames.inject(0) do |sum, ext|
+          if i = extensions.index(ext)
+            sum + i + 1
+          elsif i = aliases.index(ext)
+            sum + i + 11
+          else
+            sum
+          end
+        end
       end
+    end
+
+    def pattern_for(basename)
+      @patterns[basename] ||= build_pattern_for(basename)
+    end
+
+    def build_pattern_for(basename)
+      basename_re = Regexp.escape(basename.to_s)
+      extension_pattern = extensions.map { |e| Regexp.escape(e) }.join("|")
+      /^#{basename_re}(?:#{extension_pattern})*$/
     end
   end
 end

--- a/lib/opal/nodes/call.rb
+++ b/lib/opal/nodes/call.rb
@@ -230,12 +230,9 @@ module Opal
         # do this first to preserve the ./ for builder, etc.
         str = DependencyResolver.new(compiler, file).resolve
         if file.type == :str
-          filename = file[1]
-          match = /^\.\/(.*)/.match(filename)
-          if match
-            # Hike/PathReader take care of finding require './something' in the filesytem, but we need to strip the ./
-            file[1] = match[1]
-          end
+          # Hike/PathReader take care of finding require './something' in the filesytem, but we need to strip off the ./ or ../
+          match = %r{\A\.?\.#{File::SEPARATOR}(.*)}.match(file[1])
+          file[1] = match[1] if match
         end
         compile_default!
         compiler.requires << str unless str.nil?

--- a/lib/opal/nodes/call.rb
+++ b/lib/opal/nodes/call.rb
@@ -226,8 +226,18 @@ module Opal
       end
 
       add_special :require do
+        file = arglist[1]
+        # do this first to preserve the ./ for builder, etc.
+        str = DependencyResolver.new(compiler, file).resolve
+        if file.type == :str
+          filename = file[1]
+          match = /^\.\/(.*)/.match(filename)
+          if match
+            # Hike/PathReader take care of finding require './something' in the filesytem, but we need to strip the ./
+            file[1] = match[1]
+          end
+        end
         compile_default!
-        str = DependencyResolver.new(compiler, arglist[1]).resolve
         compiler.requires << str unless str.nil?
         push fragment('')
       end

--- a/lib/opal/nodes/top.rb
+++ b/lib/opal/nodes/top.rb
@@ -38,7 +38,12 @@ module Opal
 
       def opening
         if compiler.requirable?
-          path = Pathname(compiler.file).cleanpath.to_s
+          path = Pathname(compiler.file)
+          # Don't want relative paths in modules
+          if path.to_s =~ /^\.\./
+            path = path.relative_path_from(path.dirname)
+          end
+          path = path.cleanpath.to_s
           line "Opal.modules[#{path.inspect}] = function(Opal) {"
         elsif compiler.eval?
           line "(function(Opal, self) {"

--- a/lib/opal/path_reader.rb
+++ b/lib/opal/path_reader.rb
@@ -13,8 +13,10 @@ module Opal
     end
 
     def expand(path)
-      if Pathname.new(path).absolute? || path =~ %r{\A\.?\.#{File::SEPARATOR}}
+      if Pathname.new(path).absolute?
         path
+      elsif path =~ %r{\A\.?\.#{File::SEPARATOR}}
+        file_finder.find(path, base_path: Dir.pwd)
       else
         file_finder.find(path)
       end

--- a/lib/opal/path_reader.rb
+++ b/lib/opal/path_reader.rb
@@ -16,7 +16,7 @@ module Opal
       if Pathname.new(path).absolute?
         path
       elsif path =~ %r{\A\.?\.#{File::SEPARATOR}}
-        file_finder.find(path, base_path: Dir.pwd)
+        file_finder.find_relative_current_dir(path)
       else
         file_finder.find(path)
       end

--- a/spec/filters/bugs/compiler_opal.rb
+++ b/spec/filters/bugs/compiler_opal.rb
@@ -2,4 +2,7 @@ opal_filter "compiler (opal)" do
   fails 'Opal::Compiler should compile undef calls'
   fails 'Opal::Compiler method names when function name is reserved generates a valid named function for method'
   fails 'Opal::Compiler pre-processing require-ish methods #require_tree parses and resolve #require argument'
+  fails 'Opal::Compiler requiring removes leading ../ from relative requires'
+  fails 'Opal::Compiler requiring removes leading ./ from relative requires'
+  fails 'Opal::Compiler requirable does not create "Opal.modules" with relative pathnames'
 end

--- a/spec/lib/compiler_spec.rb
+++ b/spec/lib/compiler_spec.rb
@@ -10,6 +10,10 @@ describe Opal::Compiler do
     it 'removes leading ./ from relative requires' do
       expect_compiled("require './pippo'").to include('self.$require("pippo")')
     end
+
+    it 'removes leading ../ from relative requires' do
+      expect_compiled("require '../pippo'").to include('self.$require("pippo")')
+    end
   end
 
   describe 'requirable' do
@@ -133,6 +137,11 @@ describe Opal::Compiler do
       it "parses and resolves #require argument with leading ./" do
         compiler = compiler_for('require "./pippo"')
         expect(compiler.requires).to eq(['./pippo'])
+      end
+
+      it "parses and resolves #require argument with leading ../" do
+        compiler = compiler_for('require "../pippo"')
+        expect(compiler.requires).to eq(['../pippo'])
       end
     end
 

--- a/spec/lib/compiler_spec.rb
+++ b/spec/lib/compiler_spec.rb
@@ -6,6 +6,10 @@ describe Opal::Compiler do
     it 'calls #require' do
       expect_compiled("require 'pippo'").to include('self.$require("pippo")')
     end
+
+    it 'removes leading ./ from relative requires' do
+      expect_compiled("require './pippo'").to include('self.$require("pippo")')
+    end
   end
 
   describe 'requirable' do
@@ -124,6 +128,11 @@ describe Opal::Compiler do
       it 'parses and resolve #require argument' do
         compiler = compiler_for(%Q{require "#{__FILE__}"})
         expect(compiler.requires).to eq([__FILE__])
+      end
+
+      it "parses and resolves #require argument with leading ./" do
+        compiler = compiler_for('require "./pippo"')
+        expect(compiler.requires).to eq(['./pippo'])
       end
     end
 

--- a/spec/lib/compiler_spec.rb
+++ b/spec/lib/compiler_spec.rb
@@ -27,6 +27,12 @@ describe Opal::Compiler do
       expect_compiled("", options).to include('Opal.modules["pippo"] = function(Opal) {')
       expect_compiled("", options).to end_with("};\n")
     end
+
+    it 'does not create "Opal.modules" with relative pathnames' do
+      options = { :requirable => true, :file => "../pippo" }
+      expect_compiled("", options).to include('Opal.modules["pippo"] = function(Opal) {')
+      expect_compiled("", options).to end_with("};\n")
+    end
   end
 
   it 'raises syntax errors properly' do

--- a/spec/lib/hike_path_finder_spec.rb
+++ b/spec/lib/hike_path_finder_spec.rb
@@ -30,6 +30,10 @@ describe Opal::HikePathFinder do
     it 'starting with ./ and no extension' do
       expect(path_finder.find_relative_current_dir('./spec/lib/shared/path_reader_shared')).to eq(path_reader_shared_full)
     end
+
+    it 'returns nil if not found' do
+      expect(path_finder.find_relative_current_dir('/foobar')).to be_nil
+    end
   end
 
   context 'relative in a different directory' do

--- a/spec/lib/hike_path_finder_spec.rb
+++ b/spec/lib/hike_path_finder_spec.rb
@@ -8,6 +8,7 @@ describe Opal::HikePathFinder do
   let(:path) { 'fixtures/opal_file' }
   let(:full_path) { File.join(root, path + ext) }
   let(:ext) { '.rb' }
+  let(:path_reader_shared_full) { File.expand_path './spec/lib/shared/path_reader_shared.rb' }
 
   include_examples :path_finder
 
@@ -18,6 +19,34 @@ describe Opal::HikePathFinder do
 
     it 'gives nil if it is missing' do
       expect(path_finder.find(full_path+'/not-real')).to eq(nil)
+    end
+  end
+
+  context 'with relative paths' do
+    it 'starting with ./ and an extension' do
+      expect(path_finder.find_relative_current_dir('./spec/lib/shared/path_reader_shared.rb')).to eq(path_reader_shared_full)
+    end
+
+    it 'starting with ./ and no extension' do
+      expect(path_finder.find_relative_current_dir('./spec/lib/shared/path_reader_shared')).to eq(path_reader_shared_full)
+    end
+  end
+
+  context 'relative in a different directory' do
+    around do |ex|
+      # expand this before we change directories
+      @expected_path = path_reader_shared_full
+      Dir.chdir './spec/lib/shared' do
+        ex.run
+      end
+    end
+
+    it 'starting with ./ and an extension' do
+      expect(path_finder.find_relative_current_dir('./path_reader_shared.rb')).to eq(@expected_path)
+    end
+
+    it 'starting with ./ and no extension' do
+      expect(path_finder.find_relative_current_dir('./path_reader_shared')).to eq(@expected_path)
     end
   end
 end

--- a/spec/lib/hike_path_finder_spec.rb
+++ b/spec/lib/hike_path_finder_spec.rb
@@ -48,5 +48,17 @@ describe Opal::HikePathFinder do
     it 'starting with ./ and no extension' do
       expect(path_finder.find_relative_current_dir('./path_reader_shared')).to eq(@expected_path)
     end
+
+    it 'starting with ../ and no extension' do
+      expect(path_finder.find_relative_current_dir('../shared/path_reader_shared')).to eq(@expected_path)
+    end
+
+    it 'starting with ../ and no extension, to parent dir' do
+      expect(path_finder.find_relative_current_dir('../hike_path_finder_spec')).to eq(__FILE__)
+    end
+
+    it 'starting with ../ to parent dir' do
+      expect(path_finder.find_relative_current_dir('../hike_path_finder_spec.rb')).to eq(__FILE__)
+    end
   end
 end

--- a/spec/lib/path_reader_spec.rb
+++ b/spec/lib/path_reader_spec.rb
@@ -44,6 +44,11 @@ describe Opal::PathReader do
       expect(path_reader.expand('./spec/lib/shared/path_reader_shared.rb')).to eq('foobar')
     end
 
+    it 'expands relative paths starting with ../' do
+      path_finder.stub(:find_relative_current_dir).with("../#{File.basename(Dir.pwd)}/spec/lib/shared/path_reader_shared.rb").and_return('foobar')
+      expect(path_reader.expand("../#{File.basename(Dir.pwd)}/spec/lib/shared/path_reader_shared.rb")).to eq('foobar')
+    end
+
     it 'expands relative paths starting with ./ without an extension' do
       path_finder.stub(:find_relative_current_dir).with('./spec/lib/shared/path_reader_shared').and_return('foobar')
       expect(path_reader.expand('./spec/lib/shared/path_reader_shared')).to eq('foobar')

--- a/spec/lib/path_reader_spec.rb
+++ b/spec/lib/path_reader_spec.rb
@@ -10,6 +10,7 @@ describe Opal::PathReader do
   let(:path) { 'opal_file' }
   let(:full_path) { File.expand_path('../fixtures/opal_file.rb', __FILE__) }
   let(:contents) { File.read(full_path) }
+  let(:path_reader_shared_full_path) { File.expand_path './spec/lib/shared/path_reader_shared.rb' }
 
   before do
     path_finder.stub(:find) {|path| nil}
@@ -26,10 +27,30 @@ describe Opal::PathReader do
     end
 
     it 'works with relative paths starting with ./' do
+      path_finder.stub(:find).with('./spec/lib/shared/path_reader_shared.rb', base_path: Dir.pwd).and_return(path_reader_shared_full_path)
       expect(path_reader.read('./spec/lib/shared/path_reader_shared.rb')).not_to be_nil
     end
 
-    it 'works with absolute paths' do
+    it 'expands absolute paths' do
+      expect(path_reader.expand(__FILE__)).to eq File.expand_path(__FILE__)
+    end
+
+    it 'expands relative paths using finder' do
+      expect(path_reader.expand('opal_file')).to eq full_path
+    end
+
+    it 'expands relative paths starting with ./' do
+      path_finder.stub(:find).with('./spec/lib/shared/path_reader_shared.rb', base_path: Dir.pwd).and_return('foobar')
+      expect(path_reader.expand('./spec/lib/shared/path_reader_shared.rb')).to eq('foobar')
+    end
+
+    it 'expands relative paths starting with ./ without an extension' do
+      path_finder.stub(:find).with('./spec/lib/shared/path_reader_shared', base_path: Dir.pwd).and_return('foobar')
+      expect(path_reader.expand('./spec/lib/shared/path_reader_shared')).to eq('foobar')
+    end
+
+    it 'works with relative paths starting with ..' do
+      path_finder.stub(:find).with("../#{File.basename(Dir.pwd)}/spec/lib/shared/path_reader_shared.rb", base_path: Dir.pwd).and_return(path_reader_shared_full_path)
       expect(path_reader.read("../#{File.basename(Dir.pwd)}/spec/lib/shared/path_reader_shared.rb")).not_to be_nil
     end
   end

--- a/spec/lib/path_reader_spec.rb
+++ b/spec/lib/path_reader_spec.rb
@@ -27,7 +27,7 @@ describe Opal::PathReader do
     end
 
     it 'works with relative paths starting with ./' do
-      path_finder.stub(:find).with('./spec/lib/shared/path_reader_shared.rb', base_path: Dir.pwd).and_return(path_reader_shared_full_path)
+      path_finder.stub(:find_relative_current_dir).with('./spec/lib/shared/path_reader_shared.rb').and_return(path_reader_shared_full_path)
       expect(path_reader.read('./spec/lib/shared/path_reader_shared.rb')).not_to be_nil
     end
 
@@ -40,17 +40,17 @@ describe Opal::PathReader do
     end
 
     it 'expands relative paths starting with ./' do
-      path_finder.stub(:find).with('./spec/lib/shared/path_reader_shared.rb', base_path: Dir.pwd).and_return('foobar')
+      path_finder.stub(:find_relative_current_dir).with('./spec/lib/shared/path_reader_shared.rb').and_return('foobar')
       expect(path_reader.expand('./spec/lib/shared/path_reader_shared.rb')).to eq('foobar')
     end
 
     it 'expands relative paths starting with ./ without an extension' do
-      path_finder.stub(:find).with('./spec/lib/shared/path_reader_shared', base_path: Dir.pwd).and_return('foobar')
+      path_finder.stub(:find_relative_current_dir).with('./spec/lib/shared/path_reader_shared').and_return('foobar')
       expect(path_reader.expand('./spec/lib/shared/path_reader_shared')).to eq('foobar')
     end
 
     it 'works with relative paths starting with ..' do
-      path_finder.stub(:find).with("../#{File.basename(Dir.pwd)}/spec/lib/shared/path_reader_shared.rb", base_path: Dir.pwd).and_return(path_reader_shared_full_path)
+      path_finder.stub(:find_relative_current_dir).with("../#{File.basename(Dir.pwd)}/spec/lib/shared/path_reader_shared.rb").and_return(path_reader_shared_full_path)
       expect(path_reader.read("../#{File.basename(Dir.pwd)}/spec/lib/shared/path_reader_shared.rb")).not_to be_nil
     end
   end


### PR DESCRIPTION
Replicate MRI behavior, probably needs some discussion before squashing.

Should fix https://github.com/opal/opal/issues/1286 - see discussion there

This approach avoids adding the current directory to the load path (which would be incompatible with MRI) and it also scrubs the ".." and "." references out of `Opal.modules` and `self.$require` calls.

The main remaining issue is there are a few bugs in Pathname that prevent the compiler_spec changes here from running under Opal (as in bootstrap compiling) and thus the filter. One of those bugs is fixed by https://github.com/opal/opal/pull/1445 but there are others.

**Alternative approach:**
Add the current directory to the load path, but ignore it unless '..' or '.' is used in the require statement. You'd still need to clean up `Opal.modules` and `self.$require` though and you'd probably do just as much if not more Hike hacking than what's done here.
