### PR TITLE
Do not compile failing and unsupported tests.

### DIFF
--- a/lib/opal/rewriter.rb
+++ b/lib/opal/rewriter.rb
@@ -6,20 +6,32 @@ require 'opal/rewriters/dot_js_syntax'
 
 module Opal
   class Rewriter
-    LIST = [
-      Rewriters::OpalEngineCheck,
-      Rewriters::BlockToIter,
-      Rewriters::DotJsSyntax,
-      Rewriters::ExplicitWriterReturn,
-      Rewriters::JsReservedWords,
-    ]
+    class << self
+      def list
+        @list ||= []
+      end
+
+      def use(rewriter)
+        list << rewriter
+      end
+
+      def delete(rewriter)
+        list.delete(rewriter)
+      end
+    end
+
+    use Rewriters::OpalEngineCheck
+    use Rewriters::BlockToIter
+    use Rewriters::DotJsSyntax
+    use Rewriters::ExplicitWriterReturn
+    use Rewriters::JsReservedWords
 
     def initialize(sexp)
       @sexp = sexp
     end
 
     def process
-      LIST.each do |rewriter_class|
+      self.class.list.each do |rewriter_class|
         rewriter = rewriter_class.new
         @sexp = rewriter.process(@sexp)
       end

--- a/lib/opal/rewriters/rubyspec/filters_rewriter.rb
+++ b/lib/opal/rewriters/rubyspec/filters_rewriter.rb
@@ -1,0 +1,65 @@
+require 'opal/rewriters/base'
+
+module Opal
+  module Rubyspec
+    class FiltersRewriter < Opal::Rewriters::Base
+      class << self
+        def filters
+          @filters ||= []
+        end
+
+        def filter(spec_name)
+          filters << spec_name
+        end
+
+        alias fails filter
+
+        def filtered?(spec_name)
+          filters.include?(spec_name)
+        end
+
+        def clear_filters!
+          @filters = []
+        end
+      end
+
+      def initialize
+        @specs_stack = []
+      end
+
+      RUBYSPEC_DSL = [:describe, :it, :context]
+
+      def on_send(node)
+        recvr, method_name, *args = *node
+
+        if rubyspec_dsl?(method_name)
+          spec_name, _ = *args.first
+          begin
+            @specs_stack.push(spec_name)
+            if skip?
+              s(:nil)
+            else
+              super
+            end
+          ensure
+            @specs_stack.pop
+          end
+        else
+          super
+        end
+      end
+
+      def skip?
+        self.class.filtered?(current_spec_name)
+      end
+
+      def rubyspec_dsl?(method_name)
+        RUBYSPEC_DSL.include?(method_name)
+      end
+
+      def current_spec_name
+        @specs_stack.join(" ")
+      end
+    end
+  end
+end

--- a/spec/filters/unsupported/array.rb
+++ b/spec/filters/unsupported/array.rb
@@ -1,4 +1,4 @@
-opal_filter "Array" do
+opal_unsupported_filter "Array" do
   fails "Array#* with a string with a tainted separator does not taint the result if the array has only one element"
   fails "Array#* with a string with a tainted separator does not taint the result if the array is empty"
   fails "Array#* with a string with a tainted separator taints the result if the array has two or more elements"
@@ -58,6 +58,7 @@ opal_filter "Array" do
   fails "Array#fill does not replicate the filler"
   fails "Array#fill raises a RuntimeError on a frozen array"
   fails "Array#fill raises a RuntimeError on an empty frozen array"
+  fails "Array#fill with (filler, index, length) raises an ArgumentError or RangeError for too-large sizes"
   fails "Array#first raises a RangeError when count is a Bignum"
   fails "Array#flatten returns a tainted array if self is tainted"
   fails "Array#flatten returns an untrusted array if self is untrusted"
@@ -66,6 +67,7 @@ opal_filter "Array" do
   fails "Array#frozen? returns false for an array being sorted by #sort"
   fails "Array#frozen? returns true if array is frozen"
   fails "Array#hash returns the same fixnum for arrays with the same content"
+  fails "Array#hash calls to_int on result of calling hash on each element"
   fails "Array#initialize is private"
   fails "Array#initialize raises a RuntimeError on frozen arrays"
   fails "Array#insert raises a RuntimeError on frozen arrays when the array is modified"

--- a/spec/filters/unsupported/basicobject.rb
+++ b/spec/filters/unsupported/basicobject.rb
@@ -1,4 +1,4 @@
-opal_filter "BasicObject" do
+opal_unsupported_filter "BasicObject" do
   fails "BasicObject#method_missing for a Class raises a NoMethodError when a private method is called"
   fails "BasicObject#method_missing for a Class raises a NoMethodError when a protected method is called"
   fails "BasicObject#method_missing for a Class with #method_missing defined is called when an private method is called"

--- a/spec/filters/unsupported/bignum.rb
+++ b/spec/filters/unsupported/bignum.rb
@@ -1,4 +1,4 @@
-opal_filter "Bignum" do
+opal_unsupported_filter "Bignum" do
   fails "BasicObject#__id__ returns a different value for two Bignum literals"
   fails "Complex#== with Numeric returns true when self's imaginary part is 0 and the real part and other have numerical equality"
   fails "Complex#fdiv with an imaginary part sets the real part to self's real part fdiv'd with the argument"

--- a/spec/filters/unsupported/class.rb
+++ b/spec/filters/unsupported/class.rb
@@ -1,4 +1,4 @@
-opal_filter "Class" do
+opal_unsupported_filter "Class" do
   fails "Class#initialize is private"
   fails "Class.inherited is called when marked as a public class method"
 end

--- a/spec/filters/unsupported/delegator.rb
+++ b/spec/filters/unsupported/delegator.rb
@@ -1,4 +1,4 @@
-opal_filter "Delegator" do
+opal_unsupported_filter "Delegator" do
   fails "SimpleDelegator.new doesn't forward private method calls even via send or __send__"
   fails "SimpleDelegator.new doesn't forward private method calls"
   fails "SimpleDelegator.new forwards protected method calls"

--- a/spec/filters/unsupported/enumerable.rb
+++ b/spec/filters/unsupported/enumerable.rb
@@ -1,4 +1,4 @@
-opal_filter "Enumerable" do
+opal_unsupported_filter "Enumerable" do
   fails "Enumerable#chunk does not return elements for which the block returns :_separator"
   fails "Enumerable#chunk raises a RuntimeError if the block returns a Symbol starting with an underscore other than :_alone or :_separator"
   fails "Enumerable#chunk with [initial_state] yields an element and an object value-equal but not identical to the object passed to #chunk"

--- a/spec/filters/unsupported/enumerator.rb
+++ b/spec/filters/unsupported/enumerator.rb
@@ -1,4 +1,4 @@
-opal_filter "Enumerator" do
+opal_unsupported_filter "Enumerator" do
   fails "Enumerator#next cannot be called again until the enumerator is rewound"
   fails "Enumerator#next raises a StopIteration exception at the end of the stream"
   fails "Enumerator#next returns the next element of the enumeration"

--- a/spec/filters/unsupported/fixnum.rb
+++ b/spec/filters/unsupported/fixnum.rb
@@ -1,4 +1,4 @@
-opal_filter "Fixnum" do
+opal_unsupported_filter "Fixnum" do
   fails "Fixnum#+ overflows to Bignum when the result does not fit in Fixnum"
   fails "Fixnum#- returns a Bignum only if the result is too large to be a Fixnum"
   fails "Fixnum#<< with n << m returns -1 when n < 0, m < 0 and n > -(2**-m)"

--- a/spec/filters/unsupported/float.rb
+++ b/spec/filters/unsupported/float.rb
@@ -1,4 +1,4 @@
-opal_filter "Float" do
+opal_unsupported_filter "Float" do
   fails "BasicObject#__id__ returns a different value for two Float literals"
   fails "Complex#/ with Fixnum raises a ZeroDivisionError when given zero"
   fails "Complex#eql? returns false when the imaginary parts are of different classes"

--- a/spec/filters/unsupported/freeze.rb
+++ b/spec/filters/unsupported/freeze.rb
@@ -1,4 +1,4 @@
-opal_filter "freezing" do
+opal_unsupported_filter "freezing" do
   fails "Array#delete returns nil on a frozen array if a modification does not take place"
   fails "Array#dup does not copy frozen status from the original"
   fails "Array#rotate does not mutate the receiver"

--- a/spec/filters/unsupported/hash.rb
+++ b/spec/filters/unsupported/hash.rb
@@ -1,4 +1,4 @@
-opal_filter "Hash" do
+opal_unsupported_filter "Hash" do
   fails "Hash#assoc only returns the first matching key-value pair for identity hashes"
   fails "Hash#clear raises a RuntimeError if called on a frozen instance"
   fails "Hash#compare_by_identity causes future comparisons on the receiver to be made by identity"

--- a/spec/filters/unsupported/integer.rb
+++ b/spec/filters/unsupported/integer.rb
@@ -1,3 +1,3 @@
-opal_filter "Integer" do
+opal_unsupported_filter "Integer" do
   fails "Integer#even? returns true for a Bignum when it is an even number"
 end

--- a/spec/filters/unsupported/kernel.rb
+++ b/spec/filters/unsupported/kernel.rb
@@ -1,4 +1,4 @@
-opal_filter "Kernel" do
+opal_unsupported_filter "Kernel" do
   fails "Kernel has private instance method Array()"
   fails "Kernel has private instance method Hash()"
   fails "Kernel#Float is a private method"

--- a/spec/filters/unsupported/language.rb
+++ b/spec/filters/unsupported/language.rb
@@ -1,4 +1,4 @@
-opal_filter "language" do
+opal_unsupported_filter "language" do
   fails "Magic comment can be after the shebang"
   fails "Magic comment can take Emacs style"
   fails "Magic comment can take vim style"

--- a/spec/filters/unsupported/marshal.rb
+++ b/spec/filters/unsupported/marshal.rb
@@ -1,4 +1,4 @@
-opal_filter "Marshal" do
+opal_unsupported_filter "Marshal" do
   # Marshal.load
   fails "Marshal.load loads a Random" # depends on the reading from the filesystem
   fails "Marshal.load when source is tainted returns a tainted object"

--- a/spec/filters/unsupported/matchdata.rb
+++ b/spec/filters/unsupported/matchdata.rb
@@ -1,4 +1,4 @@
-opal_filter "MatchData" do
+opal_unsupported_filter "MatchData" do
   fails "MatchData#begin returns nil when the nth match isn't found"
   fails "MatchData#begin returns the offset for multi byte strings"
   fails "MatchData#begin returns the offset of the start of the nth element"
@@ -27,4 +27,7 @@ opal_filter "MatchData" do
   fails "MatchData#[Symbol] returns the corresponding named match when given a Symbol"
   fails "MatchData#[Symbol] returns the last match when multiple named matches exist with the same name"
   fails "MatchData#[Symbol] returns the matching version of multiple corresponding named match"
+  fails "MatchData#begin returns the offset for multi byte strings with unicode regexp"
+  fails "MatchData#end returns the offset for multi byte strings with unicode regexp"
+  fails "MatchData#offset returns the offset for multi byte strings with unicode regexp"
 end

--- a/spec/filters/unsupported/math.rb
+++ b/spec/filters/unsupported/math.rb
@@ -1,3 +1,3 @@
-opal_filter "Math" do
+opal_unsupported_filter "Math" do
   fails "Math#atanh is a private instance method"
 end

--- a/spec/filters/unsupported/module.rb
+++ b/spec/filters/unsupported/module.rb
@@ -1,4 +1,4 @@
-opal_filter "Module" do
+opal_unsupported_filter "Module" do
   fails "Module#class_variable_set raises a RuntimeError when self is frozen"
   fails "Module#define_method is private"
   fails "Module#define_method raises a RuntimeError if frozen"

--- a/spec/filters/unsupported/pathname.rb
+++ b/spec/filters/unsupported/pathname.rb
@@ -1,3 +1,3 @@
-opal_filter "Pathname" do
+opal_unsupported_filter "Pathname" do
   fails "Pathname.new is tainted if path is tainted"
 end

--- a/spec/filters/unsupported/privacy.rb
+++ b/spec/filters/unsupported/privacy.rb
@@ -1,4 +1,4 @@
-opal_filter "private" do
+opal_unsupported_filter "private" do
   fails "BasicObject#initialize is a private instance method"
   fails "BasicObject#method_missing for a Class raises a NoMethodError when an undefined method is called"
   fails "BasicObject#method_missing is a private method"

--- a/spec/filters/unsupported/proc.rb
+++ b/spec/filters/unsupported/proc.rb
@@ -1,3 +1,3 @@
-opal_filter "Proc" do
+opal_unsupported_filter "Proc" do
   fails "Proc#hash returns an Integer"
 end

--- a/spec/filters/unsupported/random.rb
+++ b/spec/filters/unsupported/random.rb
@@ -1,4 +1,4 @@
-opal_filter "Random" do
+opal_unsupported_filter "Random" do
   fails "Random#bytes returns the same numeric output for a given seed accross all implementations and platforms"
   fails "Random#bytes returns the same numeric output for a given huge seed accross all implementations and platforms"
 end

--- a/spec/filters/unsupported/range.rb
+++ b/spec/filters/unsupported/range.rb
@@ -1,4 +1,4 @@
-opal_filter "Range" do
+opal_unsupported_filter "Range" do
   fails "Range#initialize is private"
   fails "Range#inspect returns a tainted string if either end is tainted"
   fails "Range#inspect returns a untrusted string if either end is untrusted"

--- a/spec/filters/unsupported/regexp.rb
+++ b/spec/filters/unsupported/regexp.rb
@@ -1,4 +1,4 @@
-opal_filter "Regexp" do
+opal_unsupported_filter "Regexp" do
   fails "Regexp#options does not include Regexp::FIXEDENCODING for a Regexp literal with the 'n' option"
   fails "Regexp#options includes Regexp::FIXEDENCODING for a Regexp literal with the 'e' option"
   fails "Regexp#options includes Regexp::FIXEDENCODING for a Regexp literal with the 's' option"
@@ -56,4 +56,13 @@ opal_filter "Regexp" do
   fails "Regexp.union returns a Regexp with the encoding of multiple non-conflicting Strings containing non-ASCII-compatible characters"
   fails "Regexp.union returns a Regexp with US-ASCII encoding if all arguments are ASCII-only"
   fails "Regexp.union returns a Regexp with UTF-8 if one part is UTF-8"
+  fails "Regexp#source has US-ASCII encoding when created from an ASCII-only \\u{} literal"
+  fails "Regexp#source has UTF-8 encoding when created from a non-ASCII-only \\u{} literal"
+  fails "Regexp#to_s displays options if included"
+  fails "Regexp#to_s displays groups with options"
+  fails "Regexp#to_s displays single group with same options as main regex as the main regex"
+  fails "Regexp#to_s deals properly with uncaptured groups"
+  fails "Regexp#to_s handles abusive option groups"
+  fails "Regexp.try_convert returns the argument if given a Regexp"
+  fails "Regexp with character classes doesn't match non-ASCII characters with [[:ascii:]]"
 end

--- a/spec/filters/unsupported/set.rb
+++ b/spec/filters/unsupported/set.rb
@@ -1,4 +1,4 @@
-opal_filter "Set" do
+opal_unsupported_filter "Set" do
   fails "Set#eql? returns true when the passed argument is a Set and contains the same elements"
   fails "Set#initialize is private"
 end

--- a/spec/filters/unsupported/singleton.rb
+++ b/spec/filters/unsupported/singleton.rb
@@ -1,4 +1,4 @@
-opal_filter "Singleton" do
+opal_unsupported_filter "Singleton" do
   fails "Singleton#_dump returns an empty string from a singleton subclass"
   fails "Singleton#_dump returns an empty string"
   fails "Singleton.allocate is a private method"

--- a/spec/filters/unsupported/string.rb
+++ b/spec/filters/unsupported/string.rb
@@ -1,4 +1,4 @@
-opal_filter "String" do
+opal_unsupported_filter "String" do
   fails "BasicObject#__id__ returns a different value for two String literals"
   fails "String#% always taints the result when the format string is tainted"
   fails "String#% supports negative bignums with %u or %d"
@@ -535,4 +535,8 @@ opal_filter "String" do
   fails "Ruby character strings Unicode escaping with US-ASCII source encoding produces an ASCII string when escaping ASCII characters via \\u{}"
   fails "Ruby character strings Unicode escaping with US-ASCII source encoding produces a UTF-8-encoded string when escaping non-ASCII characters via \\u"
   fails "Ruby character strings Unicode escaping with US-ASCII source encoding produces a UTF-8-encoded string when escaping non-ASCII characters via \\u{}"
+  fails "String#gsub with pattern and block raises an ArgumentError if encoding is not valid"
+  fails "String#gsub! with pattern and block raises an ArgumentError if encoding is not valid"
+  fails "String#rindex with Regexp supports \\G which matches at the given start offset"
+  fails "String#sub with pattern, replacement raises a TypeError when pattern is a Symbol"
 end

--- a/spec/filters/unsupported/struct.rb
+++ b/spec/filters/unsupported/struct.rb
@@ -1,4 +1,4 @@
-opal_filter "Struct" do
+opal_unsupported_filter "Struct" do
   fails "Struct#initialize is private"
   fails "Struct.new does not create a constant with symbol as first argument"
   fails "Struct.new fails with invalid constant name as first argument" # this invalid name gets interpreted as a struct member

--- a/spec/filters/unsupported/symbol.rb
+++ b/spec/filters/unsupported/symbol.rb
@@ -1,4 +1,4 @@
-opal_filter "Symbol" do
+opal_unsupported_filter "Symbol" do
   fails "Numeric#coerce raises a TypeError when passed a Symbol"
   fails "Fixnum#coerce raises a TypeError when given an Object that does not respond to #to_f"
   fails "Symbol#to_proc produces a proc that always returns [[:rest]] for #parameters"

--- a/spec/filters/unsupported/taint.rb
+++ b/spec/filters/unsupported/taint.rb
@@ -1,4 +1,4 @@
-opal_filter "taint" do
+opal_unsupported_filter "taint" do
   fails "Hash#reject with extra state does not taint the resulting hash"
 
   fails "String#% doesn't taint the result for %e when argument is tainted"
@@ -8,6 +8,10 @@ opal_filter "taint" do
   fails "String#% doesn't taint the result for %G when argument is tainted"
   fails "String#byteslice with index, length always taints resulting strings when self is tainted"
   fails "String#byteslice with Range always taints resulting strings when self is tainted"
+  fails "String#slice with Regexp always taints resulting strings when self or regexp is tainted"
+  fails "String#slice with Regexp returns an untrusted string if the regexp is untrusted"
+  fails "String#[] with Regexp always taints resulting strings when self or regexp is tainted"
+  fails "String#[] with Regexp returns an untrusted string if the regexp is untrusted"
 
   fails "StringScanner#pre_match taints the returned String if the input was tainted"
   fails "StringScanner#post_match taints the returned String if the input was tainted"

--- a/spec/filters/unsupported/thread.rb
+++ b/spec/filters/unsupported/thread.rb
@@ -1,4 +1,4 @@
-opal_filter "Thread" do
+opal_unsupported_filter "Thread" do
   fails "StandardError is a superclass of ThreadError"
   fails "The throw keyword raises an ArgumentError if used to exit a thread"
   fails "The throw keyword clears the current exception"

--- a/spec/filters/unsupported/time.rb
+++ b/spec/filters/unsupported/time.rb
@@ -1,4 +1,4 @@
-opal_filter "Time" do
+opal_unsupported_filter "Time" do
   fails "Time#+ accepts arguments that can be coerced into Rational"
   fails "Time#+ adds a negative Float"
   fails "Time#+ increments the time by the specified amount as rational numbers"

--- a/spec/lib/rewriters/rubyspec/filters_rewriter_spec.rb
+++ b/spec/lib/rewriters/rubyspec/filters_rewriter_spec.rb
@@ -1,0 +1,53 @@
+require 'lib/spec_helper'
+require 'opal/rewriters/rubyspec/filters_rewriter'
+require 'support/rewriters_helper'
+
+describe Opal::Rubyspec::FiltersRewriter do
+  include RewritersHelper
+
+  let(:source) do
+    <<-SOURCE
+      describe 'User#email' do
+        context 'when this' do
+          it 'does that'
+        end
+
+        it 'also does something else'
+      end
+    SOURCE
+  end
+
+  let(:ast) { ast_of(source) }
+
+  context 'when spec is filtered' do
+    around(:each) do |e|
+      Opal::Rubyspec::FiltersRewriter.filter 'User#email when this does that'
+      e.run
+      Opal::Rubyspec::FiltersRewriter.clear_filters!
+    end
+
+    let(:rewritten_source) do
+      <<-SOURCE
+        describe 'User#email' do
+          context 'when this' do
+            nil # <- right here
+          end
+
+          it 'also does something else'
+        end
+      SOURCE
+    end
+
+    let(:expected_ast) { ast_of(rewritten_source) }
+
+    it 'replaces it with nil' do
+      expect_rewritten(ast).to eq(expected_ast)
+    end
+  end
+
+  context 'when spec is not filtered' do
+    it 'does not rewrite it' do
+      expect_no_rewriting_for(ast)
+    end
+  end
+end

--- a/spec/mspec-opal/runner.rb
+++ b/spec/mspec-opal/runner.rb
@@ -51,6 +51,8 @@ class Object
     OSpecFilter.main.register_filters(description, block)
   end
 
+  alias opal_unsupported_filter opal_filter
+
   # Copyed from MSpec, with changes.
   def with_timezone(name, offset = nil, daylight_saving_zone = "")
     zone = name.dup

--- a/spec/support/rewriters_helper.rb
+++ b/spec/support/rewriters_helper.rb
@@ -1,0 +1,24 @@
+module RewritersHelper
+  def s(type, *children)
+    ::Opal::AST::Node.new(type, children)
+  end
+
+  def rewritten(ast)
+    described_class.new.process(ast)
+  end
+
+  def expect_rewritten(ast)
+    expect(rewritten(ast))
+  end
+
+  def expect_no_rewriting_for(ast)
+    expect_rewritten(ast).to eq(ast)
+  end
+
+  def ast_of(source)
+    buffer = Parser::Source::Buffer.new('(eval)')
+    buffer.source = source
+    parser = Opal::Parser.default_parser
+    parser.parse(buffer)
+  end
+end

--- a/tasks/testing.rake
+++ b/tasks/testing.rake
@@ -1,8 +1,3 @@
-# Remove when we drop support for 1.9.3
-__dir__ = defined?(Kernel.__dir__) ? Kernel.__dir__ : File.dirname(File.realpath(__FILE__))
-
-require "#{__dir__}/testing/mspec_special_calls"
-
 require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:rspec) do |t|
   t.pattern = 'spec/lib/**/*_spec.rb'

--- a/tasks/testing/mspec_special_calls.rb
+++ b/tasks/testing/mspec_special_calls.rb
@@ -46,4 +46,28 @@ class Opal::Nodes::CallNode
   end
 end
 
+require 'opal/rewriters/rubyspec/filters_rewriter'
 
+Opal::Rewriter.use Opal::Rubyspec::FiltersRewriter
+
+# When a spec is marked as filtered (most probably non-implemented functionality)
+# we need to exclude it from the test suite
+# (except of the case with inverted suite specified using INVERT_RUNNING_MODE=true)
+#
+def opal_filter(filter_name, &block)
+  unless ENV['INVERT_RUNNING_MODE']
+    Opal::Rubyspec::FiltersRewriter.instance_eval(&block)
+  end
+end
+
+# When a spec is marked as unsupported we need to exclude it from the test suite.
+#
+# This filter ignores ENV['INVERT_RUNNING_MODE'],
+# unsupported feature is always unsupported.
+#
+def opal_unsupported_filter(filter_name, &block)
+  Opal::Rubyspec::FiltersRewriter.instance_eval(&block)
+end
+
+Dir[File.expand_path('../../../spec/filters/unsupported/**/*.rb', __FILE__)].each { |f| require f }
+Dir[File.expand_path('../../../spec/filters/bugs/**/*.rb', __FILE__)].each { |f| require f }


### PR DESCRIPTION
Added `Opal::Rubyspec::FiltersRewriter` class that can exclude filtered specs directly from AST. It supports only static specs defined directly with `describe/context/it`, shared examples can't be filtered, we have to deal with them later in runtime.

This AST rewriter is used only in the test suite.

``` sh
# Master
> env rake mspec_ruby_nodejs
Finished in 69.064000 seconds

1337 files, 12299 examples, 50409 expectations, 0 failures, 0 errors, 3450 tagged

> ruby -rbundler/setup -r/home/ilyabylich/Work/opal/tasks/testing/mspec_special_calls bin/opal -gmspec -Ispec -Ilib -smspec/helpers/tmp -smspec/helpers/environment -smspec/guards/block_device -smspec/guards/endian -sa_file -slib/spec_helper -Rnodejs -Dwarning -A --enable-source-location -c tmp/mspec_nodejs.rb | wc
 274629 1856378 17611986
```

``` sh
# Patch
> env rake mspec_ruby_nodejs
Finished in 65.657000 seconds

1337 files, 9968 examples, 50370 expectations, 0 failures, 0 errors, 1152 tagged

> ruby -rbundler/setup -r/home/ilyabylich/Work/opal/tasks/testing/mspec_special_calls bin/opal -gmspec -Ispec -Ilib -smspec/helpers/tmp -smspec/helpers/environment -smspec/guards/block_device -smspec/guards/endian -sa_file -slib/spec_helper -Rnodejs -Dwarning -A --enable-source-location -c tmp/mspec_nodejs.rb | wc
 242846 1627245 15408252
```

Specs that were added to `spec/unsupported` don't have to be wrapped in rubyspec with `not_supported_on :opal` anymore. 22 opal-specific filters (80 in total) can be removed from rubyspec. @eregon @opal/core  Any ideas how to deal with [partially filtered tests](https://github.com/ruby/spec/blob/e8c46ebbf76d860a0dd50a5f45556d3bf7796ec5/core/regexp/shared/new_ascii_8bit.rb#L61-L82) / [shared tests](https://github.com/ruby/spec/blob/d5e21c871decd629d06156aa7a86578b8bdf0138/core/regexp/shared/new_ascii.rb#L25-L41)?

Also introduced a separate spec filter `opal_unsupported_filter` - we need to split specs into failing/unsupported groups to support `INVERT_RUNNING_MODE` option. When it's passed, we compile `all - unsupported`, when it's not passed - we compile `all - bugs - unsupported`.

Also getting less warnings during rubyspec compilation :smile: 