### PR TITLE
Add "$$" context to Native docs

### DIFF
--- a/stdlib/native.rb
+++ b/stdlib/native.rb
@@ -12,6 +12,9 @@
 #   do_later = $$[:setTimeout] # Accessing the "setTimeout" property
 #   do_later.call(->{ puts :hello}, 500)
 #
+# `$$` and `$global` wrap `Opal.global`, which the Opal JS runtime
+# sets to the global `this` object.
+#
 module Native
   def self.is_a?(object, klass)
     %x{


### PR DESCRIPTION
Since global variables aren't accounted for in yard, add some
extra context to the top level `Native` docs.