### PR TITLE
Bignum support for Marshal.dump

### DIFF
--- a/spec/opal/core/marshal/dump_spec.rb
+++ b/spec/opal/core/marshal/dump_spec.rb
@@ -39,6 +39,14 @@ describe 'Marshal.dump' do
     Marshal.dump(Float::NAN).should == "\004\bf\bnan"
   end
 
+  it "dumps a Integer" do
+    Marshal.dump(0).should == "\x04\bi\x00"
+    Marshal.dump(123).should == "\x04\bi\x01{"
+    Marshal.dump(-123).should == "\x04\bi\x80"
+    Marshal.dump(1234567890).should == "\x04\bl+\a\xD2\x02\x96I"
+    Marshal.dump(-1234567890).should == "\x04\bl-\a\xD2\x02\x96I"
+  end
+
   it "dumps a Regexp with flags" do
     Marshal.dump(/\w/im).should == "\x04\b/\a\\w\u0005"
   end


### PR DESCRIPTION
I modified `Marshal.dump` to correspond to a large integer value.

`Marshal.dump(value)` will be overflow when in -0x100000000 > `value` >= 0x100000000
MRI treats the value as `Bignum` in this case.

Opal
```
>> Marshal.dump(0x100000000)
=>"\u0004\bi\u0001\u0000"
```

MRI
```
irb> Marshal.dump(0x100000000)
=> "\x04\bl+\b\x00\x00\x00\x00\x01\x00"
```