### PR TITLE
WIP 🚧 Add RubyInstaller2 / Ruby 2.4+ to CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,9 @@ skip_tags: true
 clone_depth: 10
 
 environment:
-  ruby_version: '23'
+  matrix:
+    - RUBY_VERSION: 23
+    - RUBY_VERSION: 24
 
 install:
   - git submodule update --init --recursive


### PR DESCRIPTION
⚠️ Still testing this — don't merge!

This PR increases CI test coverage on Windows. Currently, the Windows CI (AppVeyor) is configured to use `ruby_version: '23'`, which resolves to `ruby 2.3.3p222`, which uses the old RubyInstaller. Adding `24` to the config will test Opal using the new RubyInstaller2, which has a [different architecture](https://rubyinstaller.org/2017/05/25/rubyinstaller-2.4.1-1-released.html) than the old installer (this architecture will be used for all future releases of Ruby).