### PR TITLE
ascii encoding fixes

### DIFF
--- a/lib/opal/nodes/call.rb
+++ b/lib/opal/nodes/call.rb
@@ -248,6 +248,7 @@ module Opal
 
           dir = File.dirname(compiler.file)
           full_path = Pathname(dir).join(relative_path).cleanpath.to_s
+          full_path.force_encoding(relative_path.encoding)
           first_arg = first_arg.updated(nil, [full_path])
         end
         @arglist = arglist.updated(nil, [first_arg] + rest)

--- a/opal/corelib/string/encoding.rb
+++ b/opal/corelib/string/encoding.rb
@@ -149,7 +149,7 @@ Encoding.register "UTF-32LE" do
   end
 end
 
-Encoding.register "ASCII-8BIT", aliases: ["BINARY"], ascii: true do
+Encoding.register "ASCII-8BIT", aliases: ["BINARY", "US-ASCII", "ASCII"], ascii: true, dummy: true do
   def each_byte(string, &block)
     %x{
       for (var i = 0, length = string.length; i < length; i++) {

--- a/opal/corelib/string/encoding.rb
+++ b/opal/corelib/string/encoding.rb
@@ -153,7 +153,9 @@ Encoding.register "ASCII-8BIT", aliases: ["BINARY"], ascii: true do
   def each_byte(string, &block)
     %x{
       for (var i = 0, length = string.length; i < length; i++) {
-        #{yield `string.charCodeAt(i) & 0xff`};
+        var code = string.charCodeAt(i);
+        #{yield `code & 0xff`};
+        #{yield `code >> 8`};
       }
     }
   end

--- a/spec/lib/compiler/call_spec.rb
+++ b/spec/lib/compiler/call_spec.rb
@@ -728,5 +728,16 @@ if (b == null) b = nil;
         it { is_expected.to include "return $send(self, Opal.find_super_dispatcher(self, 'some_method', TMP_Foobar_some_method_1, false, $Foobar), $zuper, $iter)" }
       end
     end
+
+    context 'special' do
+      describe '#require_tree' do
+        let(:method) { 'require_tree "./foo/bar"' }
+        it 'does not change the encoding of the passed string (regression)' do
+          # MRI was producing strings encoded as US-ASCII discarding the
+          # original encoding and thus compiling with calls to #force_encoding.
+          is_expected.not_to include('force_encoding')
+        end
+      end
+    end
   end
 end

--- a/spec/opal/core/string_spec.rb
+++ b/spec/opal/core/string_spec.rb
@@ -30,3 +30,21 @@ describe "String#tr" do
     'YWE/'.tr('+/', '-_').should == 'YWE_'
   end
 end
+
+describe 'Encoding' do
+  it 'supports US-ASCII' do
+    # this wouldn't be allowed under MRI:
+    #   ruby -e "# encoding: utf-16le\np 'asdf'.force_encoding 'ascii'"                                                          ~/C/opal
+    #   -e:1: UTF-16LE is not ASCII compatible (ArgumentError)
+    # although for now seems to be the best way to handle it.
+    "è".encoding.name.should == 'UTF-16LE'
+    "è".force_encoding('ASCII').should == "\xC3\xA8"
+    "è".force_encoding('ascii').should == "\xC3\xA8"
+    "è".force_encoding('US-ASCII').should == "\xC3\xA8"
+    "è".force_encoding('us-ascii').should == "\xC3\xA8"
+    "è".force_encoding('ASCII-8BIT').should == "\xC3\xA8"
+    "è".force_encoding('ascii-8bit').should == "\xC3\xA8"
+    "è".force_encoding('BINARY').should == "\xC3\xA8"
+    "è".force_encoding('binary').should == "\xC3\xA8"
+  end
+end


### PR DESCRIPTION
- `require_tree` argument was getting the wrong encoding because was being exported by `Pathname`
- Encoding::ASCII has been added as an alias of BINARY
- The whole encoding has been marked as dummy 