### PR TITLE
Add aliases for `$$` from 'stdlib/English'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Whitespace conventions:
 
 ### Added
 
+- Added aliases for `$$` from [`stdlib/English`](https://ruby-doc.org/stdlib/libdoc/English/rdoc/English.html)
 - Added support for complex (`0b1110i`) and rational (`0b1111r`) number literals. (#1487)
 - Added 2.3.0 methods:
     * `Array#bsearch_index`

--- a/stdlib/native.rb
+++ b/stdlib/native.rb
@@ -12,8 +12,8 @@
 #   do_later = $$[:setTimeout] # Accessing the "setTimeout" property
 #   do_later.call(->{ puts :hello}, 500)
 #
-# `$$` and `$global` wrap `Opal.global`, which the Opal JS runtime
-# sets to the global `this` object.
+# `$$`, `$global`, `$PID` and `$PROCESS_ID` wrap `Opal.global`,
+# which the Opal JS runtime sets to the global `this` object.
 #
 module Native
   def self.is_a?(object, klass)
@@ -621,4 +621,4 @@ class Class
 end
 
 # Exposes the global value (would be `window` inside a browser)
-$$ = $global = Native(`Opal.global`)
+$$ = $global = $PID = $PROCESS_ID = Native(`Opal.global`)


### PR DESCRIPTION
`$PID` and `$PROCESS_ID` are equivalent for `$$`.

RuboCop by default warns that they are preferable to `$$`:

*   [RuboCop cop](http://www.rubydoc.info/github/bbatsov/rubocop/Rubocop/Cop/Style/SpecialGlobalVars)
*   [Ruby Style Guide](https://github.com/bbatsov/ruby-style-guide#no-cryptic-perlisms)
*   [`stdlib/English`](https://ruby-doc.org/stdlib/libdoc/English/rdoc/English.html).