### PR TITLE
Fix $$pristine when method missing is disabled.

### DIFF
--- a/opal/corelib/helpers.rb
+++ b/opal/corelib/helpers.rb
@@ -152,10 +152,14 @@ module Opal
   # @return [nil]
   def self.pristine owner_class, *method_names
     %x{
-      var method_name;
+      var method_name, method;
       for (var i = method_names.length - 1; i >= 0; i--) {
         method_name = method_names[i];
-        owner_class.$$proto['$'+method_name].$$pristine = true
+        method = owner_class.$$proto['$'+method_name];
+
+        if (method && !method.$$stub) {
+          method.$$pristine = true;
+        }
       }
     }
     nil


### PR DESCRIPTION
Before:
```
$ opal -M -e 'p 42'
/private/var/folders/5r/6fz4187d1rj_67cvnjgcbw0w0000gn/T/opal-nodejs-runner-20180108-5821-szas81:2459
        owner_class.$$proto['$'+method_name].$$pristine = true
                                                        ^

TypeError: Cannot set property '$$pristine' of undefined
```
After:
```
$ opal -M -e 'p 42'
42
```