### PR TITLE
Optimize Hash#merge! type check

### DIFF
--- a/opal/corelib/hash.rb
+++ b/opal/corelib/hash.rb
@@ -683,7 +683,7 @@ class Hash
 
   def merge!(other, &block)
     %x{
-      if (!#{Hash === other}) {
+      if (!other.$$is_hash) {
         other = #{Opal.coerce_to!(other, Hash, :to_hash)};
       }
 


### PR DESCRIPTION
Rather than looking up the ancestor chain with Ruby, might as well utilize the browser's native prototype chain, which is a lot faster.