### PR TITLE
Resolves #1639, define Number#===

### DIFF
--- a/opal/corelib/number.rb
+++ b/opal/corelib/number.rb
@@ -261,6 +261,19 @@ class Number < Numeric
     end
   end
 
+  def ===(other)
+    %x{
+      if (other.$$is_number) {
+        if (typeof other === 'number') {
+          return self.valueOf() === other;
+        }
+        return self.valueOf() === Number(other);
+      } else {
+        return #{self == other};
+      }
+    }
+  end
+
   def ==(other)
     %x{
       if (other.$$is_number) {

--- a/opal/corelib/number.rb
+++ b/opal/corelib/number.rb
@@ -264,10 +264,7 @@ class Number < Numeric
   def ===(other)
     %x{
       if (other.$$is_number) {
-        if (typeof other === 'number') {
-          return self.valueOf() === other;
-        }
-        return self.valueOf() === Number(other);
+        return self.valueOf() === other.valueOf();
       } else {
         return #{self == other};
       }


### PR DESCRIPTION
@meh Second try :wink: 

#### Benchmark

.benchmark.rb
```ruby
require 'benchmark'

n = 50000
Benchmark.bm do |x|
  x.report { for i in 1..n; [1, 2, 3].grep(1); end }
end
```

```
bundle exec opal -- benchmark.rb
```

Before | After
------------ | -------------
`user     system      total        real` | `user     system      total        real`
`0.173000   0.173000   0.691999 (  0.173000)` | `0.112000   0.112000   0.448000 (  0.112000)`
`0.168000   0.168000   0.672000 (  0.168000)` | `0.113000   0.113000   0.452000 (  0.113000)`
`0.170000   0.170000   0.680000 (  0.170000)` | `0.113000   0.113000   0.452000 (  0.112000)`
`0.169000   0.169000   0.676000 (  0.168000)` | `0.113000   0.113000   0.452001 (  0.114000)`
`0.169000   0.169000   0.676000 (  0.169000)` | `0.113000   0.113000   0.452001 (  0.114000)`
**Average** |
`0,1698	0,1698	0,6791998	0,1696` | `0,1128	0,1128	0,4512004	0,113`

In this case the code is approximatively 50% faster