### PR TITLE
Use truth helpers instead of inlining

### DIFF
--- a/lib/opal/nodes/helpers.rb
+++ b/lib/opal/nodes/helpers.rb
@@ -47,9 +47,8 @@ module Opal
           return optimize
         end
 
-        with_temp do |tmp|
-          [fragment("((#{tmp} = "), expr(sexp), fragment(") !== nil && #{tmp} != null && (!#{tmp}.$$is_boolean || #{tmp} == true))")]
-        end
+        helper :truthy
+        [fragment("$truthy("),expr(sexp),fragment(")")]
       end
 
       def js_falsy(sexp)
@@ -61,9 +60,8 @@ module Opal
           end
         end
 
-        with_temp do |tmp|
-          [fragment("((#{tmp} = "), expr(sexp), fragment(") === nil || #{tmp} == null || (#{tmp}.$$is_boolean && #{tmp} == false))")]
-        end
+        helper :falsy
+        [fragment("$falsy("),expr(sexp),fragment(")")]
       end
 
       def js_truthy_optimize(sexp)
@@ -83,8 +81,6 @@ module Opal
             mid == :"=="
             expr(sexp)
           end
-        elsif [:lvar, :self].include? sexp.type
-          [expr(sexp.dup), fragment(" !== false && "), expr(sexp.dup), fragment(" !== nil && "), expr(sexp.dup), fragment(" != null")]
         end
       end
 

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -139,6 +139,18 @@
   }
 
 
+  // Truth
+  // -----
+
+  Opal.truthy = function(val) {
+    return (val !== nil && val != null && (!val.$$is_boolean || val == true));
+  };
+
+  Opal.falsy = function(val) {
+    return (val === nil || val == null || (val.$$is_boolean && val == false))
+  };
+
+
   // Constants
   // ---------
   //

--- a/spec/lib/compiler_spec.rb
+++ b/spec/lib/compiler_spec.rb
@@ -175,7 +175,7 @@ describe Opal::Compiler do
         end
 
         it 'adds nil check for strings' do
-          expect_compiled('foo = 42 if "test" > "bar"').to include('if ((($a = $rb_gt("test", "bar")) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))')
+          expect_compiled('foo = 42 if "test" > "bar"').to include('if ($truthy($rb_gt("test", "bar")))')
         end
 
         it 'specifically == excludes nil check for strings' do
@@ -183,7 +183,7 @@ describe Opal::Compiler do
         end
 
         it 'adds nil check for lvars' do
-          expect_compiled("bar = 4\nfoo = 42 if bar > 5").to include('if ((($a = $rb_gt(bar, 5)) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))')
+          expect_compiled("bar = 4\nfoo = 42 if bar > 5").to include('if ($truthy($rb_gt(bar, 5)))')
         end
 
         it 'specifically == excludes nil check for lvars' do
@@ -191,7 +191,7 @@ describe Opal::Compiler do
         end
 
         it 'adds nil check for constants' do
-          expect_compiled("foo = 42 if Test > 4").to include("if ((($a = $rb_gt(Opal.const_get_relative($nesting, 'Test'), 4)) !== nil && $a != null && (!$a.$$is_boolean || $a == true))) ")
+          expect_compiled("foo = 42 if Test > 4").to include("if ($truthy($rb_gt(Opal.const_get_relative($nesting, 'Test'), 4))) ")
         end
 
         it 'specifically == excludes nil check for constants' do
@@ -201,25 +201,25 @@ describe Opal::Compiler do
 
       context 'without operators' do
         it 'adds nil check for primitives' do
-          expect_compiled('foo = 42 if 2').to include('if ((($a = 2) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))')
-          expect_compiled('foo = 42 if 2.5').to include('if ((($a = 2.5) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))')
-          expect_compiled('foo = 42 if true').to include('if ((($a = true) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))')
+          expect_compiled('foo = 42 if 2').to include('if ($truthy(2))')
+          expect_compiled('foo = 42 if 2.5').to include('if ($truthy(2.5))')
+          expect_compiled('foo = 42 if true').to include('if ($truthy(true))')
         end
 
         it 'adds nil check for boolean method calls' do
-          expect_compiled('foo = 42 if true.something').to include('if ((($a = true.$something()) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))')
+          expect_compiled('foo = 42 if true.something').to include('if ($truthy(true.$something()))')
         end
 
         it 'adds nil check for strings' do
-          expect_compiled('foo = 42 if "test"').to include('if ((($a = "test") !== nil && $a != null && (!$a.$$is_boolean || $a == true)))')
+          expect_compiled('foo = 42 if "test"').to include('if ($truthy("test"))')
         end
 
         it 'adds nil check for lvars' do
-          expect_compiled("bar = 4\nfoo = 42 if bar").to include('if (bar !== false && bar !== nil && bar != null)')
+          expect_compiled("bar = 4\nfoo = 42 if bar").to include('if ($truthy(bar))')
         end
 
         it 'adds nil check for constants' do
-          expect_compiled("foo = 42 if Test").to include("if ((($a = Opal.const_get_relative($nesting, 'Test')) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))")
+          expect_compiled("foo = 42 if Test").to include("if ($truthy(Opal.const_get_relative($nesting, 'Test')))")
         end
       end
     end
@@ -227,52 +227,52 @@ describe Opal::Compiler do
     context 'parentheses' do
       context 'with operators' do
         it 'adds nil check for primitives' do
-          expect_compiled('foo = 42 if (2 > 3)').to include('if ((($a = $rb_gt(2, 3)) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))')
-          expect_compiled('foo = 42 if (2.5 > 3.5)').to include('if ((($a = $rb_gt(2.5, 3.5)) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))')
-          expect_compiled('foo = 42 if (true > false)').to include('if ((($a = $rb_gt(true, false)) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))')
+          expect_compiled('foo = 42 if (2 > 3)').to include('if ($truthy($rb_gt(2, 3))')
+          expect_compiled('foo = 42 if (2.5 > 3.5)').to include('if ($truthy($rb_gt(2.5, 3.5))')
+          expect_compiled('foo = 42 if (true > false)').to include('if ($truthy($rb_gt(true, false))')
 
-          expect_compiled('foo = 42 if (2 == 3)').to include("if ((($a = (2)['$=='](3)) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))")
-          expect_compiled('foo = 42 if (2.5 == 3.5)').to include("if ((($a = (2.5)['$=='](3.5)) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))")
-          expect_compiled('foo = 42 if (true == false)').to include("if ((($a = true['$=='](false)) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))")
+          expect_compiled('foo = 42 if (2 == 3)').to include("if ($truthy((2)['$=='](3))")
+          expect_compiled('foo = 42 if (2.5 == 3.5)').to include("if ($truthy((2.5)['$=='](3.5))")
+          expect_compiled('foo = 42 if (true == false)').to include("if ($truthy(true['$=='](false)))")
         end
 
         it 'adds nil check for strings' do
-          expect_compiled('foo = 42 if ("test" > "bar")').to include('if ((($a = $rb_gt("test", "bar")) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))')
-          expect_compiled('foo = 42 if ("test" == "bar")').to include("if ((($a = \"test\"['$=='](\"bar\")) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))")
+          expect_compiled('foo = 42 if ("test" > "bar")').to include('if ($truthy($rb_gt("test", "bar"))')
+          expect_compiled('foo = 42 if ("test" == "bar")').to include("if ($truthy(\"test\"['$=='](\"bar\"))")
         end
 
         it 'adds nil check for lvars' do
-          expect_compiled("bar = 4\nfoo = 42 if (bar > 5)").to include('if ((($a = $rb_gt(bar, 5)) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))')
-          expect_compiled("bar = 4\nfoo = 42 if (bar == 5)").to include("if ((($a = bar['$=='](5)) !== nil && $a != null && (!$a.$$is_boolean || $a == true))) ")
+          expect_compiled("bar = 4\nfoo = 42 if (bar > 5)").to include('if ($truthy($rb_gt(bar, 5))')
+          expect_compiled("bar = 4\nfoo = 42 if (bar == 5)").to include("if ($truthy(bar['$=='](5))) ")
         end
 
         it 'adds nil check for constants' do
-          expect_compiled("foo = 42 if (Test > 4)").to include("if ((($a = $rb_gt(Opal.const_get_relative($nesting, 'Test'), 4)) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))")
-          expect_compiled("foo = 42 if (Test == 4)").to include("if ((($a = Opal.const_get_relative($nesting, 'Test')['$=='](4)) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))")
+          expect_compiled("foo = 42 if (Test > 4)").to include("if ($truthy($rb_gt(Opal.const_get_relative($nesting, 'Test'), 4))")
+          expect_compiled("foo = 42 if (Test == 4)").to include("if ($truthy(Opal.const_get_relative($nesting, 'Test')['$=='](4))")
         end
       end
 
       context 'without operators' do
         it 'adds nil check for primitives' do
-          expect_compiled('foo = 42 if (2)').to include('if ((($a = 2) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))')
-          expect_compiled('foo = 42 if (2.5)').to include('if ((($a = 2.5) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))')
-          expect_compiled('foo = 42 if (true)').to include('if ((($a = true) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))')
+          expect_compiled('foo = 42 if (2)').to include('if ($truthy(2)')
+          expect_compiled('foo = 42 if (2.5)').to include('if ($truthy(2.5)')
+          expect_compiled('foo = 42 if (true)').to include('if ($truthy(true)')
         end
 
         it 'adds nil check for boolean method calls' do
-          expect_compiled('foo = 42 if (true.something)').to include('if ((($a = true.$something()) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))')
+          expect_compiled('foo = 42 if (true.something)').to include('if ($truthy(true.$something())')
         end
 
         it 'adds nil check for strings' do
-          expect_compiled('foo = 42 if ("test")').to include('if ((($a = "test") !== nil && $a != null && (!$a.$$is_boolean || $a == true)))')
+          expect_compiled('foo = 42 if ("test")').to include('if ($truthy("test")')
         end
 
         it 'adds nil check for lvars' do
-          expect_compiled("bar = 4\nfoo = 42 if (bar)").to include('if ((($a = bar) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))')
+          expect_compiled("bar = 4\nfoo = 42 if (bar)").to include('if ($truthy(bar)')
         end
 
         it 'adds nil check for constants' do
-          expect_compiled("foo = 42 if (Test)").to include("if ((($a = Opal.const_get_relative($nesting, 'Test')) !== nil && $a != null && (!$a.$$is_boolean || $a == true)))")
+          expect_compiled("foo = 42 if (Test)").to include("if ($truthy(Opal.const_get_relative($nesting, 'Test'))")
         end
       end
     end


### PR DESCRIPTION
Perf on nodejs looks roughly the same (possibly in favor of the helper), probably thanks to JIT.

The core is much more readable and shorter.

I think there are some more places that can be replaced, but I'll wait for an ok from @opal/core.