### PR TITLE
Add abbr-month-name with capital-letter support

### DIFF
--- a/spec/opal/core/date_spec.rb
+++ b/spec/opal/core/date_spec.rb
@@ -8,6 +8,11 @@ describe Date do
       Date.parse('2013-10-4').should == Date.new(2013, 10, 4)
       Date.parse('2013-06-02').should == Date.new(2013, 6, 2)
     end
+
+    it "parses date string with month name into a Date instance" do
+      Date.parse("2013 Jun 02").should == Date.new(2013, 6, 2)
+      Date.parse("2013 jun 02").should == Date.new(2013, 6, 2)
+    end
   end
 
   describe "#<" do

--- a/stdlib/date.rb
+++ b/stdlib/date.rb
@@ -124,7 +124,7 @@ class Date
         // Converts month abbr (nov) to a month number
         function fromMonthAbbr(fn) {
           return function(match) {
-            var abbr = fn(match);
+            var abbr = fn(match).toLowerCase();
             return #{ABBR_MONTHNAMES}.indexOf(abbr) + 1;
           }
         }


### PR DESCRIPTION
Current implementation of `Date.parse` doesn't support abbr-month-name with capital-letter.

```ruby
puts Date.parse("2013 jun 02").to_s # "2013-06-02"
puts Date.parse("2013 Jun 02").to_s # "2012-12-02"
```

This PR aims to solve this issue.