### PR TITLE
Convert Node.js' IO errors to Ruby's IOError object

### DIFF
--- a/test/nodejs/test_file.rb
+++ b/test/nodejs/test_file.rb
@@ -46,6 +46,18 @@ class TestNodejsFile < Test::Unit::TestCase
     assert_equal(lines.length, 2)
   end
 
+  def test_read_noexistent_should_raise_io_error
+    assert_raise IOError do
+      File.read('tmp/nonexistent')
+    end
+  end
+
+  def test_mtime_noexistent_should_raise_io_error
+    assert_raise IOError do
+      File.mtime('tmp/nonexistent')
+    end
+  end
+
   def test_linux_separators
     assert_equal('/', File::SEPARATOR)
     assert_equal('/', File::Separator)


### PR DESCRIPTION
When running Opal in a Node.js environment the following code is not working as expected:

```ruby
def try_read
  ::File.read("missing") # The file "missing" is missing (obviously), so the code will throw an exception...
rescue IOError
  # ... but in a Node.js environment the exception thrown is *not* an IOError.
  puts "As a result this code will not be executed :'("
end
```

The reason is that Node.js errors (for instance `ENOENT` https://nodejs.org/api/errors.html) are not an instance of Ruby's `IOError`.
