### PR TITLE
Let Hash.new take `Object.create(null)` JS objects

### DIFF
--- a/spec/opal/stdlib/native/hash_spec.rb
+++ b/spec/opal/stdlib/native/hash_spec.rb
@@ -36,6 +36,20 @@ describe Hash do
     expect(h).to eq(expected_hash)
   end
 
+  it 'turns Object.create(null) JS objects into a hash' do
+    %x{
+      var obj = Object.create(null);
+      var foo = Object.create(null);
+      var bar = Object.create(null);
+      obj.foo = foo;
+      foo.bar = bar;
+      bar.baz = 'baz';
+    }
+    hash = Hash.new(`obj`)
+
+    expect(hash).to eq({ foo: { bar: { baz: 'baz' } } })
+  end
+
   describe '#to_n' do
     it 'converts a hash with native objects as values' do
       obj = { 'a_key' => `{ key: 1 }` }

--- a/stdlib/native.rb
+++ b/stdlib/native.rb
@@ -529,7 +529,9 @@ class Hash
 
   def initialize(defaults = undefined, &block)
     %x{
-      if (defaults != null && defaults.constructor === Object) {
+      if (defaults != null &&
+           (defaults.constructor === undefined ||
+             defaults.constructor === Object)) {
         var smap = self.$$smap,
             keys = self.$$keys,
             key, value;
@@ -537,11 +539,15 @@ class Hash
         for (key in defaults) {
           value = defaults[key];
 
-          if (value && value.constructor === Object) {
+          if (value &&
+               (value.constructor === undefined ||
+                 value.constructor === Object)) {
             smap[key] = #{Hash.new(`value`)};
           } else if (value && value.$$is_array) {
             value = value.map(function(item) {
-              if (item && item.constructor === Object) {
+              if (item &&
+                   (item.constructor === undefined ||
+                     item.constructor === Object)) {
                 return #{Hash.new(`item`)};
               }
 


### PR DESCRIPTION
Since JS objects created with a `null` prototype are essentially a pure bag of keys and values, they should behave the same as JS object literals when given to `Hash.new`.