### PR TITLE
Rescue all subtypes of Excepton when eval ruby code in REPL

### DIFF
--- a/bin/opal-repl
+++ b/bin/opal-repl
@@ -69,7 +69,7 @@ module Opal
       code = Opal::Builder.new.build_str(str, '(irb)', :irb => true, :const_missing => true)
       code.processed[0...-1].each { |c| @v8.eval(c.to_s) }
       @v8.eval "var $_result = #{code.processed.last.to_s} ($_result == null ? 'nil' : $_result.$inspect());"
-    rescue => e
+    rescue Exception => e
       puts "#{e.message}\n\t#{e.backtrace.join("\n\t")}"
     end
 


### PR DESCRIPTION
For example, `opal-repl` command exit by following code.

    >> foo=

It should catch Exception instead of StandardError.