### PR TITLE
Optimize Class#new and aliased methods

### DIFF
--- a/opal/corelib/class.rb
+++ b/opal/corelib/class.rb
@@ -34,15 +34,28 @@ class Class
   def inherited(cls)
   end
 
-  def new(*args, &block)
-    %x{
-      var obj = #{allocate};
+  %x{
+    Opal.defn(self, '$new', function Class$new() {
+      var self = this;
+      var object = #{allocate};
+      var block = Class$new.$$p;
+      var args = new Array(arguments.length);
+      for(var index = 0; index < arguments.length; index++) {
+        args[index] = arguments[index];
+      }
 
-      obj.$initialize.$$p = block;
-      obj.$initialize.apply(obj, args);
-      return obj;
-    }
-  end
+      if(block) { Class$new.$$p = null }
+
+      Opal.send(object, object.$initialize, args, block);
+
+      return object;
+    });
+  }
+  # def new(*args, &block)
+  #   object = allocate
+  #   `Opal.send(#{object}, #{object}.$initialize, args, block)`
+  #   object
+  # end
 
   def superclass
     `self.$$super || nil`

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -1817,9 +1817,16 @@
     }
 
     new_body = function() {
-      body.$$p = new_body.$$p;
-      new_body.$$p = null;
-      return body.apply(this, arguments);
+      var block = new_body.$$p;
+      var args = new Array(arguments.length);
+
+      for(var index = 0; index < arguments.length; index++) {
+        args[index] = arguments[index];
+      }
+
+      if(block) { new_body.$$p = null }
+
+      return Opal.send(this, body, args, block);
     };
 
     new_body.length = body.length;


### PR DESCRIPTION
This PR isn't necessarily intended to be merged as is, but it wouldn't be a terrible thing if it were (except for the commented-out code I left in there). The main thing is that I noticed a de-opt in both `Class#new` and the aliased-method wrapper. In both cases, I noticed the block was being assigned directly and that `method.apply` was being used. I happened to notice that that's literally what `Opal.send` does and it somehow avoids a de-opt, so I went ahead and rewrote them in terms of `Opal.send`. Sure enough, no longer deoptimized. I have no idea why.

Running a quick benchmark using the Chrome profiler (a Clearwater app rendering about 2,000 components 25x):

| | `new_body` | `Class#new` |
|-|----|----|
| before | 60.8ms | 77.4ms |
| after | 11.3ms | 7.3ms |

So we're looking at about a 5x speedup in using method aliases (in this case, it was mostly `Array#map`) and a 10x speedup in `Class#new`. I think the selective clearing of `$$p` might have helped (the [optimizer can be touchy](https://gist.github.com/Hypercubed/89808f3051101a1a97f3) with function properties), but I haven't tested it exhaustively. If so, it could probably be built into the compiler.

The primary thing I'm wondering is whether using this pattern (`Opal.send` all the things) is preferable to manually setting up blocks and calling `function.apply`.