### PR TITLE
Resolves #1729, Define constant Regexp::EXTENDED

### DIFF
--- a/opal/corelib/regexp.rb
+++ b/opal/corelib/regexp.rb
@@ -2,6 +2,7 @@ class RegexpError < StandardError; end
 
 class Regexp < `RegExp`
   IGNORECASE = 1
+  EXTENDED = 2
   MULTILINE = 4
 
   `def.$$is_regexp = true`


### PR DESCRIPTION
Reference: https://ruby-doc.org/core-2.1.1/Regexp.html#method-i-options