### PR TITLE
Allow emojis in strings

### DIFF
--- a/lib/opal/nodes/literal.rb
+++ b/lib/opal/nodes/literal.rb
@@ -52,7 +52,12 @@ module Opal
       end
 
       def compile
-        push translate_escape_chars(value.inspect)
+        sanitized_value = value.inspect
+        sanitized_value.gsub! /\\u\{[0-9a-f]+\}/ do |char|
+          @compiler.warning("Ignoring unsupported character #{char}", @sexp.line)
+          ''
+        end
+        push translate_escape_chars(sanitized_value)
       end
     end
 

--- a/lib/opal/nodes/literal.rb
+++ b/lib/opal/nodes/literal.rb
@@ -52,8 +52,7 @@ module Opal
       end
 
       def compile
-        sanitized_value = value.inspect
-        sanitized_value.gsub! /\\u\{[0-9a-f]+\}/ do |char|
+        sanitized_value = value.inspect.gsub /\\u\{[0-9a-f]+\}/ do |char|
           @compiler.warning("Ignoring unsupported character #{char}", @sexp.line)
           ''
         end

--- a/lib/opal/nodes/literal.rb
+++ b/lib/opal/nodes/literal.rb
@@ -52,23 +52,7 @@ module Opal
       end
 
       def compile
-        push translate_escape_chars(trimmed_value.inspect)
-      end
-
-      # Some unicode characters are too big,
-      # MRI uses "\u{hex}" to display them
-      # (which is invalid for JS)
-      # There's no way to display them,
-      # so we can simply trim them
-      def trimmed_value
-        value.each_char.map do |char|
-          if char.valid_encoding? && char.ord > 65535
-            @compiler.warning("Ignoring unsupported character #{char}", @sexp.line)
-            ""
-          else
-            char
-          end
-        end.join
+        push translate_escape_chars(value.inspect)
       end
     end
 


### PR DESCRIPTION
The comment about high-value characters being returned as `"\uXXXXXXXX"` from `String#inspect` doesn't seem to hold. It worked just fine on MRI 2.1, 2.2, and 2.3. That is, `String#inspect` displayed the string exactly as it was without Unicode escaping.