### PR TITLE
Fix String#scan's output when block has multiple arguments

### DIFF
--- a/opal/corelib/string.rb
+++ b/opal/corelib/string.rb
@@ -915,9 +915,9 @@ class String < `String`
       while ((match = pattern.exec(self)) != null) {
         match_data = #{MatchData.new `pattern`, `match`};
         if (block === nil) {
-          match.length == 1 ? result.push(match[0]) : result.push(#{`match_data`.captures});
+          match.length == 1 ? result.push(match[0]) : result.push(match_data.captures);
         } else {
-          match.length == 1 ? block(match[0]) : block.call(self, #{`match_data`.captures});
+          block.length == 1 ? Opal.yield1(block, match[0]) : Opal.yieldX(block, match_data)
         }
         if (pattern.lastIndex === match.index) {
           pattern.lastIndex += 1;


### PR DESCRIPTION
Firstly, sorry if I am using incorrect terms - im a JS dev, so my mental ruby dictionary is lacking.

Given the following code

``` ruby
require 'opal'
line = %Q{foo bar baz
one two three
a b c}

line.scan(/(\w*) (\w*) (\w*)/) do |first,second,third|
  puts "first up was #{first}"
  puts "second up was #{second}"
  puts "third up was #{third}"
end
```

Ruby outptus

```
first up was foo
second up was bar
third up was baz
first up was one
second up was two
third up was three
first up was a
second up was b
third up was c
```

and Opal outputs

```
first up was foo,bar,baz
second up was 
third up was 
first up was one,two,three
second up was 
third up was 
first up was a,b,c
second up was 
third up was 
```

The reason is that d95e59a9c1bb91c2c2c9bc65d9966cb06be03dd7 made the assumption that the callback would only have a single argument, and changed the [`apply` to a `call`](https://github.com/opal/opal/blob/d95e59a9c1bb91c2c2c9bc65d9966cb06be03dd7/opal/corelib/string.rb#L933). The difference between the two in JS is call passes literal arguments (in this case, the actual Array as a single argument), and apply takes an array and passes each item in the array as a separate arg to the callback.

The solution here is to look at the length of the `block`  function (which represents the number of arguments given to the callback function. If it `== 1`, use `call`, otherwise use `apply`.

The fix is in this PR, however I am uncertain on where to add a test (since they seem to be the upstream ruby specs) to check for this sort of thing in the future. I did add this test locally however, and it passes

``` ruby
it "maps groups over to block arguments" do
  a = []
  b = []
  "cruel world".scan(/(..)(..)/) { |w,g| a << w; b << g }
  a.should == ["cr", "l "]
  b.should == ["ue", "wo"]
end
```
