### PR TITLE
Adds support for Windows paths on File.expand_path

### DIFF
--- a/opal/corelib/file.rb
+++ b/opal/corelib/file.rb
@@ -4,10 +4,12 @@ class File < IO
   PATH_SEPARATOR = ':'
   # Assuming case insenstive filesystem
   FNM_SYSCASE = 0
+  WindowsRootRx = /^[a-zA-Z]:(?:\\|\/)/
 
   class << self
     def expand_path(path, basedir = nil)
       sep = SEPARATOR
+      sep_chars = `$sep_chars()`
       new_parts = []
 
       if path.start_with?('~') || (basedir && basedir.start_with?('~'))
@@ -20,16 +22,16 @@ class File < IO
       end
 
       basedir = Dir.pwd unless basedir
-      path_abs = path.start_with?(sep)
-      basedir_abs = basedir.start_with?(sep)
+      path_abs = path.start_with?(sep) || WindowsRootRx.match?(path)
+      basedir_abs = basedir.start_with?(sep) || WindowsRootRx.match?(basedir)
 
       if path_abs
-        parts = path.split(sep)
-        leading_sep = path.sub(/^([#{sep}]+).*$/, '\1')
+        parts = path.split(/[#{sep_chars}]/)
+        leading_sep = WindowsRootRx.match?(path) ? '' : path.sub(/^([#{sep_chars}]+).*$/, '\1')
         abs = true
       else
-        parts = basedir.split(sep) + path.split(sep)
-        leading_sep = basedir.sub(/^([#{sep}]+).*$/, '\1')
+        parts = basedir.split(/[#{sep_chars}]/) + path.split(/[#{sep_chars}]/)
+        leading_sep = WindowsRootRx.match?(basedir) ? '' : basedir.sub(/^([#{sep_chars}]+).*$/, '\1')
         abs = basedir_abs
       end
 

--- a/test/nodejs/test_dir.rb
+++ b/test/nodejs/test_dir.rb
@@ -4,8 +4,13 @@ require 'nodejs'
 require 'nodejs/dir'
 
 class TestNodejsDir < Test::Unit::TestCase
+
+  def tmpdir
+    `require('os').tmpdir()`
+  end
+
   def test_dir_entries
-    path = "/tmp/testing_nodejs_dir_implementation_#{Time.now.to_i}"
+    path = tmpdir + "/testing_nodejs_dir_implementation_#{Time.now.to_i}"
     Dir.mkdir(path)
     result = Dir.entries(path)
     assert_equal(result.length, 0)

--- a/test/nodejs/test_file.rb
+++ b/test/nodejs/test_file.rb
@@ -80,8 +80,20 @@ class TestNodejsFile < Test::Unit::TestCase
   end unless windows_platform?
 
   def test_windows_separators
-    assert_equal('\\', File::SEPARATOR)
-    assert_equal('\\', File::Separator)
-    assert_equal('/', File::ALT_SEPARATOR)
+    assert_equal('/', File::SEPARATOR)
+    assert_equal('/', File::Separator)
+    assert_equal('\\', File::ALT_SEPARATOR)
+  end if windows_platform?
+
+  def test_windows_file_expand_path
+    assert_equal(Dir.pwd.gsub(/\\/, '/') + '/foo/bar.js', File.expand_path('./foo/bar.js'))
+    assert_equal('/foo/bar.js', File.expand_path('/foo/bar.js'))
+    assert_equal('c:/foo/bar.js', File.expand_path('c:/foo/bar.js'))
+    assert_equal('c:/foo/bar.js', File.expand_path('c:\\foo\\bar.js'))
+    assert_equal('c:/foo/bar.js', File.expand_path( 'bar.js', 'c:\\foo'))
+    assert_equal('c:/foo/baz/bar.js', File.expand_path('\\baz\\bar.js', 'c:\\foo'))
+    assert_equal('c:/baz/bar.js', File.expand_path( '\\baz\\bar.js', 'c:\\foo\\..'))
+    assert_equal('c:/foo/bar.js', File.expand_path( '\\..\\bar.js', 'c:\\foo\\baz'))
+    assert_equal('c:/foo/bar.js', File.expand_path( '\\..\\bar.js', 'c:\\foo\\baz\\'))
   end if windows_platform?
 end

--- a/test/nodejs/test_file.rb
+++ b/test/nodejs/test_file.rb
@@ -4,6 +4,10 @@ require 'nodejs'
 require 'nodejs/file'
 
 class TestNodejsFile < Test::Unit::TestCase
+  def tmpdir
+    `require('os').tmpdir()`
+  end
+
   def self.windows_platform?
     `process.platform`.start_with?('win')
   end
@@ -23,7 +27,7 @@ class TestNodejsFile < Test::Unit::TestCase
   end
 
   def test_write_read
-    path = "/tmp/testing_nodejs_file_implementation_#{Time.now.to_i}"
+    path = tmpdir + "/testing_nodejs_file_implementation_#{Time.now.to_i}"
     contents = 'foobar'
     assert !File.exist?(path)
     File.write path, contents


### PR DESCRIPTION
```ruby
File.expand_path('spec/share/chapter-01/index.adoc') # c:/dev/asciidoctor.js/spec/share/chapter-01/index.adoc
File.expand_path('spec\node\target\output.html') # c:/dev/asciidoctor.js/spec/node/target/output.html
File.expand_path('./spec/node/target') # c:/dev/asciidoctor.js/spec/node/target
```

Partially resolved: https://github.com/opal/opal/issues/1701