### PR TITLE
Returns earlier on force_encoding to improve performance

### DIFF
--- a/opal/corelib/string/encoding.rb
+++ b/opal/corelib/string/encoding.rb
@@ -191,6 +191,11 @@ class String
   end
 
   def force_encoding(encoding)
+    %x{
+      if (encoding === self.encoding) {
+        return self;
+      }
+    }
     encoding = Opal.coerce_to!(encoding, String, :to_s)
     encoding = Encoding.find(encoding)
 


### PR DESCRIPTION
Before: https://jsperf.com/opal-force-encoding-master-3392ee2a

![master-3392](https://cloud.githubusercontent.com/assets/333276/22865341/254fa34c-f162-11e6-9c7e-17456285f4c3.png)

After: https://jsperf.com/opal-force-encoding-master-52c0f3e0

![after](https://cloud.githubusercontent.com/assets/333276/22865342/26e7e426-f162-11e6-9ceb-f4e1fe4e8c63.png)


