### PR TITLE
Properly convert `{"a":[null]}` to {a: [nil]}

### DIFF
--- a/spec/opal/stdlib/native/hash_spec.rb
+++ b/spec/opal/stdlib/native/hash_spec.rb
@@ -12,6 +12,7 @@ describe Hash do
         e: [
           {
             f: 'g',
+            h: [null],
           },
         ],
       }
@@ -27,6 +28,7 @@ describe Hash do
       e: [
         {
           f: 'g',
+          h: [nil],
         },
       ],
     }

--- a/stdlib/native.rb
+++ b/stdlib/native.rb
@@ -542,7 +542,7 @@ class Hash
                 return #{Hash.new(`item`)};
               }
 
-              return item;
+              return #{Native(`item`)};
             });
             smap[key] = value
           } else {


### PR DESCRIPTION
`native`'s `Hash#new` recursion for arrays didn't Rubify values directly within arrays, only for values of hashes within arrays. This means that the `null` in `{ "a": [null] }` would not be converted to `nil` — it would remain `null`.

Explaining data structures in prose is terrible. The spec changes in the diff are so much more expressive than my description here.

This was actually my bug from when I added this array recursion in the first place.

/cc @catmando