### PR TITLE
Freeze parser version at 2.3.1.2.

### DIFF
--- a/opal.gemspec
+++ b/opal.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'sourcemap', '~> 0.1.0'
   s.add_dependency 'hike', '~> 1.2'
   s.add_dependency 'ast', '>= 2.3.0'
-  s.add_dependency 'parser', '>= 2.3.1.2'
+  s.add_dependency 'parser', '= 2.3.1.2'
 
   s.add_development_dependency 'mspec', '1.5.20'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
At least while https://github.com/whitequark/parser/issues/312 is open and unreleased.