### PR TITLE
docs: Fix wrong output

### DIFF
--- a/docs/compiled_ruby.md
+++ b/docs/compiled_ruby.md
@@ -38,7 +38,7 @@ and `FalseClass` classes from ruby.
 ```ruby
 "hello world!"    # => "hello world!"
 :foo              # => "foo"
-<<-EOS            # => "\nHello there.\n"
+<<-EOS            # => "Hello there.\n"
 Hello there.
 EOS
 ```


### PR DESCRIPTION
I see the following contents in `docs/compiled_ruby.md`

in section *Strings & Symbols*

```
<<-EOS            # => "\nHello there.\n"
Hello there.
EOS
```

This code outputs

     "Hello there.\n"
