### PR TITLE
Fixes Native Hash initialize to work with React.rb

### DIFF
--- a/stdlib/native.rb
+++ b/stdlib/native.rb
@@ -526,7 +526,7 @@ class Hash
 
   def initialize(defaults = undefined, &block)
     %x{
-      if (defaults !== undefined && defaults.constructor === Object) {
+      if (defaults !== undefined && defaults != null && defaults.constructor === Object) {
         var smap = self.$$smap,
             keys = self.$$keys,
             key, value;

--- a/stdlib/native.rb
+++ b/stdlib/native.rb
@@ -526,7 +526,7 @@ class Hash
 
   def initialize(defaults = undefined, &block)
     %x{
-      if (defaults !== undefined && defaults != null && defaults.constructor === Object) {
+      if (defaults != null && defaults.constructor === Object) {
         var smap = self.$$smap,
             keys = self.$$keys,
             key, value;


### PR DESCRIPTION
Currently in 0.9 when using alongside React.rb, component rendering will break and return this error
```js
TypeError: Cannot read property 'constructor' of null
```

This traces back to the Native Hash initialize method
```ruby
def initialize(defaults = undefined, &block)
  %x{
    if (defaults !== undefined && defaults.constructor === Object) {
```

In the current 0.8, this method checks
```ruby
def initialize(defaults = undefined, &block)
  %x{
    if (defaults != null) {
      if (defaults.constructor === Object) {
```

I'm not sure exactly why it was changed, but changing it to

```ruby
def initialize(defaults = undefined, &block)
  %x{
    if (defaults !== undefined && defaults != null && defaults.constructor === Object) {
```
appears to fix it and allows me to go on with life.
 