### PR TITLE
Use shorter helpers for constant lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Whitespace conventions:
 - Extended `Struct.new` to support `keyword_init` option. (#1757)
 - Added a new `Opal::Config.missing_require_severity` option and relative `--missing-require` CLI flag. This option will command how the builder will behave when a required file is missing. Previously the behavior was undefined and partly controlled by `dynamic_require_severity`. Not to be confused with the runtime config option `Opal.config.missing_require_severity;` which controls the runtime behavior.
 - Added `Matrix` (along with the internal MRI utility `E2MM`)
+- Use shorter helpers for constant lookups, `$$` for relative (nesting) lookups and `$$$` for absolute (qualified) lookups
 
 
 ### Changed

--- a/lib/opal/nodes/constants.rb
+++ b/lib/opal/nodes/constants.rb
@@ -13,11 +13,11 @@ module Opal
         if magical_data_const?
           push('$__END__')
         elsif const_scope
-          push 'Opal.const_get_qualified(', recv(const_scope), ", '#{name}')"
+          push '$$$(', recv(const_scope), ", '#{name}')"
         elsif compiler.eval?
-          push "Opal.const_get_relative($nesting, '#{name}')"
+          push "$$($nesting, '#{name}')"
         else
-          push "Opal.const_get_relative($nesting, '#{name}')"
+          push "$$($nesting, '#{name}')"
         end
       end
 

--- a/lib/opal/nodes/defined.rb
+++ b/lib/opal/nodes/defined.rb
@@ -165,12 +165,12 @@ module Opal
         const_tmp = scope.new_temp
 
         if const_scope.nil?
-          push "(#{const_tmp} = Opal.const_get_relative($nesting, '#{const_name}', 'skip_raise'))"
+          push "(#{const_tmp} = $$($nesting, '#{const_name}', 'skip_raise'))"
         elsif const_scope == s(:cbase)
-          push "(#{const_tmp} = Opal.const_get_qualified('::', '#{const_name}', 'skip_raise'))"
+          push "(#{const_tmp} = $$$('::', '#{const_name}', 'skip_raise'))"
         else
           const_scope_tmp = compile_defined(const_scope)
-          push " && (#{const_tmp} = Opal.const_get_qualified(#{const_scope_tmp}, '#{const_name}', 'skip_raise'))"
+          push " && (#{const_tmp} = $$$(#{const_scope_tmp}, '#{const_name}', 'skip_raise'))"
         end
         const_tmp
       end

--- a/lib/opal/nodes/top.rb
+++ b/lib/opal/nodes/top.rb
@@ -27,6 +27,8 @@ module Opal
             add_temp '$nesting = []'
           end
           add_temp 'nil = Opal.nil'
+          add_temp '$$$ = Opal.const_get_qualified'
+          add_temp '$$ = Opal.const_get_relative'
 
           add_used_helpers
           add_used_operators

--- a/opal/corelib/module.rb
+++ b/opal/corelib/module.rb
@@ -309,7 +309,7 @@ class Module
 
     %x{
       if (inherit) {
-        return Opal.const_get_relative([self], name);
+        return $$([self], name);
       } else {
         return Opal.const_get_local(self, name);
       }

--- a/spec/lib/compiler_spec.rb
+++ b/spec/lib/compiler_spec.rb
@@ -214,11 +214,11 @@ RSpec.describe Opal::Compiler do
         end
 
         it 'adds nil check for constants' do
-          expect_compiled("foo = 42 if Test > 4").to include("if ($truthy($rb_gt(Opal.const_get_relative($nesting, 'Test'), 4))) ")
+          expect_compiled("foo = 42 if Test > 4").to include("if ($truthy($rb_gt($$($nesting, 'Test'), 4))) ")
         end
 
         it 'specifically == excludes nil check for constants' do
-          expect_compiled("foo = 42 if Test == 4").to include("if (Opal.const_get_relative($nesting, 'Test')['$=='](4))")
+          expect_compiled("foo = 42 if Test == 4").to include("if ($$($nesting, 'Test')['$=='](4))")
         end
       end
 
@@ -242,7 +242,7 @@ RSpec.describe Opal::Compiler do
         end
 
         it 'adds nil check for constants' do
-          expect_compiled("foo = 42 if Test").to include("if ($truthy(Opal.const_get_relative($nesting, 'Test')))")
+          expect_compiled("foo = 42 if Test").to include("if ($truthy($$($nesting, 'Test')))")
         end
       end
     end
@@ -270,8 +270,8 @@ RSpec.describe Opal::Compiler do
         end
 
         it 'adds nil check for constants' do
-          expect_compiled("foo = 42 if (Test > 4)").to include("if ($truthy($rb_gt(Opal.const_get_relative($nesting, 'Test'), 4))")
-          expect_compiled("foo = 42 if (Test == 4)").to include("if ($truthy(Opal.const_get_relative($nesting, 'Test')['$=='](4))")
+          expect_compiled("foo = 42 if (Test > 4)").to include("if ($truthy($rb_gt($$($nesting, 'Test'), 4))")
+          expect_compiled("foo = 42 if (Test == 4)").to include("if ($truthy($$($nesting, 'Test')['$=='](4))")
         end
       end
 
@@ -295,7 +295,7 @@ RSpec.describe Opal::Compiler do
         end
 
         it 'adds nil check for constants' do
-          expect_compiled("foo = 42 if (Test)").to include("if ($truthy(Opal.const_get_relative($nesting, 'Test'))")
+          expect_compiled("foo = 42 if (Test)").to include("if ($truthy($$($nesting, 'Test'))")
         end
       end
     end


### PR DESCRIPTION
Conciseness should improve both readability and perf (less lookups on the `Opal` object).