### PR TITLE
Fix from 0.9-stable that changes Native Hash initialize check for null

### DIFF
--- a/stdlib/native.rb
+++ b/stdlib/native.rb
@@ -526,7 +526,7 @@ class Hash
 
   def initialize(defaults = undefined, &block)
     %x{
-      if (defaults !== undefined && defaults.constructor === Object) {
+      if (defaults != null && defaults.constructor === Object) {
         var smap = self.$$smap,
             keys = self.$$keys,
             key, value;


### PR DESCRIPTION
Sending a PR to master with the same fix.