### PR TITLE
Save a link to an object to a Marshal's object cache before processing its instance variables.

### DIFF
--- a/opal/corelib/marshal/read_buffer.rb
+++ b/opal/corelib/marshal/read_buffer.rb
@@ -317,10 +317,10 @@ module Marshal
         load_object(klass, data)
       else
         object = klass.allocate
+        @object_cache << object
         set_ivars(object)
         object
       end
-      @object_cache << result
       result
     end
 

--- a/spec/opal/core/marshal/dump_spec.rb
+++ b/spec/opal/core/marshal/dump_spec.rb
@@ -50,4 +50,22 @@ describe 'Marshal.dump' do
   it 'dumps object#marshal_dump when object responds to #marshal_dump' do
     Marshal.dump(UserMarshal.new).should == "\u0004\bU:\u0010UserMarshal\"\tdata"
   end
+
+  it 'saves a link to an object before processing its instance variables' do
+    top = Object.new
+    ref = Object.new
+    a = Object.new
+    b = Object.new
+    c = Object.new
+
+    top.instance_variable_set(:@a, a)
+    top.instance_variable_set(:@b, b)
+    top.instance_variable_set(:@a, c)
+    top.instance_variable_set(:@ref, ref)
+
+    expected = "\u0004\b[\ao:\vObject\b:\a@ao:\vObject\u0000:\a@bo:\vObject\u0000:\t@refo:\vObject\u0000@\t"
+    Marshal.dump([top, ref]).should == expected
+    loaded = Marshal.load(expected)
+    loaded[0].instance_variable_get(:@ref).object_id.should == loaded[1].object_id
+  end
 end


### PR DESCRIPTION
Closes https://github.com/opal/opal/issues/1669

Object cache is not well documented in https://github.com/ruby/ruby/blob/trunk/doc/marshal.rdoc#object-references, however, its behavior can be reverse-engineered:

``` ruby
class A
  def initialize
    @a = Object.new
    @b = Object.new
    @c = Object.new
    @d = $link
  end

  def inspect
    "#<A:instance @a=#{@a} @b=#{@b} @c=#{@c} @d=#{@d}"
  end
end

class Link
end

$link = Link.new

p Marshal.dump([A.new, $link])
```

MRI prints `"\x04\b[\ao:\x06A\t:\a@ao:\vObject\x00:\a@bo;\a\x00:\a@co;\a\x00:\a@do:\tLink\x00@\n"` after running this code. This binary data contains:
+ a list indicator `[`
+ a length of the list `\a` (2)
+ two items, the first is `A.new` that has `$link` inside, the second is an object link to 5th processed object.

We can replace the end to contain links to 0th, 1th, ... 5th elements, and, of course, change the length of the array to 7 elements to match the structure of `[A.new, @0, @1, @2, @3, @4, @5]`.

Our modified buffer is `"\x04\b[\fo:\x06A\t:\a@ao:\vObject\x00:\a@bo;\a\x00:\a@co;\a\x00:\a@do:\tLink\x00@\x00@\x06@\a@\b@\t@\n"`.

Assuming that classes `A` and `Link` are loaded, demarshalling returns `A.new` + all known object links:
``` ruby
Marshal.load("\x04\b[\fo:\x06A\t:\a@ao:\vObject\x00:\a@bo;\a\x00:\a@co;\a\x00:\a@do:\tLink\x00@\x00@\x06@\a@\b@\t@\n")
 => [
  #<A:instance @a=#<Object:0x007ff4ba879388> @b=#<Object:0x007ff4ba879310> @c=#<Object:0x007ff4ba8792c0> @d=#<Link:0x007ff4ba8791f8>,
  [...],
  #<A:instance @a=#<Object:0x007ff4ba879388> @b=#<Object:0x007ff4ba879310> @c=#<Object:0x007ff4ba8792c0> @d=#<Link:0x007ff4ba8791f8>,
  #<Object:0x007ff4ba879388>,
  #<Object:0x007ff4ba879310>,
  #<Object:0x007ff4ba8792c0>,
  #<Link:0x007ff4ba8791f8>
]
```

So, the order is:
1. array itself (as a top-level container)
2. `A.new`
3. `@a`
4. `@b`
5. `@c`
6. `$link`

And so we get a simple conclusion: the object MUST be cached BEFORE processing its instance variables.

This PR fixes it. Both reported and simplified examples from https://github.com/opal/opal/issues/1669 work as expected