### PR TITLE
[WIP] Unicode pack and unpack

### DIFF
--- a/opal/corelib/array.rb
+++ b/opal/corelib/array.rb
@@ -2293,7 +2293,7 @@ class Array < `Array`
           result.push(String.fromCharCode(combined));
         }
 
-        return result.join('')
+        return result.join('');
       }
 
       function codePointsToString(arr) {

--- a/opal/corelib/array.rb
+++ b/opal/corelib/array.rb
@@ -2283,7 +2283,7 @@ class Array < `Array`
 
   def pack(pattern)
     %x{
-      function bytesToString(arr) {
+      function bytes_to_string(arr) {
         var result = [];
 
         for (var i = 0; i < arr.length; i += 2) {
@@ -2296,23 +2296,23 @@ class Array < `Array`
         return result.join('');
       }
 
-      function codePointsToString(arr) {
+      function code_points_to_string(arr) {
         var chars = [];
 
         for (var i = 0; i < arr.length; i ++) {
-          var codePoint = arr[i];
+          var code_point = arr[i];
 
-          if (codePoint > 0xFFFF) {
-            codePoint -= 0x10000;
+          if (code_point > 0xFFFF) {
+            code_point -= 0x10000;
 
             chars.push(
               String.fromCharCode(
-                0xD800 + (codePoint >> 10), 0xDC00 + (codePoint & 0x3FF)
+                0xD800 + (code_point >> 10), 0xDC00 + (code_point & 0x3FF)
               )
             );
           } else {
             chars.push(
-              String.fromCharCode(codePoint)
+              String.fromCharCode(code_point)
             );
           }
         }
@@ -2323,9 +2323,9 @@ class Array < `Array`
 
     case pattern
       when "U*"
-        `return codePointsToString(self)`
+        `return code_points_to_string(self)`
       when "C*"
-        `return bytesToString(self)`
+        `return bytes_to_string(self)`
       else
         raise NotImplementedError
     end

--- a/opal/corelib/string.rb
+++ b/opal/corelib/string.rb
@@ -1760,10 +1760,15 @@ class String < `String`
       }
 
       function charCodeAt(string, index) {
-        var length = string.length,
-            surrogatePairs = new RegExp(
-              '[' + codePointsToString([0xD800]) + '-' + codePointsToString([0xDBFF]) + '][' + codePointsToString([0xDC00]) + '-' + codePointsToString([0xDFFF]) + ']'
-            );
+        var length = string.length;
+
+        var surrogatePairs = new RegExp(
+          '[' +
+            codePointsToString([0xD800]) + '-' + codePointsToString([0xDBFF]) +
+          '][' +
+            codePointsToString([0xDC00]) + '-' + codePointsToString([0xDFFF]) +
+          ']', 'g'
+        );
 
         while (surrogatePairs.exec(string) != null) {
           var li = surrogatePairs.lastIndex;

--- a/opal/corelib/string.rb
+++ b/opal/corelib/string.rb
@@ -1695,63 +1695,63 @@ class String < `String`
 
   def unpack(pattern)
     %x{
-      function stringToBytes(string) {
+      function string_to_bytes(string) {
         var result = [];
 
         for (var i = 0; i < string.length; i ++) {
           var chr = string.charCodeAt(i);
-          var byteArray = [];
+          var byte_array = [];
 
           while (chr > 0) {
-            byteArray.push(chr & 0xFF);
+            byte_array.push(chr & 0xFF);
             chr >>= 8;
           }
 
           // all utf-16 characters are two bytes
-          if (byteArray.length == 1) {
-            byteArray.push(0);
+          if (byte_array.length == 1) {
+            byte_array.push(0);
           }
 
           // assume big-endian
-          result = result.concat(byteArray.reverse());
+          result = result.concat(byte_array.reverse());
         }
 
         return result;
       }
 
-      function stringToCodePoints(string) {
+      function string_to_code_points(string) {
         var result = [];
 
         for (var i = 0; i < string.length; i ++) {
-          var codePoint = charCodeAt(string, i);
+          var code_point = char_code_at(string, i);
 
-          if (!codePoint) {
+          if (!code_point) {
             break;
           }
 
-          result.push(codePoint);
+          result.push(code_point);
         }
 
         return result;
       }
 
-      function codePointsToString(arr) {
+      function code_points_to_string(arr) {
         var chars = [];
 
         for (var i = 0; i < arr.length; i ++) {
-          var codePoint = arr[i];
+          var code_point = arr[i];
 
-          if (codePoint > 0xFFFF) {
-            codePoint -= 0x10000;
+          if (code_point > 0xFFFF) {
+            code_point -= 0x10000;
 
             chars.push(
               String.fromCharCode(
-                0xD800 + (codePoint >> 10), 0xDC00 + (codePoint & 0x3FF)
+                0xD800 + (code_point >> 10), 0xDC00 + (code_point & 0x3FF)
               )
             );
           } else {
             chars.push(
-              String.fromCharCode(codePoint)
+              String.fromCharCode(code_point)
             );
           }
         }
@@ -1759,19 +1759,19 @@ class String < `String`
         return chars.join('');
       }
 
-      function charCodeAt(string, index) {
+      function char_code_at(string, index) {
         var length = string.length;
 
-        var surrogatePairs = new RegExp(
+        var surrogate_pairs = new RegExp(
           '[' +
-            codePointsToString([0xD800]) + '-' + codePointsToString([0xDBFF]) +
+            code_points_to_string([0xD800]) + '-' + code_points_to_string([0xDBFF]) +
           '][' +
-            codePointsToString([0xDC00]) + '-' + codePointsToString([0xDFFF]) +
+            code_points_to_string([0xDC00]) + '-' + code_points_to_string([0xDFFF]) +
           ']', 'g'
         );
 
-        while (surrogatePairs.exec(string) != null) {
-          var li = surrogatePairs.lastIndex;
+        while (surrogate_pairs.exec(string) != null) {
+          var li = surrogate_pairs.lastIndex;
 
           if (li - 2 < index) {
             index += 1;
@@ -1798,9 +1798,9 @@ class String < `String`
 
     case pattern
       when "U*"
-        `return stringToCodePoints(self);`
+        `return string_to_code_points(self);`
       when "C*"
-        `return stringToBytes(self);`
+        `return string_to_bytes(self);`
       else
         raise NotImplementedError
     end

--- a/opal/corelib/string.rb
+++ b/opal/corelib/string.rb
@@ -1723,7 +1723,7 @@ class String < `String`
         var result = [];
 
         for (var i = 0; i < string.length; i ++) {
-          codePoint = charCodeAt(string, i);
+          var codePoint = charCodeAt(string, i);
 
           if (!codePoint) {
             break;

--- a/spec/opal/core/array/pack_spec.rb
+++ b/spec/opal/core/array/pack_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe 'Array#pack' do
+  describe 'C*' do
+    it 'packs standard ASCII bytes' do
+      [0, 97, 0, 98, 0, 99].pack('C*').should == 'abc'
+    end
+
+    it 'packs multibyte characters' do
+      [48, 66, 48, 138, 48, 76, 48, 104].pack('C*').should == 'ありがと'
+    end
+
+    it "packs astral plane characters (UTF-16 surrogate pairs)" do
+      [216, 81, 221, 35].pack('C*').should == '𤔣'
+    end
+  end
+
+  describe 'U*' do
+    it 'packs standard ASCII characters' do
+      [97, 98, 99].pack('U*').should == 'abc'
+    end
+
+    it 'packs multibyte characters' do
+      [12354, 12426, 12364, 12392].pack('U*').should == 'ありがと'
+    end
+
+    it 'packs astral plane characters' do
+      [148771].pack('U*').should == '𤔣'
+    end
+  end
+end

--- a/spec/opal/core/array/pack_spec.rb
+++ b/spec/opal/core/array/pack_spec.rb
@@ -11,7 +11,8 @@ describe 'Array#pack' do
     end
 
     it "packs astral plane characters (UTF-16 surrogate pairs)" do
-      [216, 81, 221, 35].pack('C*').should == '𤔣'
+      char = %x{String.fromCharCode(55377, 56611)}
+      [216, 81, 221, 35].pack('C*').should == char
     end
   end
 
@@ -25,7 +26,8 @@ describe 'Array#pack' do
     end
 
     it 'packs astral plane characters' do
-      [148771].pack('U*').should == '𤔣'
+      char = %x{String.fromCharCode(55377, 56611)}
+      [148771].pack('U*').should == char
     end
   end
 end

--- a/spec/opal/core/string/unpack_spec.rb
+++ b/spec/opal/core/string/unpack_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe 'String#unpack' do
+  describe 'C*' do
+    it 'unpacks standard ASCII bytes' do
+      'abc'.unpack('C*').should == [0, 97, 0, 98, 0, 99]
+    end
+
+    it 'unpacks multibyte characters' do
+      'ありがと'.unpack('C*').should == [48, 66, 48, 138, 48, 76, 48, 104]
+    end
+
+    it "unpacks astral plane characters (UTF-16 surrogate pairs)" do
+      '𤔣'.unpack('C*').should == [216, 81, 221, 35]
+    end
+  end
+
+  describe 'U*' do
+    it 'unpacks standard ASCII characters' do
+      'abc'.unpack('U*').should == [97, 98, 99]
+    end
+
+    it 'unpacks multibyte characters' do
+      'ありがと'.unpack('U*').should == [12354, 12426, 12364, 12392]
+    end
+
+    it 'unpacks astral plane characters' do
+      '𤔣'.unpack('U*').should == [148771]
+    end
+  end
+end

--- a/spec/opal/core/string/unpack_spec.rb
+++ b/spec/opal/core/string/unpack_spec.rb
@@ -11,7 +11,8 @@ describe 'String#unpack' do
     end
 
     it "unpacks astral plane characters (UTF-16 surrogate pairs)" do
-      '𤔣'.unpack('C*').should == [216, 81, 221, 35]
+      char = %x{String.fromCharCode(55377, 56611)}
+      char.unpack('C*').should == [216, 81, 221, 35]
     end
   end
 
@@ -25,7 +26,8 @@ describe 'String#unpack' do
     end
 
     it 'unpacks astral plane characters' do
-      '𤔣'.unpack('U*').should == [148771]
+      char = %x{String.fromCharCode(55377, 56611)}
+      char.unpack('U*').should == [148771]
     end
   end
 end


### PR DESCRIPTION
The current implementations of String#unpack and Array#pack don't take surrogate pairs into consideration. This PR is an attempt to add support for them. (Just before submitting I realized my method and variable names are supposed to be snake_cased. I'll try to fix them this weekend).

I believe this work should be part of a wider effort to support UTF-safe string operations in Opal-generated code, but I don't really know where to start or whether such an effort would be well-received by the Opal maintainers and community. I did a little Google searching but couldn't find a comprehensive Javascript library for doing this, so I wrote [utfstring](https://github.com/camertron/utfstring). I think much of its functionality could be incorporated into Opal. Please let me know what you think!
