### PR TITLE
Make runtime.js compatible with opal/mini

### DIFF
--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -1321,7 +1321,7 @@
       // A splatted array must be copied
       return value.slice();
     }
-    else if (value['$respond_to?']('to_a', true)) {
+    else if (typeof(value.$to_a) === 'function' && !value.$to_a.$$stub) {
       var ary = value.$to_a();
       if (ary === nil) {
         return [value];


### PR DESCRIPTION
It was calling `Kernel#respond_to?`, which doesn't come with opal/mini. Instead, that call needs to use the lower-level implementation of that method.