### PR TITLE
Optimize Method#to_proc

### DIFF
--- a/opal/corelib/method.rb
+++ b/opal/corelib/method.rb
@@ -32,7 +32,7 @@ class Method
 
   def to_proc
     %x{
-      var proc = function () { return self.$call.apply(self, $slice.call(arguments)); };
+      var proc = self.$call.bind(self);
       proc.$$unbound = #@method;
       proc.$$is_lambda = true;
       return proc;


### PR DESCRIPTION
This replaces a function wrapper with a bound version of the same function, which AFAIK inherits optimizations from the original. 

I don't think the fact that the previous version leaked an `arguments` object had much effect on performance in this scenario. Calling `foo(&method(:bar))` only ever executed that function once, so optimization couldn't happen anyway. I think most of the performance difference here is from inheriting previous optimizations.

Benchmark:

``` ruby
Measurement.new('Method#to_proc', &method(:noop))
```

Results in iterations per second:

Safari 10: 3.3M up from 2.26M (46% faster)
Chrome 53: 1.36M up from 925K (47% faster)
Firefox 48: 1.6M up from 483K (231% faster)
