### PR TITLE
update browser opal-rspec example

### DIFF
--- a/docs/rspec.md
+++ b/docs/rspec.md
@@ -51,7 +51,8 @@ $ bundle exec rake
 require 'bundler'
 Bundler.require
 
-run Opal::Server.new { |s|
+sprockets_env = Opal::RSpec::SprocketsEnvironment.new
+run Opal::Server.new(sprockets: sprockets_env) { |s|
   s.main = 'opal/rspec/sprockets_runner'
   s.append_path 'spec'
   s.debug = false


### PR DESCRIPTION
Following the docs and couldn't the In a Browser example working without creating a fake env `sprockets_env = Opal::RSpec::SprocketsEnvironment.new` first.