### PR TITLE
Check that process.stderr and process.stdout are defined

### DIFF
--- a/opal/corelib/io.rb
+++ b/opal/corelib/io.rb
@@ -70,8 +70,8 @@ STDIN  = $stdin  = IO.new
 STDOUT = $stdout = IO.new
 
 `var console = Opal.global.console`
-STDOUT.write_proc = `typeof(process) === 'object' ? function(s){process.stdout.write(s)} : function(s){console.log(s)}`
-STDERR.write_proc = `typeof(process) === 'object' ? function(s){process.stderr.write(s)} : function(s){console.warn(s)}`
+STDOUT.write_proc = `typeof(process) === 'object' && typeof(process.stdout) === 'object' ? function(s){process.stdout.write(s)} : function(s){console.log(s)}`
+STDERR.write_proc = `typeof(process) === 'object' && typeof(process.stderr) === 'object' ? function(s){process.stderr.write(s)} : function(s){console.warn(s)}`
 
 STDOUT.extend(IO::Writable)
 STDERR.extend(IO::Writable)


### PR DESCRIPTION
`process` object is defined in a Webpack environment but `process.stderr` and `process.stdout` are not.