### PR TITLE
Optimize comparison on literal values

### DIFF
--- a/lib/opal/nodes/call.rb
+++ b/lib/opal/nodes/call.rb
@@ -18,7 +18,7 @@ module Opal
                     :< => :lt, :<= => :le, :> => :gt, :>= => :ge }
 
       # JavaScript comparisons operators that get optimized
-      COMPARISON_OPERATORS = [ '==', '!=', '>', '<', '>=', '<=']
+      COMPARISON_OPERATORS = [ '==', '!=', '>', '<', '>=', '<=', '===']
 
       def self.add_special(name, options = {}, &handler)
         SPECIALS[name] = options
@@ -154,7 +154,7 @@ module Opal
       end
 
       def is_literal_type(sexp)
-        sexp.type == 'int' || sexp.type == 'str' || sexp.type == 'float'
+        sexp.type == :int || sexp.type == :str || sexp.type == :float
       end
 
       def splat?


### PR DESCRIPTION
Given the follwing code:

```ruby
twenty_two_int = 22
twenty_three_int = 23
twenty_three_string = '23'
zero_point_one = 0.1
if 23 == twenty_three_int
  puts '23 == twenty_three_int'
end
if twenty_three_int == twenty_three_int
  puts 'twenty_three_int == twenty_three_int'
end
if '23' == twenty_three_string
  puts "'23' == twenty_three_string"
end
if 23 == twenty_two_int
  puts '23 == twenty_two_int'
end
if 0.1 == zero_point_one
  puts '0.1 == zero_point_one'
end
```

**Before**

```javascript
(function(Opal) {
  twenty_two_int = 22;
  twenty_three_int = 23;
  twenty_three_string = "23";

  if ((23)['$=='](twenty_three_int)) {
    self.$puts("23 == twenty_three_int")};

  if (twenty_three_int['$=='](twenty_three_int)) {
    self.$puts("twenty_three_int == twenty_three_int")};

  if ("23"['$=='](twenty_three_string)) {
    self.$puts("'23' == twenty_three_string")};

  if ((23)['$=='](twenty_two_int)) {
    return self.$puts("23 == twenty_two_int")};

  if ((0.1)['$=='](zero_point_one)) {
    return self.$puts("0.1 == zero_point_one")
  } else {
    return nil
  };
})(Opal);
```

**After**

```javascript
(function(Opal) {
  twenty_two_int = 22;
  twenty_three_int = 23;
  twenty_three_string = "23";

  if ((23)==(twenty_three_int)) {
    self.$puts("23 == twenty_three_int")};

  if (twenty_three_int['$=='](twenty_three_int)) {
    self.$puts("twenty_three_int == twenty_three_int")};

  if ("23"==(twenty_three_string)) {
    self.$puts("'23' == twenty_three_string")};

  if ((23)==(twenty_two_int)) {
    return self.$puts("23 == twenty_two_int")};

  if ((0.1)==(zero_point_one)) {
    return self.$puts("0.1 == zero_point_one")
  } else {
    return nil
  };
})(Opal);
```