### PR TITLE
Remove warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,7 @@ before_install:
   - bundle config without doc
   - which google-chrome-stable
   - google-chrome-stable --version
+  - export RUBYOPT=-w
 
 script:
   - "bundle exec rake $RUN"

--- a/lib/opal/cli_runners/applescript.rb
+++ b/lib/opal/cli_runners/applescript.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'opal/cli_runners'
 
 module Opal
   module CliRunners

--- a/lib/opal/cli_runners/nashorn.rb
+++ b/lib/opal/cli_runners/nashorn.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'opal/cli_runners'
 require 'opal/paths'
 
 module Opal

--- a/lib/opal/cli_runners/nodejs.rb
+++ b/lib/opal/cli_runners/nodejs.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'opal/cli_runners'
 require 'opal/paths'
 require 'shellwords'
 

--- a/lib/opal/cli_runners/server.rb
+++ b/lib/opal/cli_runners/server.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'opal/cli_runners'
 
 module Opal
   module CliRunners

--- a/lib/opal/compiler.rb
+++ b/lib/opal/compiler.rb
@@ -156,6 +156,7 @@ module Opal
       @unique = 0
       @options = options
       @comments = Hash.new([])
+      @case_stmt = nil
     end
 
     # Compile some ruby code to a string.

--- a/lib/opal/deprecations.rb
+++ b/lib/opal/deprecations.rb
@@ -5,7 +5,7 @@ module Opal
 
     def deprecation message
       message = "DEPRECATION WARNING: #{message}"
-      if @raise_on_deprecation
+      if defined?(@raise_on_deprecation) && @raise_on_deprecation
         raise message
       else
         warn message

--- a/lib/opal/nodes/call.rb
+++ b/lib/opal/nodes/call.rb
@@ -32,6 +32,8 @@ module Opal
         if last_arg && [:iter, :block_pass].include?(last_arg.type)
           @iter = last_arg
           args = rest
+        else
+          @iter = nil
         end
 
         @arglist = s(:arglist, *args)
@@ -281,7 +283,6 @@ module Opal
       end
 
       add_special :nesting do |compile_default|
-        recv, method, *args = children
         push_nesting = push_nesting?(children)
         push '(Opal.Module.$$nesting = $nesting, ' if push_nesting
         compile_default.call
@@ -289,7 +290,6 @@ module Opal
       end
 
       add_special :constants do |compile_default|
-        recv, method, *args = children
         push_nesting = push_nesting?(children)
         push '(Opal.Module.$$nesting = $nesting, ' if push_nesting
         compile_default.call

--- a/lib/opal/nodes/node_with_args.rb
+++ b/lib/opal/nodes/node_with_args.rb
@@ -212,7 +212,7 @@ module Opal
       # Returns an array of JS conditions for raising and argument
       # error caused by arity check
       def arity_checks
-        return @arity_checks if @arity_checks
+        return @arity_checks if defined?(@arity_checks)
 
         arity = args.children.size
         arity -= (opt_args.size)

--- a/lib/opal/nodes/scope.rb
+++ b/lib/opal/nodes/scope.rb
@@ -53,6 +53,7 @@ module Opal
         @methods = []
 
         @uses_block = false
+        @in_ensure = false
 
         # used by classes to store all ivars used in direct def methods
         @proto_ivars = []

--- a/lib/opal/nodes/super.rb
+++ b/lib/opal/nodes/super.rb
@@ -36,10 +36,6 @@ module Opal
 
       private
 
-      def method_id
-        raise 'Not implemented, see #add_method'
-      end
-
       # Using super in a block inside a method is allowed, e.g.
       # def a
       #  { super }

--- a/lib/opal/rewriter.rb
+++ b/lib/opal/rewriter.rb
@@ -31,7 +31,7 @@ module Opal
       end
 
       def disabled?
-        @disabled
+        @disabled if defined?(@disabled)
       end
     end
 

--- a/lib/opal/rewriters/binary_operator_assignment.rb
+++ b/lib/opal/rewriters/binary_operator_assignment.rb
@@ -80,8 +80,6 @@ module Opal
       #   using SendHandler to `recvr.nil? ? nil : (recvr.meth = recvr.meth + rhs)`
       class ConditionalSendHandler < self
         def self.call(lhs, op, rhs)
-          root_type = :op_asgn
-
           recvr, meth, *args = *lhs
 
           recvr_tmp = new_temp
@@ -89,7 +87,6 @@ module Opal
           recvr = s(:js_tmp, recvr_tmp)
 
           recvr_is_nil = s(:send, recvr, :nil?)                 # recvr.nil?
-          nil_node = s(:nil)                                    # nil
           plain_send = lhs.updated(:send, [recvr, meth, *args]) # recvr.meth
           plain_op_asgn = s(:op_asgn, plain_send, op, rhs)      # recvr.meth += rhs
 

--- a/lib/opal/rewriters/for_rewriter.rb
+++ b/lib/opal/rewriters/for_rewriter.rb
@@ -53,7 +53,6 @@ module Opal
           # i, j = __jstmp
           s(:masgn, loop_variable, get_tmp_loop_variable)
         else # single argument like "for i in (0..3)"
-          loop_variable_name, _ = *loop_variable
           # i = __jstmp
           loop_variable << get_tmp_loop_variable
         end

--- a/lib/opal/rewriters/logical_operator_assignment.rb
+++ b/lib/opal/rewriters/logical_operator_assignment.rb
@@ -89,7 +89,6 @@ module Opal
           recvr = s(:js_tmp, recvr_tmp)
 
           recvr_is_nil = s(:send, recvr, :nil?)                 # recvr.nil?
-          nil_node = s(:nil)                                    # nil
           plain_send = lhs.updated(:send, [recvr, meth, *args]) # recvr.meth
           plain_or_asgn = s(root_type, plain_send, rhs)         # recvr.meth ||= rhs
 

--- a/lib/opal/simple_server.rb
+++ b/lib/opal/simple_server.rb
@@ -17,6 +17,7 @@ class Opal::SimpleServer
   def initialize(options = {})
     @prefix = options.fetch(:prefix, 'assets')
     @main = options.fetch(:main, 'application')
+    @index_path = nil
     yield self if block_given?
     freeze
   end

--- a/spec/lib/paths_spec.rb
+++ b/spec/lib/paths_spec.rb
@@ -11,7 +11,7 @@ describe 'Opal.use_gem' do
       skip %(Will fail if GEM_HOME has "rake" in the path, that's ok)
     end
 
-    added_rake_paths = Opal.paths.grep /rake/
+    added_rake_paths = Opal.paths.grep(/rake/)
     expect(added_rake_paths.size).to eq(1)
     expect(added_rake_paths.first).to match(%r{/rake-[\d\.]+/lib$})
   end

--- a/spec/lib/rewriters/binary_operator_assignment_spec.rb
+++ b/spec/lib/rewriters/binary_operator_assignment_spec.rb
@@ -82,6 +82,8 @@ describe Opal::Rewriters::BinaryOperatorAssignment do
               s(:send, cached, :b),
               :+,
               parse('rhs'))))
+
+        expect(rewritten).to eq(expected)
       end
     end
 

--- a/spec/lib/rewriters/opal_engine_check_spec.rb
+++ b/spec/lib/rewriters/opal_engine_check_spec.rb
@@ -21,60 +21,62 @@ describe Opal::Rewriters::OpalEngineCheck do
   let(:false_branch) { s(:int, 2) }
 
   [:RUBY_ENGINE, :RUBY_PLATFORM].each do |const_name|
-    let(:ruby_const_sexp) { s(:const, nil, const_name) }
+    context "for #{const_name} constant" do
+      let(:ruby_const_sexp) { s(:const, nil, const_name) }
 
-    context "#{const_name} == rhs" do
-      context "when rhs == 'opal'" do
-        let(:check) do
-          s(:send, ruby_const_sexp, :==, opal_str_sexp)
+      context "#{const_name} == rhs" do
+        context "when rhs == 'opal'" do
+          let(:check) do
+            s(:send, ruby_const_sexp, :==, opal_str_sexp)
+          end
+
+          it 'replaces true branch with s(:nil)' do
+            expect_rewritten(
+              s(:if, check, true_branch, false_branch)
+            ).to eq(
+              s(:if, check, true_branch, s(:nil))
+            )
+          end
         end
 
-        it 'replaces true branch with s(:nil)' do
-          expect_rewritten(
-            s(:if, check, true_branch, false_branch)
-          ).to eq(
-            s(:if, check, true_branch, s(:nil))
-          )
-        end
-      end
+        context "when rhs != 'opal'" do
+          let(:check) do
+            s(:send, ruby_const_sexp, :==, s(:nil))
+          end
 
-      context "when rhs != 'opal'" do
-        let(:check) do
-          s(:send, ruby_const_sexp, :==, s(:nil))
-        end
-
-        it 'does not modify sexp' do
-          expect_no_rewriting_for(
-            s(:if, check, true_branch, false_branch)
-          )
-        end
-      end
-    end
-
-    context "#{const_name} != rhs" do
-      context "when rhs == 'opal'" do
-        let(:check) do
-          s(:send, ruby_const_sexp, :!=, opal_str_sexp)
-        end
-
-        it 'replaces true branch with s(:nil)' do
-          expect_rewritten(
-            s(:if, check, true_branch, false_branch)
-          ).to eq(
-            s(:if, check, s(:nil), false_branch)
-          )
+          it 'does not modify sexp' do
+            expect_no_rewriting_for(
+              s(:if, check, true_branch, false_branch)
+            )
+          end
         end
       end
 
-      context "when rhs != 'opal'" do
-        let(:check) do
-          s(:send, ruby_const_sexp, :!=, s(:nil))
+      context "#{const_name} != rhs" do
+        context "when rhs == 'opal'" do
+          let(:check) do
+            s(:send, ruby_const_sexp, :!=, opal_str_sexp)
+          end
+
+          it 'replaces true branch with s(:nil)' do
+            expect_rewritten(
+              s(:if, check, true_branch, false_branch)
+            ).to eq(
+              s(:if, check, s(:nil), false_branch)
+            )
+          end
         end
 
-        it 'does not modify sexp' do
-          expect_no_rewriting_for(
-            s(:if, check, true_branch, false_branch)
-          )
+        context "when rhs != 'opal'" do
+          let(:check) do
+            s(:send, ruby_const_sexp, :!=, s(:nil))
+          end
+
+          it 'does not modify sexp' do
+            expect_no_rewriting_for(
+              s(:if, check, true_branch, false_branch)
+            )
+          end
         end
       end
     end

--- a/spec/lib/spec_helper.rb
+++ b/spec/lib/spec_helper.rb
@@ -1,3 +1,5 @@
+$VERBOSE = true
+
 if ENV['CHECK_COVERAGE']
   require 'coveralls'
   Coveralls.wear!

--- a/tasks/testing.rake
+++ b/tasks/testing.rake
@@ -259,7 +259,7 @@ platforms.each do |platform|
 
       stubs = Testing::MSpec.stubs.map{|s| "-s#{s}"}.join(' ')
 
-      sh "ruby -rbundler/setup -r#{__dir__}/testing/mspec_special_calls "\
+      sh "ruby -w -rbundler/setup -r#{__dir__}/testing/mspec_special_calls "\
          "bin/opal -gmspec -Ispec -Ilib #{stubs} -R#{platform} -Dwarning -A --enable-source-location #{filename}"
 
       if bm_filepath


### PR DESCRIPTION
Fixes #1690.

`-w` is a default flag for all tasks running specs on CI and locally.

There are still some warnings:
1. https://github.com/whitequark/parser/issues/360 - reported and looks trivial to fix. Edit: nope, it should be fixed in ragel and doesn't look trivial 😄 
2. rubyspecs suite has some tests for floats like `1e1020`. parser uses `Float('1e1020')` to parse them. Both `ruby -we 'p 1e1020'` and `ruby -we "p Float('1e1020')"` print this warning (this float is actually `Float::INFINITY`). It doesn't look like a ruby version -specific warning, probably it should be silenced in rubyspec. I'll try to fix it.

@lloeki I'm not sure that this PR fixes all warnings from #1690, some of them can be unused in our CI suite.