### PR TITLE
Optimize Enumerable#count

### DIFF
--- a/opal/corelib/array.rb
+++ b/opal/corelib/array.rb
@@ -554,6 +554,14 @@ class Array < `Array`
     self
   end
 
+  def count(object = nil, &block)
+    if !(object || block) && respond_to?(:size)
+      size
+    else
+      super
+    end
+  end
+
   def initialize_copy(other)
     replace other
   end

--- a/opal/corelib/array.rb
+++ b/opal/corelib/array.rb
@@ -555,10 +555,10 @@ class Array < `Array`
   end
 
   def count(object = nil, &block)
-    if !(object || block) && respond_to?(:size)
-      size
-    else
+    if object || block
       super
+    else
+      size
     end
   end
 

--- a/opal/corelib/enumerable.rb
+++ b/opal/corelib/enumerable.rb
@@ -111,11 +111,11 @@ module Enumerable
     map { |item| yield item }.flatten(1)
   end
 
-  def count(object = nil, &block)
+  def count(object = undefined, &block)
     %x{
       var result = 0;
 
-      if (#{Opal.truthy?(`object`)}) {
+      if (object != null) {
         block = function(arg) {
           return #{`arg` == `object`};
         };

--- a/opal/corelib/enumerable.rb
+++ b/opal/corelib/enumerable.rb
@@ -112,35 +112,21 @@ module Enumerable
   end
 
   def count(object = undefined, &block)
-    %x{
-      var result = 0;
+    result = 0
 
-      if (object != null) {
-        block = function() {
-          var args = [];
-          for(var i = 0; i < arguments.length; i++) { args[i] = arguments[i] }
+    if `object != null`
+      block = proc do |*args|
+        `Opal.destructure(args)` == object
+      end
+    elsif block.nil?
+      block = proc { true }
+    end
 
-          return #{`Opal.destructure(args)` == `object`};
-        };
-      } else if (block === nil) {
-        block = function() { return true; };
-      }
+    each do |*args|
+      `result++` if block.call(*args)
+    end
 
-      self.$each.$$p = function() {
-        var args = [];
-        for(var i = 0; i < arguments.length; i++) { args[i] = arguments[i] }
-
-        var value = Opal.yieldX(block, args);
-
-        if (#{Opal.truthy?(`value`)}) {
-          result++;
-        }
-      }
-
-      self.$each();
-
-      return result;
-    }
+    result
   end
 
   def cycle(n = nil, &block)

--- a/opal/corelib/enumerable.rb
+++ b/opal/corelib/enumerable.rb
@@ -111,21 +111,24 @@ module Enumerable
     map { |item| yield item }.flatten(1)
   end
 
-  def count(object = undefined, &block)
+  def count(object = nil, &block)
     %x{
       var result = 0;
 
-      if (object != null) {
-        block = function() {
-          return #{Opal.destructure(`arguments`) == `object`};
+      if (#{Opal.truthy?(`object`)}) {
+        block = function(arg) {
+          return #{`arg` == `object`};
         };
-      }
-      else if (block === nil) {
+      } else if (block === nil) {
         block = function() { return true; };
       }
 
       self.$each.$$p = function() {
-        var value = Opal.yieldX(block, arguments);
+        var args = [];
+        for(var i = 0; i < arguments.length; i++) {
+          args[i] = arguments[i];
+        }
+        var value = Opal.yieldX(block, args);
 
         if (#{Opal.truthy?(`value`)}) {
           result++;

--- a/opal/corelib/enumerable.rb
+++ b/opal/corelib/enumerable.rb
@@ -116,8 +116,11 @@ module Enumerable
       var result = 0;
 
       if (object != null) {
-        block = function(arg) {
-          return #{`arg` == `object`};
+        block = function() {
+          var args = [];
+          for(var i = 0; i < arguments.length; i++) { args[i] = arguments[i] }
+
+          return #{`Opal.destructure(args)` == `object`};
         };
       } else if (block === nil) {
         block = function() { return true; };
@@ -125,9 +128,8 @@ module Enumerable
 
       self.$each.$$p = function() {
         var args = [];
-        for(var i = 0; i < arguments.length; i++) {
-          args[i] = arguments[i];
-        }
+        for(var i = 0; i < arguments.length; i++) { args[i] = arguments[i] }
+
         var value = Opal.yieldX(block, args);
 
         if (#{Opal.truthy?(`value`)}) {

--- a/opal/corelib/enumerable.rb
+++ b/opal/corelib/enumerable.rb
@@ -112,10 +112,6 @@ module Enumerable
   end
 
   def count(object = nil, &block)
-    unless object || block
-      return size
-    end
-
     %x{
       var result = 0;
 

--- a/opal/corelib/enumerable.rb
+++ b/opal/corelib/enumerable.rb
@@ -116,14 +116,14 @@ module Enumerable
 
     if `object != null`
       block = proc do |*args|
-        `Opal.destructure(args)` == object
+        Opal.destructure(args) == object
       end
     elsif block.nil?
       block = proc { true }
     end
 
     each do |*args|
-      `result++` if block.call(*args)
+      `result++` if `Opal.yieldX(block, args)`
     end
 
     result

--- a/opal/corelib/enumerable.rb
+++ b/opal/corelib/enumerable.rb
@@ -112,6 +112,10 @@ module Enumerable
   end
 
   def count(object = nil, &block)
+    unless object || block
+      return size
+    end
+
     %x{
       var result = 0;
 


### PR DESCRIPTION
One of the most common uses of `Enumerable#count` is as an alias for `length` or `size`. Without a block or argument, we can short-circuit this to `size`. I also switched out the passing of `arguments` to `Opal.yieldX` so the function could be optimized.

I broke some tests for what looks like the more obscure cases, so I'll need to check into that, but it seems to work for the more common cases.

All benchmarks are iterations/sec after a 100ms warmup. The array has 1000 elements. Higher results are better. I included `Array#size` to show the performance ceiling.

### Safari 9.1.2

#### Before

```
array.size
  1779658
array.count
  4931
array.count(1)
  1958
array.count(&:odd?)
  480
array.count { |i| i.odd? }
  2042
```

#### After

```
array.size
  1546681
array.count
  1471198
array.count(1)
  2873
array.count(&:odd?)
  464
array.count { |i| i.odd? }
  2572
```

### Chrome 51

#### Before

```
array.size
  3197569
array.count
  3905
array.count(1)
  2087
array.count(&:odd?)
  397
array.count { |i| i.odd? }
  1868
```

#### After

```
array.size
  2191544
array.count
  2100559
array.count(1)
  3324
array.count(&:odd?)
  567
array.count { |i| i.odd? }
  3134
```

### Firefox 43

#### Before

```
    array.size
        1642654
    array.count
        1333
    array.count(1)
        693
    array.count(&:odd?)
        359
    array.count { |i| i.odd? }
        840
```

#### After

```
    array.size
        1840939
    array.count
        1434968
    array.count(1)
        1929
    array.count(&:odd?)
        458
    array.count { |i| i.odd? }
        1933
```