### PR TITLE
Remove duplicate `0.10.3` header in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,6 @@ Whitespace conventions:
 
 - Removed `yaml` from stdlib, the older implementation was only available for NodeJS and not tested. Replace with `require 'nodejs/yaml'`
 - Extracted sprockets support to `opal-sprockets` which should allow for wider support and less coupling (e.g. the `opal` gem will now be able to improve the compiler without worrying about `sprockets` updates). All the old behavior is preserved except for `Opal::Server` that has become `Opal::Sprockets::Server` (see Deprecated section above).
-## [0.10.3] - 2016-09-09
 
 
 ### Fixed


### PR DESCRIPTION
h2 header of `0.10.3` is duplicated in CHANGELOG. And the removed header is not needed.



Note
------

The following fixes are under 0.10.3 header that is removed.

> ### Fixed
>
> - Newly compliant with the Ruby Spec Suite:
>     * `Module#class_variables`
>     * `Module#class_variable_get`
>     * `Module#class_variable_set`
>     * `Module#remove_class_variable`
>     * `Module#include?`
>     * `Numeric#step` (#1512)
>
> - Improvements for Range class (#1486)
>     * Moved private/tainted/untrusted specs to not supported
>     * Conforming `Range#to_s` and `Range#inspect`
>     * Starting `Range#bsearch` implementation
>     * Simple `Range#step` implementation
>     * Fixing `Range#min` for empty Ranges
>     * Fixing `Range#last(n)` `Range#first(n)` and one edge case of `Range#each`
>     * Fixing some `Range#step` issues on String ranges
>     * Simple `Range#bsearch` implementation, passes about half the specs
>     * Minor styling improvements. Fixed size of `Range#step`.
>     * Compile complex ranges to "Range.new" so there will be a check for begin and end to be comparable.
>
> - Fixed `defined?` for methods raising exceptions
> - Fixed `Kernel#loop` (to catch `StopIteration` error)
> - Fixed inheritance from the `Module` class.
> - Fixed using `--preload` along with `--no-opal` for CLI
> - Fixed `Integer("0")` raising `ArgumentError` instead of parsing as 0
> - Fixed `JSON#parse` to raise `JSON::ParserError` for invalid input
> - `Module#append_features` now detects cyclic includes

However, I think the fixes are not released.
So, I didn't move the fixes into `0.10.3`.