### PR TITLE
Fix a link to runtime.js document

### DIFF
--- a/opal/README.md
+++ b/opal/README.md
@@ -3,7 +3,7 @@
 This is the Opal corelib implementation API documentation.
 The whole corelib is loaded upon `require 'opal'`.
 
-The `runtime.js` documentation is [available here](runtime.js.html)
+The `runtime.js` documentation is [available here](http://opalrb.org/docs/api/master/corelib/file.RUNTIME.html) (in master)
 
 # Cherry-picking
 


### PR DESCRIPTION
I found a link to `runtime.js` document broken.