### PR TITLE
Reduce stub method calls on startup

### DIFF
--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -1189,19 +1189,23 @@
     var subscriber, subscribers = Opal.stub_subscribers,
         i, ilength = stubs.length,
         j, jlength = subscribers.length,
-        method_name, stub;
+        method_name, stub,
+        opal_stubs = Opal.stubs;
 
     for (i = 0; i < ilength; i++) {
       method_name = stubs[i];
-      // Save method name to populate other subscribers with this stub
-      Opal.stubs[method_name] = true;
-      stub = Opal.stub_for(method_name);
 
-      for (j = 0; j < jlength; j++) {
-        subscriber = subscribers[j];
+      if(!opal_stubs.hasOwnProperty(method_name)) {
+        // Save method name to populate other subscribers with this stub
+        opal_stubs[method_name] = true;
+        stub = Opal.stub_for(method_name);
 
-        if (!(method_name in subscriber)) {
-          subscriber[method_name] = stub;
+        for (j = 0; j < jlength; j++) {
+          subscriber = subscribers[j];
+
+          if (!(method_name in subscriber)) {
+            subscriber[method_name] = stub;
+          }
         }
       }
     }


### PR DESCRIPTION
In an effort to reduce startup time (it's only about 60-80ms in Safari on my machine, which is pretty great, but it's nearly 300ms in Chrome), I noticed that `Opal.add_stubs` monopolized CPU time on loading the runtime.

This PR reduces the number of iterations within this function on startup by almost 4x in real-world apps. A Clearwater app was setting almost 11k stubs. With this patch, it was reduced to just over 2800. Since Opal sets up stubs for methods that are either defined or called within a file, it isn't necessary for all subscribers to receive all stubs. I couldn't find any adverse effects of this patch, so I figured I'd send it your way.

Admittedly, it doesn't have a huge effect on startup time, but it does shave off 20-40ms in Chrome. I'm still investigating ways to improve this further.