### PR TITLE
Handle DOS path

### DIFF
--- a/opal/corelib/file.rb
+++ b/opal/corelib/file.rb
@@ -1,6 +1,6 @@
 class File < IO
   Separator = SEPARATOR = '/'
-  ALT_SEPARATOR = nil
+  ALT_SEPARATOR = '\\'
   PATH_SEPARATOR = ':'
   # Assuming case insenstive filesystem
   FNM_SYSCASE = 0
@@ -79,7 +79,7 @@ class File < IO
       }
 
       function isDirSep(sep) {
-        return sep.charAt(0) === #{SEPARATOR};
+        return sep.charAt(0) === #{SEPARATOR} || sep.charAt(0) === #{ALT_SEPARATOR};
       }
 
       function skipRoot(path) {


### PR DESCRIPTION
Ruby MRI:
```ruby
puts File.dirna­me('c:\dev­\playgroun­d\test.ado­c') # "c:\\dev\\playground"
````
Opal:
````javascript
console.log($scope.get('File').$dirname('c:\dev­\playgroun­d\test.ado­c')) // "."
````
In Ruby.c the method isdirsep is checking both Unix separator / and DOS separator \: https://github.com/ruby/ruby/blob/trunk/file.c#L2912

In Opal the method isDirSep is only checking for Unix separator: https://github.com/opal/opal/blob/master/opal/corelib/file.rb#L82

As a result `"c:\dev­\playgroun­d\test.ado­c"` is considered as a filename and not a path. 😢