### PR TITLE
Failing spec for begin/end with early return that passes on MRI

### DIFF
--- a/spec/opal/core/language/memoization_spec.rb
+++ b/spec/opal/core/language/memoization_spec.rb
@@ -1,0 +1,16 @@
+describe "memoization" do
+  it "memoizes a value with complex internal logic" do
+    klass = Class.new do
+      def memoized_value(dependency: nil)
+        @memoized_value ||= begin
+                              return nil if dependency.nil?
+
+                              dependency.call
+                            end
+      end
+    end
+
+    expect(klass.new.memoized_value(dependency: proc { :value })).to eq :value
+    expect(klass.new.memoized_value).to eq nil
+  end
+end


### PR DESCRIPTION
I found this while running one of my apps against #1653.

Memoization with a begin/end block and an early return seems to be causing something to go wrong. I haven't found what it is, but I was able to reproduce it in a failing spec.

This spec passes on MRI (and on Opal 0.10), but fails on Opal with a NoMethodError. I don't know what part of this fails yet and haven't had time yet to investigate (I doubt it's actually the memoization part, but that was my use case), but I wanted to get it in here because it might break other people's code, as well. I figured you guys are more familiar with the recent compiler changes than I am so something might jump out at you. If not, I can investigate a bit more.