### PR TITLE
MSpec intergation: run every spec file in a separate environment to avoid potential conflicts.

### DIFF
--- a/spec/mspec-opal/runner.rb
+++ b/spec/mspec-opal/runner.rb
@@ -82,13 +82,6 @@ class Object
   end
 end
 
-module MSpec
-  def self.opal_runner
-    @env = Object.new
-    @env.extend MSpec
-  end
-end
-
 class OSpecFormatter
   def self.main
     @main ||= self.new
@@ -112,35 +105,18 @@ class OSpecFormatter
   end
 end
 
-class OSpecRunner
+class OpalBM
   def self.main
     @main ||= self.new
   end
 
-  def initialize
-    register
-    run
-  end
-
-  def register
-    OSpecFormatter.main.register
-    OSpecFilter.main.register
-  end
-
-  def run
-    MSpec.opal_runner
-  end
-
-  def will_start
-    MSpec.actions :start
-  end
-
-  def bm!(repeat, bm_filepath)
+  def register(repeat, bm_filepath)
     `self.bm = {}`
     `self.bm_filepath = bm_filepath`
     MSpec.repeat = repeat
     MSpec.register :before, self
     MSpec.register :after,  self
+    MSpec.register :finish, self
   end
 
   def before(state = nil)
@@ -159,7 +135,7 @@ class OSpecRunner
     }
   end
 
-  def did_finish
+  def finish
     %x{
       var obj = self.bm, key, val, report = '';
       if (obj) {
@@ -172,7 +148,6 @@ class OSpecRunner
         require('fs').writeFileSync(self.bm_filepath, report);
       }
     }
-    MSpec.actions :finish
   end
 end
 
@@ -191,3 +166,6 @@ module OutputSilencer
     end
   end
 end
+
+OSpecFormatter.main.register
+OSpecFilter.main.register

--- a/spec/opal/core/kernel/respond_to_spec.rb
+++ b/spec/opal/core/kernel/respond_to_spec.rb
@@ -12,6 +12,9 @@ class RespondToSpecs
   def some_method
     :foo
   end
+
+  def foo
+  end
 end
 
 describe "Kernel.respond_to?" do
@@ -35,7 +38,7 @@ describe "Kernel#respond_to?" do
   end
 
   it "returns false if a method exists, but is marked with a '$$stub' property" do
-    `#{@a}.$some_method.$$stub = true`
-    @a.respond_to?(:some_method).should be_false
+    `#{@a}.$foo.$$stub = true`
+    @a.respond_to?(:foo).should be_false
   end
 end

--- a/tasks/testing/mspec_special_calls.rb
+++ b/tasks/testing/mspec_special_calls.rb
@@ -39,6 +39,11 @@ class Opal::Nodes::CallNode
       compile_default!
     end
   end
+
+  add_special :requirable_spec_file do
+    str = DependencyResolver.new(compiler, arglist.children[0]).resolve
+    compiler.requires << str unless str.nil?
+  end
 end
 
 


### PR DESCRIPTION
Closes #1536

The idea of this PR is to run every file in a separate environment, so dynamically defined methods will not conflict. This can be achieved using a default MSpec behavior. In fact, this PR doesn't introduce any new mechanism.

+ it uses `MSpec.register_files` to populate MSpec's configuration.
+ it uses `MSpec.files` to run every single file in it's own environment
+ `MSpec.files` dynamically loads every file, which is not allowed by Opal. To make it working added `requirable_spec_file` special call (available only in the MSpec test suite) that explicitly adds passed filepath to compiler's list of required files. By doing this we can automatically inject spec's code to the generated file and require it later (when MSpec needs it).

New `mspec_nodejs.rb` looks like:
``` ruby
require 'spec_helper'
require 'opal/full'

# ... conditionally injected code for benchmarks ...

require 'filters/unsupported/...'
# ... other files from 'unsupported' and 'bugs' directories ...

requirable_spec_file 'ruby/language/lambda_spec.rb'
# ... other files from rubyspec/opal suite ...

MSpec.register_files [
  'ruby/language/lambda_spec.rb',
  # ... other files from rubyspec/opal suite ...
]

OSpecRunner.main.start_suite
OSpecFilter.main.unused_filters_message(list: false)
OSpecRunner.main.did_finish
exit MSpec.exit_code
```

@eregon Is it closer to how it should be? :smile: 
@Mogztter This branch is in the Opal's repo. Could you test it please?