### PR TITLE
correct anchor to get proper regex source and use supplied flags

### DIFF
--- a/stdlib/strscan.rb
+++ b/stdlib/strscan.rb
@@ -297,6 +297,10 @@ class StringScanner
 
 private
   def anchor(pattern)
-    `new RegExp('^(?:' + pattern.toString().substr(1, pattern.toString().length - 2) + ')')`
+    %x{
+      var flags = pattern.toString().match(/\/([^\/]+)$/);
+      flags = flags ? flags[1] : undefined;
+      return new RegExp('^(?:' + pattern.source + ')', flags);
+    }
   end
 end


### PR DESCRIPTION
currently, anchor is grabbing `pattern[1..-2]`, which works fine for most regexes, but pukes when you supply one with flags, defeating the entire purpose of it. Instead, we now grab the `source` directly. 

Also, currently the flags are being dropped, this fixes that as well