### PR TITLE
Use magic encoding comment to encode compiled strings.

### DIFF
--- a/lib/opal/ast/builder.rb
+++ b/lib/opal/ast/builder.rb
@@ -5,10 +5,6 @@ require 'parser/ruby23'
 module Opal
   module AST
     class Builder < ::Parser::Builders::Default
-      def string_value(token)
-        token[0]
-      end
-
       def n(type, children, location)
         ::Opal::AST::Node.new(type, children, location: location)
       end

--- a/lib/opal/cli.rb
+++ b/lib/opal/cli.rb
@@ -116,7 +116,7 @@ module Opal
 
     def show_sexp
       evals_or_file do |contents, filename|
-        buffer = ::Parser::Source::Buffer.new(filename)
+        buffer = ::Opal::Source::Buffer.new(filename)
         buffer.source = contents
         sexp = Opal::Parser.default_parser.parse(buffer)
         puts sexp.inspect

--- a/lib/opal/compiler.rb
+++ b/lib/opal/compiler.rb
@@ -171,7 +171,7 @@ module Opal
     end
 
     def parse
-      @buffer = ::Parser::Source::Buffer.new(file, 1)
+      @buffer = ::Opal::Source::Buffer.new(file, 1)
       @buffer.source = @source
 
       @parser = Opal::Parser.default_parser

--- a/lib/opal/nodes/literal.rb
+++ b/lib/opal/nodes/literal.rb
@@ -61,13 +61,13 @@ module Opal
           string_value = string_value.force_encoding('UTF-8')
         end
 
-        sanitized_value = value.inspect.gsub(/\\u\{([0-9a-f]+)\}/) do |match|
+        sanitized_value = string_value.inspect.gsub(/\\u\{([0-9a-f]+)\}/) do |match|
           code_point = $1.to_i(16)
           to_utf16(code_point)
         end
         push translate_escape_chars(sanitized_value)
 
-        if should_encode
+        if should_encode && RUBY_ENGINE != 'opal'
           push '.$force_encoding("', encoding.name, '")'
         end
       end

--- a/lib/opal/nodes/literal.rb
+++ b/lib/opal/nodes/literal.rb
@@ -53,11 +53,23 @@ module Opal
       end
 
       def compile
+        string_value = value
+        encoding = string_value.encoding
+        should_encode = encoding != Encoding::UTF_8
+
+        if should_encode
+          string_value = string_value.force_encoding('UTF-8')
+        end
+
         sanitized_value = value.inspect.gsub(/\\u\{([0-9a-f]+)\}/) do |match|
           code_point = $1.to_i(16)
           to_utf16(code_point)
         end
         push translate_escape_chars(sanitized_value)
+
+        if should_encode
+          push '.$force_encoding("', encoding.name, '")'
+        end
       end
 
       # http://www.2ality.com/2013/09/javascript-unicode.html

--- a/lib/opal/parser.rb
+++ b/lib/opal/parser.rb
@@ -3,6 +3,14 @@ require 'opal/ast/builder'
 require 'opal/rewriter'
 
 module Opal
+  module Source
+    class Buffer < Parser::Source::Buffer
+      def self.recognize_encoding(string)
+        super || Encoding::UTF_8
+      end
+    end
+  end
+
   class Parser < ::Parser::Ruby23
     class << self
       attr_accessor :diagnostics_consumer

--- a/opal/corelib/array.rb
+++ b/opal/corelib/array.rb
@@ -1881,7 +1881,7 @@ class Array < `Array`
 
     %x{
       var original = self.length;
-      #{ keep_if &block };
+      #{ keep_if(&block) };
       return self.length === original ? nil : self;
     }
   end

--- a/opal/corelib/marshal/read_buffer.rb
+++ b/opal/corelib/marshal/read_buffer.rb
@@ -456,6 +456,11 @@ module Marshal
       object = read
 
       primitive_ivars = read_hash(cache: false)
+
+      if primitive_ivars.any? && object.is_a?(String)
+        object = `new String(object)`
+      end
+
       primitive_ivars.each do |name, value|
         if name != 'E'
           object.instance_variable_set(name, value)

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -2261,7 +2261,13 @@
 
   // Forward .toString() to #to_s
   _Object.$$proto.toString = function() {
-    return this.$to_s();
+    var to_s = this.$to_s();
+    if (to_s.$$is_string && typeof(to_s) === 'object') {
+      // a string created using new String('string')
+      return to_s.valueOf();
+    } else {
+      return to_s;
+    }
   };
 
   // Make Kernel#require immediately available as it's needed to require all the

--- a/opal/corelib/string/inheritance.rb
+++ b/opal/corelib/string/inheritance.rb
@@ -69,7 +69,7 @@ class String::Wrapper
   alias === ==
 
   def to_s
-    @literal
+    @literal.to_s
   end
 
   alias to_str to_s

--- a/spec/lib/compiler/call_spec.rb
+++ b/spec/lib/compiler/call_spec.rb
@@ -68,7 +68,7 @@ if (a == null) a = nil;
               end
 
               context 'via reference' do
-                let(:invocation) { 'call_method *stuff, &block2' }
+                let(:invocation) { 'call_method(*stuff, &block2)' }
 
                 it { is_expected.to include "return $send(self, 'call_method', Opal.to_a(stuff), block2.$to_proc())" }
               end
@@ -90,7 +90,7 @@ if (a == null) a = nil;
               end
 
               context 'via reference' do
-                let(:invocation) { 'call_method &block2' }
+                let(:invocation) { 'call_method(&block2)' }
 
                 it { is_expected.to include "return $send(self, 'call_method', [], block2.$to_proc())" }
               end
@@ -122,7 +122,7 @@ if (a == null) a = nil;
               end
 
               context 'via reference' do
-                let(:invocation) { 'call_method *stuff, &block2' }
+                let(:invocation) { 'call_method(*stuff, &block2)' }
 
                 it { is_expected.to include "return $send(self, 'call_method', Opal.to_a(stuff), self.$block2().$to_proc())" }
               end
@@ -144,7 +144,7 @@ if (a == null) a = nil;
               end
 
               context 'via reference' do
-                let(:invocation) { 'call_method &block2' }
+                let(:invocation) { 'call_method(&block2)' }
 
                 it { is_expected.to include "return $send(self, 'call_method', [], self.$block2().$to_proc())" }
               end
@@ -288,7 +288,7 @@ if (a == null) a = nil;
                   end
 
                   context 'via reference' do
-                    let(:invocation) { 'super *stuff, &block2' }
+                    let(:invocation) { 'super(*stuff, &block2)' }
 
                     it { is_expected.to include "return $send(self, Opal.find_super_dispatcher(self, 'some_method', TMP_Foobar_some_method_1, false), Opal.to_a(stuff), block2.$to_proc())" }
                   end
@@ -310,7 +310,7 @@ if (a == null) a = nil;
                   end
 
                   context 'via reference' do
-                    let(:invocation) { 'super &block2' }
+                    let(:invocation) { 'super(&block2)' }
 
                     it { is_expected.to include "return $send(self, Opal.find_super_dispatcher(self, 'some_method', TMP_Foobar_some_method_1, false), [], block2.$to_proc())" }
                   end
@@ -350,7 +350,7 @@ if (a == null) a = nil;
                   end
 
                   context 'via reference' do
-                    let(:invocation) { 'super *stuff, &block2' }
+                    let(:invocation) { 'super(*stuff, &block2)' }
 
                     it { is_expected.to include "return $send(self, Opal.find_super_dispatcher(self, 'some_method', TMP_Foobar_some_method_1, false), Opal.to_a(stuff), self.$block2().$to_proc())" }
                   end
@@ -372,7 +372,7 @@ if (a == null) a = nil;
                   end
 
                   context 'via reference' do
-                    let(:invocation) { 'super &block2' }
+                    let(:invocation) { 'super(&block2)' }
 
                     it { is_expected.to include "return $send(self, Opal.find_super_dispatcher(self, 'some_method', TMP_Foobar_some_method_1, false), [], self.$block2().$to_proc())" }
                   end

--- a/spec/lib/compiler_spec.rb
+++ b/spec/lib/compiler_spec.rb
@@ -358,7 +358,7 @@ RSpec.describe Opal::Compiler do
       context 'valid sequence' do
         let(:string) { 'λ' }
 
-        include_examples 'it compiles the string as', '"λ"'
+        include_examples 'it compiles the string as', 'λ'.inspect
         include_examples 'it does not re-encode the string using $force_encoding'
         include_examples 'it does not print any warnings'
       end
@@ -387,7 +387,7 @@ RSpec.describe Opal::Compiler do
       context 'unicode sequence' do
         let(:string) { 'λ' }
 
-        include_examples 'it compiles the string as', '"λ".$force_encoding("ASCII-8BIT")'
+        include_examples 'it compiles the string as', 'λ'.inspect + '.$force_encoding("ASCII-8BIT")'
         include_examples 'it does not print any warnings'
       end
     end

--- a/spec/lib/compiler_spec.rb
+++ b/spec/lib/compiler_spec.rb
@@ -307,8 +307,100 @@ RSpec.describe Opal::Compiler do
     end
   end
 
+  describe 'magic encoding comment' do
+    let(:diagnostics) { [] }
+
+    around(:each) do |e|
+      original_diagnostics_consumer = Opal::Parser.diagnostics_consumer
+      Opal::Parser.diagnostics_consumer = ->(diagnostic) { diagnostics << diagnostic }
+      e.run
+      Opal::Parser.diagnostics_consumer = original_diagnostics_consumer
+    end
+
+    let(:encoding_comment) { '' }
+    let(:string) { '' }
+
+    let(:file) do
+      <<-RUBY
+        # encoding: #{encoding_comment}
+        "#{string}"
+      RUBY
+    end
+
+    shared_examples 'it compiles the string as' do |expected|
+      it "compiles the string as #{expected}" do
+        expect_compiled(file).to include(expected)
+      end
+    end
+
+    shared_examples 'it re-encodes the string using $force_encoding' do
+      it 'it re-encodes the string using $force_encoding' do
+        expect_compiled(file).to include("$force_encoding")
+      end
+    end
+
+    shared_examples 'it does not re-encode the string using $force_encoding' do
+      it 'it does not re-encode the string using $force_encoding' do
+        expect_compiled(file).to_not include("$force_encoding")
+      end
+    end
+
+    shared_examples 'it does not print any warnings' do
+      it 'does not print any warnings' do
+        compile(file)
+        expect(diagnostics).to eq([])
+      end
+    end
+
+    context 'utf-8 comment' do
+      let(:encoding_comment) { 'utf-8' }
+
+      context 'valid sequence' do
+        let(:string) { 'λ' }
+
+        include_examples 'it compiles the string as', '"λ"'
+        include_examples 'it does not re-encode the string using $force_encoding'
+        include_examples 'it does not print any warnings'
+      end
+
+      context 'invalid sequence' do
+        let(:string) { "\xFF" }
+
+        it 'raises an error' do
+          expect {
+            compiled(file)
+          }.to raise_error(EncodingError, 'invalid byte sequence in UTF-8')
+        end
+      end
+    end
+
+    context 'ascii-8bit comment' do
+      let(:encoding_comment) { 'ascii-8bit' }
+
+      context 'valid sequence' do
+        let(:string) { "\xFF" }
+
+        include_examples 'it compiles the string as', '"\xFF".$force_encoding("ASCII-8BIT")'
+        include_examples 'it does not print any warnings'
+      end
+
+      context 'unicode sequence' do
+        let(:string) { 'λ' }
+
+        include_examples 'it compiles the string as', '"λ".$force_encoding("ASCII-8BIT")'
+        include_examples 'it does not print any warnings'
+      end
+    end
+  end
+
+  def compiled(*args)
+    Opal::Compiler.new(*args).compile
+  end
+
+  alias compile compiled
+
   def expect_compiled(*args)
-    expect(Opal::Compiler.new(*args).compile)
+    expect(compiled(*args))
   end
 
   def compiler_for(*args)

--- a/spec/lib/rewriters/binary_operator_assignment_spec.rb
+++ b/spec/lib/rewriters/binary_operator_assignment_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Opal::Rewriters::BinaryOperatorAssignment do
 
   def parse(source)
     parser = Opal::Parser.default_parser
-    buffer = ::Parser::Source::Buffer.new('(eval)')
+    buffer = ::Opal::Source::Buffer.new('(eval)')
     buffer.source = source
     parser.parse(buffer)
   end

--- a/spec/lib/rewriters/logical_operator_assignment_spec.rb
+++ b/spec/lib/rewriters/logical_operator_assignment_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Opal::Rewriters::LogicalOperatorAssignment do
 
   def parse(source)
     parser = Opal::Parser.default_parser
-    buffer = ::Parser::Source::Buffer.new('(eval)')
+    buffer = ::Opal::Source::Buffer.new('(eval)')
     buffer.source = source
     parser.parse(buffer)
   end

--- a/spec/opal/core/marshal/dump_spec.rb
+++ b/spec/opal/core/marshal/dump_spec.rb
@@ -1,3 +1,5 @@
+# encoding: binary
+
 require 'spec_helper'
 
 module MarshalExtension

--- a/spec/support/rewriters_helper.rb
+++ b/spec/support/rewriters_helper.rb
@@ -18,7 +18,7 @@ module RewritersHelper
   end
 
   def parse(source)
-    buffer = Parser::Source::Buffer.new('(eval)')
+    buffer = Opal::Source::Buffer.new('(eval)')
     buffer.source = source
     parser = Opal::Parser.default_parser
     parser.parse(buffer)
@@ -27,7 +27,7 @@ module RewritersHelper
   alias :ast_of :parse
 
   def parse_without_rewriting(source)
-    buffer = Parser::Source::Buffer.new('(eval)')
+    buffer = Opal::Source::Buffer.new('(eval)')
     buffer.source = source
     parser = Opal::Parser.superclass.new
     parser.parse(buffer)

--- a/tasks/testing.rake
+++ b/tasks/testing.rake
@@ -280,7 +280,7 @@ platforms.each do |platform|
           benchmark/test_benchmark.rb
           ruby/test_call.rb
           opal/test_keyword.rb
-          base64/test_base64.rb
+          opal/test_base64.rb
           opal/unsupported_and_bugs.rb
         ]
       end

--- a/test/opal/test_base64.rb
+++ b/test/opal/test_base64.rb
@@ -1,0 +1,115 @@
+# coding: ascii-8bit
+# frozen_string_literal: false
+require "test/unit"
+require "base64"
+
+class TestBase64 < Test::Unit::TestCase
+  def test_sample
+    assert_equal("U2VuZCByZWluZm9yY2VtZW50cw==\n", Base64.encode64('Send reinforcements'))
+    assert_equal('Send reinforcements', Base64.decode64("U2VuZCByZWluZm9yY2VtZW50cw==\n"))
+    assert_equal(
+      "Tm93IGlzIHRoZSB0aW1lIGZvciBhbGwgZ29vZCBjb2RlcnMKdG8gbGVhcm4g\nUnVieQ==\n",
+      Base64.encode64("Now is the time for all good coders\nto learn Ruby"))
+    assert_equal(
+      "Now is the time for all good coders\nto learn Ruby",
+      Base64.decode64("Tm93IGlzIHRoZSB0aW1lIGZvciBhbGwgZ29vZCBjb2RlcnMKdG8gbGVhcm4g\nUnVieQ==\n"))
+    assert_equal(
+      "VGhpcyBpcyBsaW5lIG9uZQpUaGlzIGlzIGxpbmUgdHdvClRoaXMgaXMgbGlu\nZSB0aHJlZQpBbmQgc28gb24uLi4K\n",
+      Base64.encode64("This is line one\nThis is line two\nThis is line three\nAnd so on...\n"))
+    assert_equal(
+      "This is line one\nThis is line two\nThis is line three\nAnd so on...\n",
+      Base64.decode64("VGhpcyBpcyBsaW5lIG9uZQpUaGlzIGlzIGxpbmUgdHdvClRoaXMgaXMgbGluZSB0aHJlZQpBbmQgc28gb24uLi4K"))
+  end
+
+  def test_encode64
+    assert_equal("", Base64.encode64(""))
+    assert_equal("AA==\n", Base64.encode64("\0"))
+    assert_equal("AAA=\n", Base64.encode64("\0\0"))
+    assert_equal("AAAA\n", Base64.encode64("\0\0\0"))
+    assert_equal("/w==\n", Base64.encode64("\377"))
+    assert_equal("//8=\n", Base64.encode64("\377\377"))
+    assert_equal("////\n", Base64.encode64("\377\377\377"))
+    assert_equal("/+8=\n", Base64.encode64("\xff\xef"))
+  end
+
+  def test_decode64
+    assert_equal("", Base64.decode64(""))
+    assert_equal("\0", Base64.decode64("AA==\n"))
+    assert_equal("\0\0", Base64.decode64("AAA=\n"))
+    assert_equal("\0\0\0", Base64.decode64("AAAA\n"))
+    assert_equal("\377", Base64.decode64("/w==\n"))
+    assert_equal("\377\377", Base64.decode64("//8=\n"))
+    assert_equal("\377\377\377", Base64.decode64("////\n"))
+    assert_equal("\xff\xef", Base64.decode64("/+8=\n"))
+  end
+
+  def test_strict_encode64
+    assert_equal("", Base64.strict_encode64(""))
+    assert_equal("AA==", Base64.strict_encode64("\0"))
+    assert_equal("AAA=", Base64.strict_encode64("\0\0"))
+    assert_equal("AAAA", Base64.strict_encode64("\0\0\0"))
+    assert_equal("/w==", Base64.strict_encode64("\377"))
+    assert_equal("//8=", Base64.strict_encode64("\377\377"))
+    assert_equal("////", Base64.strict_encode64("\377\377\377"))
+    assert_equal("/+8=", Base64.strict_encode64("\xff\xef"))
+  end
+
+  def test_strict_decode64
+    assert_equal("", Base64.strict_decode64(""))
+    assert_equal("\0", Base64.strict_decode64("AA=="))
+    assert_equal("\0\0", Base64.strict_decode64("AAA="))
+    assert_equal("\0\0\0", Base64.strict_decode64("AAAA"))
+    assert_equal("\377", Base64.strict_decode64("/w=="))
+    assert_equal("\377\377", Base64.strict_decode64("//8="))
+    assert_equal("\377\377\377", Base64.strict_decode64("////"))
+    assert_equal("\xff\xef", Base64.strict_decode64("/+8="))
+
+    assert_raise(ArgumentError) { Base64.strict_decode64("^") }
+    assert_raise(ArgumentError) { Base64.strict_decode64("A") }
+    assert_raise(ArgumentError) { Base64.strict_decode64("A^") }
+    assert_raise(ArgumentError) { Base64.strict_decode64("AA") }
+    assert_raise(ArgumentError) { Base64.strict_decode64("AA=") }
+    assert_raise(ArgumentError) { Base64.strict_decode64("AA===") }
+    assert_raise(ArgumentError) { Base64.strict_decode64("AA=x") }
+    assert_raise(ArgumentError) { Base64.strict_decode64("AAA") }
+    assert_raise(ArgumentError) { Base64.strict_decode64("AAA^") }
+    assert_raise(ArgumentError) { Base64.strict_decode64("AB==") }
+    assert_raise(ArgumentError) { Base64.strict_decode64("AAB=") }
+  end
+
+  def test_urlsafe_encode64
+    assert_equal("", Base64.urlsafe_encode64(""))
+    assert_equal("AA==", Base64.urlsafe_encode64("\0"))
+    assert_equal("AAA=", Base64.urlsafe_encode64("\0\0"))
+    assert_equal("AAAA", Base64.urlsafe_encode64("\0\0\0"))
+    assert_equal("_w==", Base64.urlsafe_encode64("\377"))
+    assert_equal("__8=", Base64.urlsafe_encode64("\377\377"))
+    assert_equal("____", Base64.urlsafe_encode64("\377\377\377"))
+    assert_equal("_-8=", Base64.urlsafe_encode64("\xff\xef"))
+  end
+
+  def test_urlsafe_encode64_unpadded
+    assert_equal("", Base64.urlsafe_encode64("", padding: false))
+    assert_equal("AA", Base64.urlsafe_encode64("\0", padding: false))
+    assert_equal("AAA", Base64.urlsafe_encode64("\0\0", padding: false))
+    assert_equal("AAAA", Base64.urlsafe_encode64("\0\0\0", padding: false))
+  end
+
+  def test_urlsafe_decode64
+    assert_equal("", Base64.urlsafe_decode64(""))
+    assert_equal("\0", Base64.urlsafe_decode64("AA=="))
+    assert_equal("\0\0", Base64.urlsafe_decode64("AAA="))
+    assert_equal("\0\0\0", Base64.urlsafe_decode64("AAAA"))
+    assert_equal("\377", Base64.urlsafe_decode64("_w=="))
+    assert_equal("\377\377", Base64.urlsafe_decode64("__8="))
+    assert_equal("\377\377\377", Base64.urlsafe_decode64("____"))
+    assert_equal("\xff\xef", Base64.urlsafe_decode64("_+8="))
+  end
+
+  def test_urlsafe_decode64_unpadded
+    assert_equal("\0", Base64.urlsafe_decode64("AA"))
+    assert_equal("\0\0", Base64.urlsafe_decode64("AAA"))
+    assert_equal("\0\0\0", Base64.urlsafe_decode64("AAAA"))
+    assert_raise(ArgumentError) { Base64.urlsafe_decode64("AA=") }
+  end
+end


### PR DESCRIPTION
``` ruby
# encoding: ascii-8bit
'λ'
```

Now compiles to:
``` js
"λ".$force_encoding("ASCII-8BIT")
```

When no magic comment specified all strings are treated as UTF-8 and have no re-encoding.

Also the parser now raises an error for invalid UTF-8 byte sequences like:
``` ruby
"\xFF"
```

or

``` ruby
# encoding: utf-8
"\xFF"
```

If you want to make an ascii-string with 255 char, use `encoding` comment and specify any encoding that supports it. You can always check it by running `String#valid_encoding?` method.

Also now we probably can correctly implement `String#bytes` and friends.

Two related modifications:
1. `Object#to_s` now converts its return value from String object to a plain string. [Demo of the bug](http://opalrb.com/try/?code:obj%20%3D%20Object.new%0A%0Adef%20obj.to_s%0A%20%20%22string%22.force_encoding(%27ASCII-8BIT%27)%0Aend%0A%0Aputs%20%22%23%7Bobj%7D%22). 
2. Since `String#force_encoding` (which is now used in many places in specs) returns a String object, it becomes mutable. There were two specs for `Marshal` module that were relying on setting instance variables on the `String`. Before this patch the string was immutable and `instance_variable_set` was no-op. Now it's created using `.force_encoding` and thus is mutable and can have ivars.

About performance:
1. For no magic comment there's absolutely no difference.
2. For `encoding: utf-8` comment there's absolutely no difference.
3. For `encoding: any-non-utf-8-encoding` there's a difference for inline string allocation.