### PR TITLE
super fixes for replace-opal-parser branch

### DIFF
--- a/lib/opal/nodes/scope.rb
+++ b/lib/opal/nodes/scope.rb
@@ -265,11 +265,10 @@ module Opal
             chain << scope.identify!
             scope = scope.parent if scope.parent
 
-          elsif scope.type == :def
+          elsif [:def, :defs].include?(scope.type)
             defn = scope.identify!
             mid  = "'#{scope.mid}'"
             break
-
           else
             break
           end

--- a/lib/opal/nodes/super.rb
+++ b/lib/opal/nodes/super.rb
@@ -26,8 +26,9 @@ module Opal
       end
 
       def extract_iter
+        super
         # TODO: Find a way to make this more elegant
-        @iter = s(:js_tmp, 'null')
+        @iter ||= s(:js_tmp, 'null')
       end
 
       def method_jsid
@@ -127,9 +128,14 @@ module Opal
       handle :zsuper
 
       def extract_iter
-        # Need to support passing block up even if it's not referenced in this method at all
-        scope.uses_block!
-        @iter = s(:js_tmp, '$iter')
+        super
+        # preserve a block if we have one already but otherwise, assume a block is coming from higher
+        # up the chain
+        unless iter.type == :iter
+          # Need to support passing block up even if it's not referenced in this method at all
+          scope.uses_block!
+          @iter = s(:js_tmp, '$iter')
+        end
       end
 
       def compile

--- a/lib/opal/nodes/super.rb
+++ b/lib/opal/nodes/super.rb
@@ -80,7 +80,6 @@ module Opal
         chain, cur_defn, mid = scope.get_super_chain
         trys = chain.map { |c| "#{c}.$$def" }.join(' || ')
         implicit = @implicit_args.to_s
-
         "Opal.find_iter_super_dispatcher(self, #{mid}, (#{trys} || #{cur_defn}), #{defined_check_param}, #{implicit_arguments_param})"
       end
 

--- a/lib/opal/nodes/super.rb
+++ b/lib/opal/nodes/super.rb
@@ -27,7 +27,6 @@ module Opal
 
       def extract_iter
         super
-        # TODO: Find a way to make this more elegant
         @iter ||= s(:js_tmp, 'null')
       end
 

--- a/lib/opal/nodes/super.rb
+++ b/lib/opal/nodes/super.rb
@@ -17,7 +17,6 @@ module Opal
       private
 
       def extract_arglist
-        puts 'extract arglist'
         self.arglist = s(:arglist, *@sexp.children)
       end
 
@@ -26,17 +25,9 @@ module Opal
         s(:self)
       end
 
-      def iter
-        # Need to support passing block up even if it's not referenced in this method at all
-        @iter ||= begin
-          puts "arglist is #{arglist}"
-          if arglist.children.any? # TODO: Better understand this elsif vs. the else code path
-            s(:js_tmp, 'null')
-          else
-            scope.uses_block!
-            s(:js_tmp, '$iter')
-          end
-        end
+      def extract_iter
+        # TODO: Find a way to make this more elegant
+        @iter = s(:js_tmp, 'null')
       end
 
       def method_jsid
@@ -93,7 +84,6 @@ module Opal
       end
 
       def add_method(temporary_receiver)
-        puts "add_method, scope.def? #{scope.def?} scope iter? #{scope.iter?}"
         super_call = if scope.def?
           super_method_invocation
         elsif scope.iter?
@@ -136,6 +126,12 @@ module Opal
     class ZsuperNode < SuperNode
       handle :zsuper
 
+      def extract_iter
+        # Need to support passing block up even if it's not referenced in this method at all
+        scope.uses_block!
+        @iter = s(:js_tmp, '$iter')
+      end
+
       def compile
         @implicit_args = true
         if containing_def_scope
@@ -143,9 +139,7 @@ module Opal
           implicit_args = [s(:js_tmp, '$zuper')]
           # If the method we're in has a block and we're using a default super call with no args, we need to grab the block
           # If an iter (block via braces) is provided, that takes precedence
-          puts "formal_block_parameter is #{formal_block_parameter} !iter #{!iter} iter is #{iter}"
           if (block_arg = formal_block_parameter) && !iter
-            puts 'adding block in'
             block_pass = s(:block_pass, s(:lvar, block_arg[1]))
             implicit_args << expr
           end
@@ -156,12 +150,10 @@ module Opal
       end
 
       def formal_block_parameter
-        puts "containing_def_scope is #{containing_def_scope}"
         case containing_def_scope
           when Opal::Nodes::IterNode
             containing_def_scope.extract_block_arg
           when Opal::Nodes::DefNode
-            puts "def node block_arg is #{containing_def_scope.block_arg}"
             containing_def_scope.block_arg
           else
             raise "Don't know what to do with scope #{containing_def_scope}"

--- a/spec/filters/bugs/switching_to_parser.rb
+++ b/spec/filters/bugs/switching_to_parser.rb
@@ -11,14 +11,6 @@ opal_filter 'To fix in corelib/**:' do
   # hash
   fails "Hash#default_proc= uses :to_proc on its argument" # looks like it didn't work before, returning value must be a passed argument
 
-  # range (most probably a super issue)
-  fails "Range#min given a block passes each pair of values in the range to the block"
-  fails "Range#min given a block passes each pair of elements to the block where the first argument is the current element, and the last is the first element"
-  fails "Range#min given a block returns the element the block determines to be the minimum"
-  fails "Range#max given a block passes each pair of values in the range to the block"
-  fails "Range#max given a block passes each pair of elements to the block in reversed order"
-  fails "Range#max given a block returns the element the block determines to be the maximum"
-
   # string
   fails "String#rindex with Regexp returns nil if the substring isn't found"
 end

--- a/spec/lib/compiler/call_spec.rb
+++ b/spec/lib/compiler/call_spec.rb
@@ -16,13 +16,13 @@ describe Opal::Compiler do
 
     context 'outside block' do
       context 'method missing on' do
-        it { is_expected.to include "return (!(Opal.find_super_dispatcher(self, 'some_method', TMP_1, true).$$stub) ? \"super\" : nil);" }
+        it { is_expected.to include "return (!(Opal.find_super_dispatcher(self, 'some_method', TMP_1, true).$$stub) ? \"super\" : nil)" }
       end
 
       context 'method missing off' do
         let(:compiler) { Opal::Compiler.new(method, method_missing: false) }
 
-        it { is_expected.to include "return ((Opal.find_super_dispatcher(self, 'some_method', TMP_1, true)) != null ? \"super\" : nil);" }
+        it { is_expected.to include "return ((Opal.find_super_dispatcher(self, 'some_method', TMP_1, true)) != null ? \"super\" : nil)" }
       end
     end
 
@@ -62,7 +62,7 @@ describe Opal::Compiler do
                   is_expected.to include <<-CODE
     return ($b = ($c = self).$call_method, $b.$$p = (TMP_2 = function(a){var self = TMP_2.$$s || this;
 if (a == null) a = nil;
-    return self.$foobar()}, TMP_2.$$s = self, TMP_2.$$arity = 1, TMP_2), $b).apply($c, Opal.to_a(stuff));
+    return self.$foobar()}, TMP_2.$$s = self, TMP_2.$$arity = 1, TMP_2), $b).apply($c, Opal.to_a(stuff))
                   CODE
                 end
               end
@@ -70,7 +70,7 @@ if (a == null) a = nil;
               context 'via reference' do
                 let(:invocation) { 'call_method *stuff, &block2' }
 
-                it { is_expected.to include "return ($b = ($c = self).$call_method, $b.$$p = block2.$to_proc(), $b).apply($c, Opal.to_a(stuff));" }
+                it { is_expected.to include "return ($b = ($c = self).$call_method, $b.$$p = block2.$to_proc(), $b).apply($c, Opal.to_a(stuff))" }
               end
             end
           end
@@ -84,7 +84,7 @@ if (a == null) a = nil;
                   is_expected.to include <<-CODE
     return ($b = ($c = self).$call_method, $b.$$p = (TMP_2 = function(a){var self = TMP_2.$$s || this;
 if (a == null) a = nil;
-    return self.$foobar()}, TMP_2.$$s = self, TMP_2.$$arity = 1, TMP_2), $b).call($c);
+    return self.$foobar()}, TMP_2.$$s = self, TMP_2.$$arity = 1, TMP_2), $b).call($c)
                   CODE
                 end
               end
@@ -92,7 +92,7 @@ if (a == null) a = nil;
               context 'via reference' do
                 let(:invocation) { 'call_method &block2' }
 
-                it { is_expected.to include "return ($b = ($c = self).$call_method, $b.$$p = block2.$to_proc(), $b).call($c);" }
+                it { is_expected.to include "return ($b = ($c = self).$call_method, $b.$$p = block2.$to_proc(), $b).call($c)" }
               end
             end
           end
@@ -116,7 +116,7 @@ if (a == null) a = nil;
                   is_expected.to include <<-CODE
     return ($b = ($c = self).$call_method, $b.$$p = (TMP_1 = function(a){var self = TMP_1.$$s || this;
 if (a == null) a = nil;
-    return self.$foobar()}, TMP_1.$$s = self, TMP_1.$$arity = 1, TMP_1), $b).apply($c, Opal.to_a(stuff));
+    return self.$foobar()}, TMP_1.$$s = self, TMP_1.$$arity = 1, TMP_1), $b).apply($c, Opal.to_a(stuff))
                   CODE
                 end
               end
@@ -124,7 +124,7 @@ if (a == null) a = nil;
               context 'via reference' do
                 let(:invocation) { 'call_method *stuff, &block2' }
 
-                it { is_expected.to include "return ($b = ($c = self).$call_method, $b.$$p = self.$block2().$to_proc(), $b).apply($c, Opal.to_a(stuff));" }
+                it { is_expected.to include "return ($b = ($c = self).$call_method, $b.$$p = self.$block2().$to_proc(), $b).apply($c, Opal.to_a(stuff))" }
               end
             end
           end
@@ -138,7 +138,7 @@ if (a == null) a = nil;
                   is_expected.to include <<-CODE
     return ($b = ($c = self).$call_method, $b.$$p = (TMP_1 = function(a){var self = TMP_1.$$s || this;
 if (a == null) a = nil;
-    return self.$foobar()}, TMP_1.$$s = self, TMP_1.$$arity = 1, TMP_1), $b).call($c);
+    return self.$foobar()}, TMP_1.$$s = self, TMP_1.$$arity = 1, TMP_1), $b).call($c)
                   CODE
                 end
               end
@@ -146,7 +146,7 @@ if (a == null) a = nil;
               context 'via reference' do
                 let(:invocation) { 'call_method &block2' }
 
-                it { is_expected.to include "return ($b = ($c = self).$call_method, $b.$$p = self.$block2().$to_proc(), $b).call($c);" }
+                it { is_expected.to include "return ($b = ($c = self).$call_method, $b.$$p = self.$block2().$to_proc(), $b).call($c)" }
               end
             end
           end
@@ -165,27 +165,27 @@ if (a == null) a = nil;
         context 'no splat' do
           let(:invocation) { 'another_method(42)' }
 
-          it { is_expected.to include 'return self.$another_method(42);' }
+          it { is_expected.to include 'return self.$another_method(42)' }
         end
 
         context 'splat' do
           context 'with no block' do
             let(:invocation) { 'another_method(*args)' }
 
-            it { is_expected.to include 'return ($a = self).$another_method.apply($a, Opal.to_a(self.$args()));' }
+            it { is_expected.to include 'return ($a = self).$another_method.apply($a, Opal.to_a(self.$args()))' }
           end
 
           context 'with block' do
             context 'via variable' do
               let(:invocation) { 'another_method(*args) {|b| foobar }' }
 
-              it { is_expected.to include "return ($a = ($b = self).$another_method, $a.$$p = (TMP_1 = function(b){var self = TMP_1.$$s || this;\nif (b == null) b = nil;\n    return self.$foobar()}, TMP_1.$$s = self, TMP_1.$$arity = 1, TMP_1), $a).apply($b, Opal.to_a(self.$args()));" }
+              it { is_expected.to include "return ($a = ($b = self).$another_method, $a.$$p = (TMP_1 = function(b){var self = TMP_1.$$s || this;\nif (b == null) b = nil;\n    return self.$foobar()}, TMP_1.$$s = self, TMP_1.$$arity = 1, TMP_1), $a).apply($b, Opal.to_a(self.$args()))" }
             end
 
             context 'via reference' do
               let(:invocation) { 'another_method(*args, &block2)' }
 
-              it { is_expected.to include "return ($a = ($b = self).$another_method, $a.$$p = self.$block2().$to_proc(), $a).apply($b, Opal.to_a(self.$args()));" }
+              it { is_expected.to include "return ($a = ($b = self).$another_method, $a.$$p = self.$block2().$to_proc(), $a).apply($b, Opal.to_a(self.$args()))" }
             end
           end
         end
@@ -194,13 +194,13 @@ if (a == null) a = nil;
           context 'via variable' do
             let(:invocation) { 'another_method {|b| foobar }' }
 
-            it { is_expected.to include "return ($a = ($b = self).$another_method, $a.$$p = (TMP_1 = function(b){var self = TMP_1.$$s || this;\nif (b == null) b = nil;\n    return self.$foobar()}, TMP_1.$$s = self, TMP_1.$$arity = 1, TMP_1), $a).call($b);" }
+            it { is_expected.to include "return ($a = ($b = self).$another_method, $a.$$p = (TMP_1 = function(b){var self = TMP_1.$$s || this;\nif (b == null) b = nil;\n    return self.$foobar()}, TMP_1.$$s = self, TMP_1.$$arity = 1, TMP_1), $a).call($b)" }
           end
 
           context 'via reference' do
             let(:invocation) { 'another_method(&block)' }
 
-            it { is_expected.to include 'return ($a = ($b = self).$another_method, $a.$$p = self.$block().$to_proc(), $a).call($b);' }
+            it { is_expected.to include 'return ($a = ($b = self).$another_method, $a.$$p = self.$block().$to_proc(), $a).call($b)' }
           end
         end
       end
@@ -223,14 +223,14 @@ if (a == null) a = nil;
             context 'no arguments' do
               let(:invocation) { 'super()' }
 
-              it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1, false)), $a.$$p = null, $a).call($b);" }
+              it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1, false)), $a.$$p = null, $a).call($b)" }
             end
 
             context 'implicit arguments' do
               let(:invocation) { 'super' }
 
               context 'no block' do
-                it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1, false)), $a.$$p = $iter, $a).apply($b, $zuper);" }
+                it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1, false)), $a.$$p = $iter, $a).apply($b, $zuper)" }
               end
 
               context 'block' do
@@ -244,7 +244,7 @@ if (a == null) a = nil;
                   CODE
                 end
 
-                it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1, false)), $a.$$p = $iter, $a).apply($b, $zuper);" }
+                it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1, false)), $a.$$p = $iter, $a).apply($b, $zuper)" }
               end
             end
           end
@@ -270,7 +270,7 @@ if (a == null) a = nil;
                       is_expected.to include <<-CODE
     return ($b = ($c = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1, false)), $b.$$p = (TMP_2 = function(a){var self = TMP_2.$$s || this;
 if (a == null) a = nil;
-      return self.$foobar()}, TMP_2.$$s = self, TMP_2.$$arity = 1, TMP_2), $b).apply($c, Opal.to_a(stuff));
+      return self.$foobar()}, TMP_2.$$s = self, TMP_2.$$arity = 1, TMP_2), $b).apply($c, Opal.to_a(stuff))
                       CODE
                     end
                   end
@@ -278,7 +278,7 @@ if (a == null) a = nil;
                   context 'via reference' do
                     let(:invocation) { 'super *stuff, &block2' }
 
-                    it { is_expected.to include "return ($b = ($c = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1, false)), $b.$$p = block2.$to_proc(), $b).apply($c, Opal.to_a(stuff));" }
+                    it { is_expected.to include "return ($b = ($c = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1, false)), $b.$$p = block2.$to_proc(), $b).apply($c, Opal.to_a(stuff))" }
                   end
                 end
               end
@@ -292,7 +292,7 @@ if (a == null) a = nil;
                       is_expected.to include <<-CODE
     return ($b = ($c = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1, false)), $b.$$p = (TMP_2 = function(a){var self = TMP_2.$$s || this;
 if (a == null) a = nil;
-      return self.$foobar()}, TMP_2.$$s = self, TMP_2.$$arity = 1, TMP_2), $b).apply($c, $zuper);
+      return self.$foobar()}, TMP_2.$$s = self, TMP_2.$$arity = 1, TMP_2), $b).apply($c, $zuper)
                       CODE
                     end
                   end
@@ -300,7 +300,7 @@ if (a == null) a = nil;
                   context 'via reference' do
                     let(:invocation) { 'super &block2' }
 
-                    it { is_expected.to include "return ($b = ($c = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1, false)), $b.$$p = block2.$to_proc(), $b).call($c);" }
+                    it { is_expected.to include "return ($b = ($c = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1, false)), $b.$$p = block2.$to_proc(), $b).call($c)" }
                   end
                 end
               end
@@ -308,7 +308,7 @@ if (a == null) a = nil;
               context 'no arguments' do
                 let(:invocation) { 'super()' }
 
-                it { is_expected.to include "return ($b = ($c = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1, false)), $b.$$p = null, $b).call($c);" }
+                it { is_expected.to include "return ($b = ($c = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1, false)), $b.$$p = null, $b).call($c)" }
               end
             end
 
@@ -332,7 +332,7 @@ if (a == null) a = nil;
                       is_expected.to include <<-CODE
       return ($b = ($c = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1, false)), $b.$$p = (TMP_2 = function(a){var self = TMP_2.$$s || this;
 if (a == null) a = nil;
-      return self.$foobar()}, TMP_2.$$s = self, TMP_2.$$arity = 1, TMP_2), $b).apply($c, Opal.to_a(stuff));
+      return self.$foobar()}, TMP_2.$$s = self, TMP_2.$$arity = 1, TMP_2), $b).apply($c, Opal.to_a(stuff))
                       CODE
                     end
                   end
@@ -340,7 +340,7 @@ if (a == null) a = nil;
                   context 'via reference' do
                     let(:invocation) { 'super *stuff, &block2' }
 
-                    it { is_expected.to include "return ($b = ($c = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1, false)), $b.$$p = self.$block2().$to_proc(), $b).apply($c, Opal.to_a(stuff));" }
+                    it { is_expected.to include "return ($b = ($c = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1, false)), $b.$$p = self.$block2().$to_proc(), $b).apply($c, Opal.to_a(stuff))" }
                   end
                 end
               end
@@ -354,7 +354,7 @@ if (a == null) a = nil;
                       is_expected.to include <<-CODE
       return ($b = ($c = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1, false)), $b.$$p = (TMP_2 = function(a){var self = TMP_2.$$s || this;
 if (a == null) a = nil;
-      return self.$foobar()}, TMP_2.$$s = self, TMP_2.$$arity = 1, TMP_2), $b).apply($c, $zuper);
+      return self.$foobar()}, TMP_2.$$s = self, TMP_2.$$arity = 1, TMP_2), $b).apply($c, $zuper)
       CODE
                     end
                   end
@@ -362,7 +362,7 @@ if (a == null) a = nil;
                   context 'via reference' do
                     let(:invocation) { 'super &block2' }
 
-                    it { is_expected.to include "return ($b = ($c = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1, false)), $b.$$p = self.$block2().$to_proc(), $b).call($c);" }
+                    it { is_expected.to include "return ($b = ($c = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1, false)), $b.$$p = self.$block2().$to_proc(), $b).call($c)" }
                   end
                 end
               end
@@ -370,7 +370,7 @@ if (a == null) a = nil;
               context 'no arguments' do
                 let(:invocation) { 'super()' }
 
-                it { is_expected.to include "return ($b = ($c = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1, false)), $b.$$p = null, $b).call($c);" }
+                it { is_expected.to include "return ($b = ($c = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1, false)), $b.$$p = null, $b).call($c)" }
               end
             end
           end
@@ -390,14 +390,14 @@ if (a == null) a = nil;
           context 'no splat' do
             let(:invocation) { 'super(42)' }
 
-            it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'regular_method', TMP_1, false)), $a.$$p = null, $a).call($b, 42);" }
+            it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'regular_method', TMP_1, false)), $a.$$p = null, $a).call($b, 42)" }
           end
 
           context 'splat' do
             context 'with no block' do
               let(:invocation) { "args=[1,2,3]\nsuper(*args)" }
 
-              it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'regular_method', TMP_1, false)), $a.$$p = null, $a).apply($b, Opal.to_a(args));" }
+              it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'regular_method', TMP_1, false)), $a.$$p = null, $a).apply($b, Opal.to_a(args))" }
             end
 
             context 'with block' do
@@ -408,7 +408,7 @@ if (a == null) a = nil;
                   is_expected.to include <<-CODE
       return ($a = ($b = self, Opal.find_super_dispatcher(self, 'regular_method', TMP_1, false)), $a.$$p = (TMP_2 = function(b){var self = TMP_2.$$s || this;
 if (b == null) b = nil;
-      return self.$foobar()}, TMP_2.$$s = self, TMP_2.$$arity = 1, TMP_2), $a).apply($b, Opal.to_a(self.$args()));
+      return self.$foobar()}, TMP_2.$$s = self, TMP_2.$$arity = 1, TMP_2), $a).apply($b, Opal.to_a(self.$args()))
                   CODE
                 end
               end
@@ -416,7 +416,7 @@ if (b == null) b = nil;
               context 'via reference' do
                 let(:invocation) { 'super(*args, &block2)' }
 
-                it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'regular_method', TMP_1, false)), $a.$$p = self.$block2().$to_proc(), $a).apply($b, Opal.to_a(self.$args()));" }
+                it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'regular_method', TMP_1, false)), $a.$$p = self.$block2().$to_proc(), $a).apply($b, Opal.to_a(self.$args()))" }
               end
             end
           end
@@ -429,7 +429,7 @@ if (b == null) b = nil;
                 is_expected.to include <<-CODE
       return ($a = ($b = self, Opal.find_super_dispatcher(self, 'regular_method', TMP_1, false)), $a.$$p = (TMP_2 = function(b){var self = TMP_2.$$s || this;
 if (b == null) b = nil;
-      return self.$foobar()}, TMP_2.$$s = self, TMP_2.$$arity = 1, TMP_2), $a).apply($b, $zuper);
+      return self.$foobar()}, TMP_2.$$s = self, TMP_2.$$arity = 1, TMP_2), $a).apply($b, $zuper)
                 CODE
               end
             end
@@ -437,14 +437,14 @@ if (b == null) b = nil;
             context 'via reference' do
               let(:invocation) { 'super(&block)' }
 
-              it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'regular_method', TMP_1, false)), $a.$$p = self.$block().$to_proc(), $a).call($b);" }
+              it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'regular_method', TMP_1, false)), $a.$$p = self.$block().$to_proc(), $a).call($b)" }
             end
           end
 
           context 'no arguments' do
             let(:invocation) { 'super()' }
 
-            it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'regular_method', TMP_1, false)), $a.$$p = null, $a).call($b);" }
+            it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'regular_method', TMP_1, false)), $a.$$p = null, $a).call($b)" }
           end
         end
       end
@@ -465,7 +465,7 @@ if (b == null) b = nil;
             CODE
           end
 
-          it { is_expected.to include "return ($c = ($d = self, Opal.find_iter_super_dispatcher(self, 'in_method', (TMP_1.$$def || TMP_2), false, true)), $c.$$p = $iter, $c).apply($d, $zuper)}, TMP_1.$$s = self, TMP_1.$$arity = 0, TMP_1), $a).call($b);" }
+          it { is_expected.to include "return ($c = ($d = self, Opal.find_iter_super_dispatcher(self, 'in_method', (TMP_1.$$def || TMP_2), false, true)), $c.$$p = $iter, $c).apply($d, $zuper)}, TMP_1.$$s = self, TMP_1.$$arity = 0, TMP_1), $a).call($b)" }
         end
 
         context 'not first node' do
@@ -480,7 +480,7 @@ if (b == null) b = nil;
             CODE
           end
 
-          it { is_expected.to include "Opal.ret(($c = ($d = self, Opal.find_iter_super_dispatcher(self, 'foo', (TMP_1.$$def || TMP_2), false, true)), $c.$$p = $iter, $c).apply($d, $zuper))}, TMP_1.$$s = self, TMP_1.$$arity = 0, TMP_1), $a).call($b);" }
+          it { is_expected.to include "Opal.ret(($c = ($d = self, Opal.find_iter_super_dispatcher(self, 'foo', (TMP_1.$$def || TMP_2), false, true)), $c.$$p = $iter, $c).apply($d, $zuper))}, TMP_1.$$s = self, TMP_1.$$arity = 0, TMP_1), $a).call($b)" }
         end
 
         context 'right method is called, IS THIS A NEW CASE??' do
@@ -505,7 +505,7 @@ if (b == null) b = nil;
           end
 
           # runtime if (current_func.$$def) code should take care of locating the correct method here
-          it { is_expected.to include "return ($d = ($e = self, Opal.find_iter_super_dispatcher(self, 'setup', (TMP_3.$$def || TMP_4), false, false)), $d.$$p = null, $d).apply($e, Opal.to_a(args))}, TMP_3.$$s = self, TMP_3.$$arity = -1, TMP_3), $a).call($b, \"m\");" }
+          it { is_expected.to include "return ($d = ($e = self, Opal.find_iter_super_dispatcher(self, 'setup', (TMP_3.$$def || TMP_4), false, false)), $d.$$p = null, $d).apply($e, Opal.to_a(args))}, TMP_3.$$s = self, TMP_3.$$arity = -1, TMP_3), $a).call($b, \"m\")" }
         end
       end
 
@@ -598,7 +598,7 @@ if (b == null) b = nil;
               CODE
             end
 
-            it { is_expected.to include "return ($i = ($j = self, Opal.find_iter_super_dispatcher(self, null, (TMP_6.$$def || TMP_5.$$def || TMP_3.$$def || null), false, false)), $i.$$p = nil.$to_proc(), $i).call($j)}, TMP_6.$$s = self, TMP_6.$$arity = 0, TMP_6), $g).call($h)}, TMP_5.$$s = self, TMP_5.$$arity = 0, TMP_5), $d).call($f, \"a\");}, TMP_3.$$s = self, TMP_3.$$arity = 0, TMP_3), $a).call($c, sup);" }
+            it { is_expected.to include "return ($i = ($j = self, Opal.find_iter_super_dispatcher(self, null, (TMP_6.$$def || TMP_5.$$def || TMP_3.$$def || null), false, false)), $i.$$p = nil.$to_proc(), $i).call($j)}, TMP_6.$$s = self, TMP_6.$$arity = 0, TMP_6), $g).call($h)}, TMP_5.$$s = self, TMP_5.$$arity = 0, TMP_5), $d).call($f, \"a\");}, TMP_3.$$s = self, TMP_3.$$arity = 0, TMP_3), $a).call($c, sup)" }
           end
 
           context 'not last method in class' do
@@ -620,7 +620,7 @@ if (b == null) b = nil;
               CODE
             end
 
-            it { is_expected.to include "return ($h = ($i = self, Opal.find_iter_super_dispatcher(self, null, (TMP_5.$$def || TMP_4.$$def || TMP_3.$$def || null), false, false)), $h.$$p = nil.$to_proc(), $h).call($i)}, TMP_5.$$s = self, TMP_5.$$arity = 0, TMP_5), $f).call($g)}, TMP_4.$$s = self, TMP_4.$$arity = 0, TMP_4), $d).call($e, \"a\");" }
+            it { is_expected.to include "return ($h = ($i = self, Opal.find_iter_super_dispatcher(self, null, (TMP_5.$$def || TMP_4.$$def || TMP_3.$$def || null), false, false)), $h.$$p = nil.$to_proc(), $h).call($i)}, TMP_5.$$s = self, TMP_5.$$arity = 0, TMP_5), $f).call($g)}, TMP_4.$$s = self, TMP_4.$$arity = 0, TMP_4), $d).call($e, \"a\")" }
           end
         end
 
@@ -645,7 +645,7 @@ if (b == null) b = nil;
             CODE
           end
 
-          it { is_expected.to include "return ($f = ($g = self, Opal.find_iter_super_dispatcher(self, 'foo', (TMP_4.$$def || TMP_3.$$def || TMP_5), false, false)), $f.$$p = block2.$to_proc(), $f).call($g, self.$some_arg())}, TMP_4.$$s = self, TMP_4.$$arity = 0, TMP_4), $d).call($e)}, TMP_3.$$s = self, TMP_3.$$arity = 0, TMP_3), $a).call($c, \"a\");" }
+          it { is_expected.to include "return ($f = ($g = self, Opal.find_iter_super_dispatcher(self, 'foo', (TMP_4.$$def || TMP_3.$$def || TMP_5), false, false)), $f.$$p = block2.$to_proc(), $f).call($g, self.$some_arg())}, TMP_4.$$s = self, TMP_4.$$arity = 0, TMP_4), $d).call($e)}, TMP_3.$$s = self, TMP_3.$$arity = 0, TMP_3), $a).call($c, \"a\")" }
           it { is_expected.to include "return ($g = ($h = self, Opal.find_iter_super_dispatcher(self, 'foo', (TMP_7.$$def || TMP_6.$$def || TMP_5), false, false)), $g.$$p = nil.$to_proc(), $g).call($h)}, TMP_7.$$s = self, TMP_7.$$arity = 0, TMP_7), $e).call($f)}, TMP_6.$$s = self, TMP_6.$$arity = 0, TMP_6), $a).call($d, \"a\")" }
         end
 
@@ -676,9 +676,9 @@ if (b == null) b = nil;
             CODE
           end
 
-          it { is_expected.to include "return ($e = ($f = self, Opal.find_iter_super_dispatcher(self, null, (TMP_2.$$def || TMP_1.$$def || null), false, true)), $e.$$p = $iter, $e).apply($f)}, TMP_2.$$s = self, TMP_2.$$arity = 0, TMP_2), $c).call($d, \"foo\");" }
+          it { is_expected.to include "return ($e = ($f = self, Opal.find_iter_super_dispatcher(self, null, (TMP_2.$$def || TMP_1.$$def || null), false, true)), $e.$$p = $iter, $e).apply($f)}, TMP_2.$$s = self, TMP_2.$$arity = 0, TMP_2), $c).call($d, \"foo\")" }
 
-          it { is_expected.to include "return ($c = ($d = self, Opal.find_iter_super_dispatcher(self, 'm', (TMP_5.$$def || TMP_6), false, true)), $c.$$p = $iter, $c).apply($d, $zuper)}, TMP_5.$$s = self, TMP_5.$$arity = 0, TMP_5), $a).call($b);" }
+          it { is_expected.to include "return ($c = ($d = self, Opal.find_iter_super_dispatcher(self, 'm', (TMP_5.$$def || TMP_6), false, true)), $c.$$p = $iter, $c).apply($d, $zuper)}, TMP_5.$$s = self, TMP_5.$$arity = 0, TMP_5), $a).call($b)" }
         end
       end
 
@@ -693,7 +693,7 @@ if (b == null) b = nil;
           CODE
         end
 
-        it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1, false, $Foobar)), $a.$$p = $iter, $a).apply($b, $zuper);" }
+        it { is_expected.to include "return ($a = ($b = self, Opal.find_super_dispatcher(self, 'some_method', TMP_1, false, $Foobar)), $a.$$p = $iter, $a).apply($b, $zuper)" }
       end
     end
   end


### PR DESCRIPTION
Fixes all the call_specs and removed filters for range min/max since those pass now too. By all means do a code review since there might be better ways to do some of this.

Besides the scope.rb change:
* Removed semicolons from call_spec for less brittle specs and to focus more on real failures
* Take advantage of `extract_iter` inheritance from call.rb and utilize that properly for the zsuper case
* zsuper's `@arguments_without_block = []` else clause was not being used anymore since that was all removed, so clean that up