### PR TITLE
Resolves #1550, define the default open mode on the File constructor

### DIFF
--- a/stdlib/nodejs/file.rb
+++ b/stdlib/nodejs/file.rb
@@ -101,7 +101,7 @@ class File < IO
 
   # Instance Methods
 
-  def initialize(path, flags)
+  def initialize(path, flags = 'r')
     binary_flag_regexp = /b/
     encoding_flag_regexp = /:(.*)/
     # binary flag is unsupported

--- a/test/nodejs/test_file.rb
+++ b/test/nodejs/test_file.rb
@@ -4,6 +4,21 @@ require 'nodejs'
 require 'nodejs/file'
 
 class TestNodejsFile < Test::Unit::TestCase
+
+  def test_instantiate_without_open_mode
+    # By default the open mode is 'r' (read only)
+    File.write('tmp/quz', "world")
+    file = File.new('tmp/quz')
+    assert_equal('tmp/quz', file.path)
+  end
+
+  def test_mtime
+    File.write('tmp/qix', "hello")
+    file = File.new('tmp/qix', 'r')
+    file_mtime = file.mtime
+    assert(Time.now >= file_mtime, 'File modification time should be before now')
+  end
+
   def test_write_read
     path = "/tmp/testing_nodejs_file_implementation_#{Time.now.to_i}"
     contents = 'foobar'


### PR DESCRIPTION
Also adds tests for Node.js on File.new and File.mtime