### PR TITLE
Optimize Array#any? for an empty array

### DIFF
--- a/opal/corelib/array.rb
+++ b/opal/corelib/array.rb
@@ -440,6 +440,14 @@ class Array < `Array`
     end
   end
 
+  def any?
+    if empty?
+      false
+    else
+      super
+    end
+  end
+
   def assoc(object)
     %x{
       for (var i = 0, length = self.length, item; i < length; i++) {


### PR DESCRIPTION
If an array is empty, we know `any?` cannot possibly return true. Otherwise, fall back to the `Enumerable` implementation of the method.

This is an optimization made [within MRI](http://ruby-doc.org/core-2.3.1/Array.html#method-i-any-3F) as well. It's functionally correct without it, but this is quite a bit faster for empty arrays since [early method returns within blocks aren't cheap](https://github.com/opal/opal/blob/59e7a48f5b6d62b26a7f4b3c6d284aee751b2c3b/opal/corelib/runtime.js#L1239).