### PR TITLE
Make a couple optimizations in Array

### DIFF
--- a/opal/corelib/array.rb
+++ b/opal/corelib/array.rb
@@ -21,7 +21,13 @@ class Array < `Array`
     `toArraySubclass(objects, self)`
   end
 
-  def initialize(size = nil, obj = nil, &block)
+  def initialize(*args, &block)
+    # Don't take these in as method args because they were getting reassigned
+    # in the compiled JS (to nil if they weren't passed in). Reassigning
+    # function arguments while also referencing the arguments object in the JS
+    # function results in a deoptimization.
+    size, obj = args[0], args[1]
+
     %x{
       if (size > #{Integer::MAX}) {
         #{raise ArgumentError, "array size too big"}
@@ -161,7 +167,7 @@ class Array < `Array`
     end
 
     return [] if `self.length === 0`
-    return clone.to_a if `other.length === 0`
+    return `self.slice()` if `other.length === 0`
 
     %x{
       var result = [], hash = #{{}}, i, length, item;

--- a/opal/corelib/array.rb
+++ b/opal/corelib/array.rb
@@ -22,11 +22,12 @@ class Array < `Array`
   end
 
   def initialize(*args, &block)
-    # Don't take these in as method args because they were getting reassigned
-    # in the compiled JS (to nil if they weren't passed in). Reassigning
-    # function arguments while also referencing the arguments object in the JS
-    # function results in a deoptimization.
-    size, obj = args[0], args[1]
+    # Don't take these in as optional method args because they were getting
+    # reassigned in the compiled JS (to nil if they weren't passed in).
+    # Reassigning function arguments while also referencing the arguments object
+    # in the JS function results in a deoptimization.
+    size = `typeof args[0] === 'undefined' ? nil : args[0]`
+    obj = `typeof args[1] === 'undefined' ? nil : args[1]`
 
     %x{
       if (size > #{Integer::MAX}) {

--- a/opal/corelib/array.rb
+++ b/opal/corelib/array.rb
@@ -21,14 +21,7 @@ class Array < `Array`
     `toArraySubclass(objects, self)`
   end
 
-  def initialize(*args, &block)
-    # Don't take these in as optional method args because they were getting
-    # reassigned in the compiled JS (to nil if they weren't passed in).
-    # Reassigning function arguments while also referencing the arguments object
-    # in the JS function results in a deoptimization.
-    size = `typeof args[0] === 'undefined' ? nil : args[0]`
-    obj = `typeof args[1] === 'undefined' ? nil : args[1]`
-
+  def initialize(size = nil, obj = nil, &block)
     %x{
       if (size > #{Integer::MAX}) {
         #{raise ArgumentError, "array size too big"}


### PR DESCRIPTION
- `Array#initialize` was reassigning function arguments — Ruby default positional args compiles to reassignment of JS function args. This leads to a deoptimization when also using the `arguments` object.
- `Array#-` called `Array#clone` if the other array is empty, which is an expensive operation. It's cheaper to use `JS.Array.prototype.slice`.