### PR TITLE
Implement Array#pack('U')

### DIFF
--- a/opal/corelib/array/pack.rb
+++ b/opal/corelib/array/pack.rb
@@ -110,7 +110,14 @@ class Array
       return function(data) {
         var buffer = callback(data);
         return buffer.map(function(item) {
-          return String.fromCodePoint(item);
+          try {
+            return String.fromCodePoint(item);
+          } catch (error) {
+            if (error instanceof RangeError) {
+              #{raise RangeError, "value out of range"};
+            }
+            throw error;
+          }
         });
       }
     }

--- a/opal/corelib/array/pack.rb
+++ b/opal/corelib/array/pack.rb
@@ -106,6 +106,15 @@ class Array
       }
     }
 
+    function fromCodePoint(callback) {
+      return function(data) {
+        var buffer = callback(data);
+        return buffer.map(function(item) {
+          return String.fromCodePoint(item);
+        });
+      }
+    }
+
     function joinChars(callback) {
       return function(data) {
         var buffer = callback(data);
@@ -140,7 +149,7 @@ class Array
       'v': null,
       'V': null,
 
-      'U': null,
+      'U': joinChars(fromCodePoint(identityFunction)),
       'w': null,
 
       // Float
@@ -283,7 +292,7 @@ class Array
       'v': null,
       'V': null,
 
-      'U': null,
+      'U': readNTimesFromBufferAndMerge(readItem),
       'w': null,
 
       // Float

--- a/opal/corelib/array/pack.rb
+++ b/opal/corelib/array/pack.rb
@@ -149,7 +149,7 @@ class Array
       'v': null,
       'V': null,
 
-      'U': joinChars(fromCodePoint(identityFunction)),
+      'U': joinChars(fromCodePoint(toInt(identityFunction))),
       'w': null,
 
       // Float
@@ -348,7 +348,7 @@ class Array
       'v': null,
       'V': null,
 
-      'U': null,
+      'U': false,
       'w': null,
 
       // Float
@@ -369,7 +369,7 @@ class Array
       'b': null,
       'H': null,
       'h': null,
-      'u': null,
+      'u': false,
       'M': null,
       'm': null,
 

--- a/spec/filters/bugs/pack_unpack.rb
+++ b/spec/filters/bugs/pack_unpack.rb
@@ -86,8 +86,6 @@ opal_filter "Array#pack" do
   fails "Array#pack with format 'U' sets the output string to UTF-8 encoding" # Expected #<Encoding:UTF-8> to be computed by "\u0000".encoding (computed #<Encoding:UTF-16LE> instead)
   fails "Array#pack with format 'U' calls #to_str to coerce the directives string" # RuntimeError: Unsupported pack directive "x" (no chunk reader defined)
   fails "Array#pack with format 'U' encodes values larger than UTF-8 max codepoints" # Exception: Invalid code point 1114112
-  fails "Array#pack with format 'U' raises a RangeError if passed a negative number" # Exception: Invalid code point -1
-  fails "Array#pack with format 'U' raises a RangeError if passed a number larger than an unsigned 32-bit integer" # Exception: Invalid code point 4294967296
   fails "Array#pack with format 'U' taints the output string if the format string is tainted" # RuntimeError: Unsupported pack directive "x" (no chunk reader defined)
   fails "Array#pack with format 'u' appends a newline to the end of the encoded string" # RuntimeError: Unsupported pack directive "u" (no chunk reader defined)
   fails "Array#pack with format 'u' calls #to_str to coerce the directives string" # RuntimeError: Unsupported pack directive "x" (no chunk reader defined)

--- a/spec/filters/bugs/pack_unpack.rb
+++ b/spec/filters/bugs/pack_unpack.rb
@@ -82,4 +82,29 @@ opal_filter "Array#pack" do
   fails "Array#pack with format 'l' with modifier '>' encodes the number of array elements specified by the count modifier" # RuntimeError: Unsupported pack directive "l>" (no chunk reader defined)
   fails "Array#pack with format 'l' with modifier '>' ignores NULL bytes between directives" # RuntimeError: Unsupported pack directive "l>" (no chunk reader defined)
   fails "Array#pack with format 'l' with modifier '>' ignores spaces between directives" # RuntimeError: Unsupported pack directive "l>" (no chunk reader defined)
+  fails "Array#pack with format 'U' raises a TypeError if #to_int does not return an Integer" # Expected TypeError but no exception was raised ("\u0005" was returned)
+  fails "Array#pack with format 'U' sets the output string to UTF-8 encoding" # Expected #<Encoding:UTF-8> to be computed by "\u0000".encoding (computed #<Encoding:UTF-16LE> instead)
+  fails "Array#pack with format 'U' calls #to_str to coerce the directives string" # RuntimeError: Unsupported pack directive "x" (no chunk reader defined)
+  fails "Array#pack with format 'U' encodes values larger than UTF-8 max codepoints" # Exception: Invalid code point 1114112
+  fails "Array#pack with format 'U' raises a RangeError if passed a negative number" # Exception: Invalid code point -1
+  fails "Array#pack with format 'U' raises a RangeError if passed a number larger than an unsigned 32-bit integer" # Exception: Invalid code point 4294967296
+  fails "Array#pack with format 'U' taints the output string if the format string is tainted" # RuntimeError: Unsupported pack directive "x" (no chunk reader defined)
+  fails "Array#pack with format 'u' appends a newline to the end of the encoded string" # RuntimeError: Unsupported pack directive "u" (no chunk reader defined)
+  fails "Array#pack with format 'u' calls #to_str to coerce the directives string" # RuntimeError: Unsupported pack directive "x" (no chunk reader defined)
+  fails "Array#pack with format 'u' calls #to_str to convert an object to a String" # Mock 'pack m string' expected to receive 'to_str' exactly 1 times but received it 0 times
+  fails "Array#pack with format 'u' calls #to_str to convert an object to a String" # RuntimeError: Unsupported pack directive "u" (no chunk reader defined)
+  fails "Array#pack with format 'u' emits a newline after complete groups of count / 3 input characters when passed a count modifier" # RuntimeError: Unsupported pack directive "u" (no chunk reader defined)
+  fails "Array#pack with format 'u' encodes 1, 2, or 3 characters in 4 output characters (uuencoding)" # RuntimeError: Unsupported pack directive "u" (no chunk reader defined)
+  fails "Array#pack with format 'u' encodes all ascii characters" # RuntimeError: Unsupported pack directive "u" (no chunk reader defined)
+  fails "Array#pack with format 'u' encodes an empty string as an empty string" # RuntimeError: Unsupported pack directive "u" (no chunk reader defined)
+  fails "Array#pack with format 'u' encodes one element per directive" # RuntimeError: Unsupported pack directive "u" (no chunk reader defined)
+  fails "Array#pack with format 'u' ignores whitespace in the format string" # RuntimeError: Unsupported pack directive "u" (no chunk reader defined)
+  fails "Array#pack with format 'u' implicitly has a count of 45 when passed '*', 0, 1, 2 or no count modifier" # RuntimeError: Unsupported pack directive "u" (no chunk reader defined)
+  fails "Array#pack with format 'u' prepends the length of each segment of the input string as the first character (+32) in each line of the output" # RuntimeError: Unsupported pack directive "u" (no chunk reader defined)
+  fails "Array#pack with format 'u' raises a TypeError if #to_str does not return a String" # RuntimeError: Unsupported pack directive "u" (no chunk reader defined)
+  fails "Array#pack with format 'u' raises a TypeError if passed an Integer" # RuntimeError: Unsupported pack directive "u" (no chunk reader defined)
+  fails "Array#pack with format 'u' raises a TypeError if passed nil" # RuntimeError: Unsupported pack directive "u" (no chunk reader defined)
+  fails "Array#pack with format 'u' raises an ArgumentError if there are fewer elements than the format requires" # RuntimeError: Unsupported pack directive "u" (no chunk reader defined)
+  fails "Array#pack with format 'u' sets the output string to US-ASCII encoding" # RuntimeError: Unsupported pack directive "u" (no chunk reader defined)
+  fails "Array#pack with format 'u' taints the output string if the format string is tainted" # RuntimeError: Unsupported pack directive "x" (no chunk reader defined)
 end

--- a/spec/filters/bugs/pack_unpack.rb
+++ b/spec/filters/bugs/pack_unpack.rb
@@ -58,7 +58,6 @@ opal_filter "Array#pack" do
   fails "Array#pack with format 'A' returns a string in encoding of common to the concatenated results" # RuntimeError: Unsupported pack directive "U" (no chunk reader defined)
   fails "Array#pack with format 'L' calls #to_str to coerce the directives string" # RuntimeError: Unsupported pack directive "x" (no chunk reader defined)
   fails "Array#pack with format 'L' returns an ASCII-8BIT string" # Expected #<Encoding:UTF-16LE> to equal #<Encoding:ASCII-8BIT>
-  fails "Array#pack with format 'L' taints the output string if the format string is tainted" # RuntimeError: Unsupported pack directive "x" (no chunk reader defined)
   fails "Array#pack with format 'L' with modifier '>' calls #to_int to convert the pack argument to an Integer" # Mock 'to_int' expected to receive 'to_int' exactly 1 times but received it 0 times
   fails "Array#pack with format 'L' with modifier '>' calls #to_int to convert the pack argument to an Integer" # RuntimeError: Unsupported pack directive "L>" (no chunk reader defined)
   fails "Array#pack with format 'L' with modifier '>' encodes a Float truncated as an Integer" # RuntimeError: Unsupported pack directive "L>" (no chunk reader defined)
@@ -72,7 +71,6 @@ opal_filter "Array#pack" do
   fails "Array#pack with format 'a' returns a string in encoding of common to the concatenated results" # RuntimeError: Unsupported pack directive "U" (no chunk reader defined)
   fails "Array#pack with format 'l' calls #to_str to coerce the directives string" # RuntimeError: Unsupported pack directive "x" (no chunk reader defined)
   fails "Array#pack with format 'l' returns an ASCII-8BIT string" # Expected #<Encoding:UTF-16LE> to equal #<Encoding:ASCII-8BIT>
-  fails "Array#pack with format 'l' taints the output string if the format string is tainted" # RuntimeError: Unsupported pack directive "x" (no chunk reader defined)
   fails "Array#pack with format 'l' with modifier '>' calls #to_int to convert the pack argument to an Integer" # Mock 'to_int' expected to receive 'to_int' exactly 1 times but received it 0 times
   fails "Array#pack with format 'l' with modifier '>' calls #to_int to convert the pack argument to an Integer" # RuntimeError: Unsupported pack directive "l>" (no chunk reader defined)
   fails "Array#pack with format 'l' with modifier '>' encodes a Float truncated as an Integer" # RuntimeError: Unsupported pack directive "l>" (no chunk reader defined)
@@ -86,7 +84,6 @@ opal_filter "Array#pack" do
   fails "Array#pack with format 'U' sets the output string to UTF-8 encoding" # Expected #<Encoding:UTF-8> to be computed by "\u0000".encoding (computed #<Encoding:UTF-16LE> instead)
   fails "Array#pack with format 'U' calls #to_str to coerce the directives string" # RuntimeError: Unsupported pack directive "x" (no chunk reader defined)
   fails "Array#pack with format 'U' encodes values larger than UTF-8 max codepoints" # Exception: Invalid code point 1114112
-  fails "Array#pack with format 'U' taints the output string if the format string is tainted" # RuntimeError: Unsupported pack directive "x" (no chunk reader defined)
   fails "Array#pack with format 'u' appends a newline to the end of the encoded string" # RuntimeError: Unsupported pack directive "u" (no chunk reader defined)
   fails "Array#pack with format 'u' calls #to_str to coerce the directives string" # RuntimeError: Unsupported pack directive "x" (no chunk reader defined)
   fails "Array#pack with format 'u' calls #to_str to convert an object to a String" # Mock 'pack m string' expected to receive 'to_str' exactly 1 times but received it 0 times
@@ -104,5 +101,4 @@ opal_filter "Array#pack" do
   fails "Array#pack with format 'u' raises a TypeError if passed nil" # RuntimeError: Unsupported pack directive "u" (no chunk reader defined)
   fails "Array#pack with format 'u' raises an ArgumentError if there are fewer elements than the format requires" # RuntimeError: Unsupported pack directive "u" (no chunk reader defined)
   fails "Array#pack with format 'u' sets the output string to US-ASCII encoding" # RuntimeError: Unsupported pack directive "u" (no chunk reader defined)
-  fails "Array#pack with format 'u' taints the output string if the format string is tainted" # RuntimeError: Unsupported pack directive "x" (no chunk reader defined)
 end

--- a/spec/filters/unsupported/taint.rb
+++ b/spec/filters/unsupported/taint.rb
@@ -45,4 +45,8 @@ opal_unsupported_filter "taint" do
   fails "Array#pack with format 'A' taints the output string if the format string is tainted"
   fails "Array#pack with format 'C' taints the output string if the format string is tainted"
   fails "Array#pack with format 'c' taints the output string if the format string is tainted"
+  fails "Array#pack with format 'L' taints the output string if the format string is tainted"
+  fails "Array#pack with format 'l' taints the output string if the format string is tainted"
+  fails "Array#pack with format 'U' taints the output string if the format string is tainted"
+  fails "Array#pack with format 'u' taints the output string if the format string is tainted"
 end

--- a/spec/ruby_specs
+++ b/spec/ruby_specs
@@ -20,7 +20,7 @@ ruby/core/array/pack/l_spec
 !ruby/core/array/pack/percent_spec
 !ruby/core/array/pack/q_spec
 !ruby/core/array/pack/s_spec
-!ruby/core/array/pack/u_spec
+ruby/core/array/pack/u_spec
 !ruby/core/array/pack/v_spec
 !ruby/core/array/pack/w_spec
 !ruby/core/array/pack/x_spec


### PR DESCRIPTION
```
2.4.1 :001 > [49, 50, 51].pack('U*')
 => "123" 
```

```
bundle exec opal -e "require 'corelib/array/pack'; p [49, 50, 51].pack('U*')"  
"123"
```

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCodePoint

//cc @iliabylich :wink: 
