### PR TITLE
JSON#parse raises JSON::ParserError on invalid input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ Whitespace conventions:
 - Fixed inheritance from the `Module` class.
 - Fixed using `--preload` along with `--no-opal` for CLI
 - Fixed `Integer("0")` raising `ArgumentError` instead of parsing as 0
+- Fixed `JSON#parse` to raise `JSON::ParserError` for invalid input
 
 
 

--- a/spec/opal/stdlib/json/parse_spec.rb
+++ b/spec/opal/stdlib/json/parse_spec.rb
@@ -30,4 +30,8 @@ describe "JSON.parse" do
     JSON.parse('{"a": "b"}').should == {"a" => "b"}
     JSON.parse('{"a": null, "b": 10, "c": [true, false]}').should == {"a" => nil, "b" => 10, "c" => [true, false]}
   end
+
+  it "raises ParserError for invalid JSON" do
+    lambda { JSON.parse("invalid_json") }.should raise_error(JSON::ParserError)
+  end
 end

--- a/stdlib/json.rb
+++ b/stdlib/json.rb
@@ -1,7 +1,20 @@
 module JSON
+  class JSONError < StandardError
+  end
+
+  class ParserError < JSONError
+  end
+
   %x{
-    var $parse  = JSON.parse,
-        $hasOwn = Opal.hasOwnProperty;
+    var $hasOwn = Opal.hasOwnProperty;
+
+    function $parse(source) {
+      try {
+        return JSON.parse(source);
+      } catch (e) {
+        #{raise JSON::ParserError, `e.message`};
+      }
+    };
 
     function to_opal(value, options) {
       var klass, arr, hash, i, ii, k;


### PR DESCRIPTION
JSON.parse and JSON.load raise ParserError when encountering an invalid JSON string.

When JavaScripts native JSON.parse fails, re-raise the SyntaxError as
JSON::ParserError. Class ancestors for ParserError match MRI
implementation.

Fixes #1545 