### PR TITLE
Number#=== is called instead of Kernel#=== on switch/case with Numeric

### DIFF
--- a/opal/corelib/number.rb
+++ b/opal/corelib/number.rb
@@ -261,6 +261,10 @@ class Number < Numeric
     end
   end
 
+  def ===(other)
+    `self === other`
+  end
+
   def ==(other)
     %x{
       if (other.$$is_number) {


### PR DESCRIPTION
Resolves #1639 