### PR TITLE
Close parentheses in error message

### DIFF
--- a/opal/corelib/array.rb
+++ b/opal/corelib/array.rb
@@ -2160,7 +2160,7 @@ class Array < `Array`
       max ||= `row.length`
 
       if `row.length` != max
-        raise IndexError, "element size differs (#{`row.length`} should be #{max}"
+        raise IndexError, "element size differs (#{`row.length`} should be #{max})"
       end
 
       `row.length`.times {|i|


### PR DESCRIPTION
Selfish reasons for doing this, tbh — my script mentioned in #1734 can't parse JS functions correctly without this change because it thinks it's still inside a parenthetical expression — it doesn't know about strings. :-) Adding a closing parenthesis here fixes it.