### PR TITLE
Fix base AST rewriter to visit children of Opal-specific jscall, jsattr and jsattrasgn nodes.

### DIFF
--- a/lib/opal/rewriters/base.rb
+++ b/lib/opal/rewriters/base.rb
@@ -13,49 +13,12 @@ module Opal
         ::Opal::AST::Node.new(type, children)
       end
 
-      alias on_iter   process_regular_node
-      alias on_top    process_regular_node
-      alias on_zsuper process_regular_node
-
-      # TODO: remove patches above after releasing
-      # https://github.com/whitequark/parser/commit/cd8d5db
-      def on_vasgn(node)
-        name, value_node = *node
-
-        if !value_node.nil?
-          node.updated(nil, [
-            name, process(value_node)
-          ])
-        else
-          node
-        end
-      end
-
-      def on_casgn(node)
-        scope_node, name, value_node = *node
-
-        if !value_node.nil?
-          node.updated(nil, [
-            process(scope_node), name, process(value_node)
-          ])
-        else
-          node.updated(nil, [
-            process(scope_node), name
-          ])
-        end
-      end
-
-      def on_argument(node)
-        arg_name, value_node = *node
-
-        if !value_node.nil?
-          node.updated(nil, [
-            arg_name, process(value_node)
-          ])
-        else
-          node
-        end
-      end
+      alias on_iter    process_regular_node
+      alias on_top     process_regular_node
+      alias on_zsuper  process_regular_node
+      alias on_jscall  on_send
+      alias jsattr     process_regular_node
+      alias jsattrasgn process_regular_node
 
       # Prepends given +node+ to +body+ node.
       #


### PR DESCRIPTION
Also removed old patch, our version of parser includes it.

Closes https://github.com/opal/opal/issues/1673