### PR TITLE
Allow passing dynamic symbols to undef/alias.

### DIFF
--- a/lib/opal/nodes/definitions.rb
+++ b/lib/opal/nodes/definitions.rb
@@ -5,20 +5,11 @@ module Opal
     class UndefNode < Base
       handle :undef
 
+      children :value
+
       def compile
         children.each do |child|
-          value = child.children[0]
-          statements = []
-          if child.type == :js_return
-             value = value.children[0]
-             statements << expr(s(:js_return))
-          end
-          statements << "Opal.udef(self, '$#{value.to_s}');"
-          if children.length > 1 && child != children.first
-            line *statements
-          else
-            push *statements
-          end
+          line "Opal.udef(self, '$' + ", expr(child), ");"
         end
       end
     end
@@ -26,22 +17,10 @@ module Opal
     class AliasNode < Base
       handle :alias
 
-      children :new_name_sexp, :old_name_sexp
-
-      def new_name
-        new_name_sexp.children[0].to_s
-      end
-
-      def old_name
-        old_name_sexp.children[0].to_s
-      end
+      children :new_name, :old_name
 
       def compile
-        if scope.class? or scope.module?
-          scope.methods << "$#{new_name}"
-        end
-
-        push "Opal.alias(self, '#{new_name}', '#{old_name}')"
+        push "Opal.alias(self, ", expr(new_name), ", ", expr(old_name), ")"
       end
     end
 

--- a/spec/lib/compiler_spec.rb
+++ b/spec/lib/compiler_spec.rb
@@ -54,8 +54,8 @@ describe Opal::Compiler do
   end
 
   it "should compile undef calls" do
-    expect_compiled("undef a").to include("Opal.udef(self, '$a')")
-    expect_compiled("undef a,b").to match(/Opal.udef\(self, '\$a'\);.*return Opal.udef\(self, '\$b'\);/m)
+    expect_compiled("undef a").to include("Opal.udef(self, '$' + \"a\")")
+    expect_compiled("undef a,b").to match(/Opal.udef\(self, '\$' \+ "a"\);.*Opal.udef\(self, '\$' \+ "b"\);/m)
   end
 
   describe "class names" do

--- a/spec/opal/core/language_spec.rb
+++ b/spec/opal/core/language_spec.rb
@@ -43,3 +43,35 @@ describe "generated method names" do
     }
   end
 end
+
+describe 'undef with dynamic symbol (regression for https://github.com/opal/opal/pull/1128)' do
+  class UndefWithDynamicSymbol
+    def foo_bar
+    end
+  end
+
+  class UndefWithDynamicSymbol
+    bar = "bar"
+    undef :"foo_#{bar}"
+  end
+
+  it 'should work' do
+    lambda { UndefWithDynamicSymbol.new.foo_bar }.should raise_error(NoMethodError)
+  end
+end
+
+describe 'alias with dynamic symbol (regression for https://github.com/opal/opal/pull/1128)' do
+  class AliasWithDynamicSymbol
+    def method1
+    end
+  end
+
+  class AliasWithDynamicSymbol
+    alias :"method#{2}" :"method#{1}"
+  end
+
+  it 'should work' do
+    AliasWithDynamicSymbol.new.should respond_to(:method1)
+    AliasWithDynamicSymbol.new.should respond_to(:method2)
+  end
+end


### PR DESCRIPTION
Reincarnation of https://github.com/opal/opal/pull/1128 :smile: + fix for `alias :dynamic_symbol` + minor refactoring of `Compiler#returns`
Closes #1127
Closes #1128 