### PR TITLE
Resolves #1630, Escapes meta characters in RegExp

### DIFF
--- a/lib/opal/path_reader.rb
+++ b/lib/opal/path_reader.rb
@@ -3,7 +3,7 @@ require 'opal/hike_path_finder'
 
 module Opal
   class PathReader
-    RELATIVE_PATH_REGEXP = %r{#{Opal::REGEXP_START}\.?\.#{File::SEPARATOR}}
+    RELATIVE_PATH_REGEXP = %r{#{Opal::REGEXP_START}\.?\.#{Regexp.quote File::SEPARATOR}}
 
     def initialize(file_finder = HikePathFinder.new)
       @file_finder = file_finder


### PR DESCRIPTION
Especially backslashes!
When running on Windows with Node.js, File::SEPARATOR is equals to `path.sep = '\\'`.

Reference: https://nodejs.org/api/path.html#path_path_sep

Fixes #1630