### PR TITLE
Add a short $$ helper to navigate constants manually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Whitespace conventions:
 - Added support for a static folder in the "server" CLI runner via the `OPAL_CLI_RUNNERS_SERVER_STATIC_FOLDER` env var
 - Added ability to pass the port to the "server" CLI runner using the `OPAL_CLI_RUNNERS_SERVER_PORT` (explicit option passed via CLI is still working but deprecated)
 - Added the CLI option `--runner-options` that allows passing arbitrary options to the selected runner, currently the only runner making use of them is `server` accepting `port` and `static_folder`
+- Added a short helper to navigate constants manually: E.g. `Opal.$$.Regexp.$$.IGNORECASE` (see docs for "Compiled Ruby")
 
 
 ### Changed

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -297,6 +297,11 @@
     cref.$$const = (cref.$$const || Object.create(null));
     cref.$$const[name] = value;
 
+    // Add a short helper to navigate constants manually.
+    // @example
+    //   Opal.$$.Regexp.$$.IGNORECASE
+    cref.$$ = cref.$$const;
+
     Opal.const_cache_version++;
 
     // Expose top level constants onto the Opal object
@@ -2274,6 +2279,11 @@
   // other corelib files.
   _Object.$$proto.$require = Opal.require;
 
+  // Add a short helper to navigate constants manually.
+  // @example
+  //   Opal.$$.Regexp.$$.IGNORECASE
+  Opal.$$ = _Object.$$;
+
   // Instantiate the main object
   Opal.top = new _Object.$$alloc();
   Opal.top.$to_s = Opal.top.$inspect = function() { return 'main' };
@@ -2283,8 +2293,9 @@
   nil = Opal.nil = new NilClass_alloc();
   nil.$$id = nil_id;
   nil.call = nil.apply = function() { throw Opal.LocalJumpError.$new('no block given'); };
+
+  // Errors
   Opal.breaker  = new Error('unexpected break (old)');
   Opal.returner = new Error('unexpected return');
-
   TypeError.$$super = Error;
 }).call(this);


### PR DESCRIPTION
The documentation should read better now

E.g.

```js
  Opal.$$.Regexp.$$.IGNORECASE
```

Fixes #1554 cc @camertron @radanskoric