### PR TITLE
cruby_tests has been renamed to test_cruby

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,4 +11,4 @@ import 'tasks/building.rake'
 import 'tasks/linting.rake'
 import 'tasks/benchmarking.rake'
 
-task :default => [:rspec, :mspec_nodejs, :cruby_tests]
+task :default => [:rspec, :mspec_nodejs, :test_cruby]


### PR DESCRIPTION
Follow-up of https://github.com/opal/opal/commit/9c168a5010210490c9a6fb6a72950ada359421f5

This should fix the build on Appveyor.