### PR TITLE
Fixed multiple line Regexp literal to not generate invalid syntax as JavaScript

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -32,6 +32,7 @@
 - ISO-8859-1 and US-ASCII encodings are now separated as in MRI (#2235)
 - `String#b` no longer modifies object strings in-place (#2235)
 - Parser::Builder::Default.check_lvar_name patch (#2195)
+- Fixed multiple line Regexp literal to not generate invalid syntax as JavaScript (#1616)
 
 ### Changed
 

--- a/lib/opal/nodes/literal.rb
+++ b/lib/opal/nodes/literal.rb
@@ -164,11 +164,10 @@ module Opal
         *values, flags_sexp = *children
         self.flags = flags_sexp.children.map(&:to_s)
 
-        self.value = case values.length
-                     when 0
+        self.value = if values.empty?
                        # empty regexp, we can process it inline
                        s(:str, '')
-                     when 1
+                     elsif single_line?(values)
                        # simple plain regexp, we can put it inline
                        values[0]
                      else
@@ -199,6 +198,16 @@ module Opal
 
       def raw_value
         self.value = @sexp.loc.expression.source
+      end
+
+      private
+
+      def single_line?(values)
+        return false if values.length > 1
+
+        value = values[0]
+        # JavaScript doesn't support multiline regexp
+        value.type != :str || !value.children[0].include?("\n")
       end
     end
 


### PR DESCRIPTION


Currently, the following ruby code is compiled to invalid syntax as a
JavaScript code by Opal.

```ruby
 # test.rb
x = /re
/
```

```sh
$ opal test.rb
/tmp/opal-nodejs-runner-20170109-25185-cupfor:20157
  return (x = /re
              ^
SyntaxError: Invalid regular expression: missing /
    at Object.exports.runInThisContext (vm.js:78:16)
    at Module._compile (module.js:543:28)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
    at Module.runMain (module.js:605:10)
    at run (bootstrap_node.js:420:7)
    at startup (bootstrap_node.js:139:9)
    at bootstrap_node.js:535:3

$ opal -cO test.rb
/* Generated by Opal 0.11.0.dev */
(function(Opal) {
  var self = Opal.top, $scope = Opal, $scopes = [Opal], nil = Opal.nil, $breaker = Opal.breaker, $slice = Opal.slice, x = nil;

  return (x = /re
/)
})(Opal);

/* Generated by Opal 0.11.0.dev */
(function(Opal) {
  var self = Opal.top, $scope = Opal, $scopes = [Opal], nil = Opal.nil, $breaker = Opal.breaker, $slice = Opal.slice;

  Opal.add_stubs(['$exit']);
  return Opal.const_get($scopes, 'Kernel', true, true).$exit()
})(Opal);
```

Ruby allows new line(s) in a regexp literal.
However, JavaScript does not allow it.

Currently Opal optimizes a simple regexp literal.
The simple literal includes the above literal that includes a new line.
So, it's incorrectly optimized.

This change fixes the problem.