### PR TITLE
Remove code duplication in runners

### DIFF
--- a/lib/opal/cli_runners.rb
+++ b/lib/opal/cli_runners.rb
@@ -66,6 +66,8 @@ module Opal
       names.each { |name| self[name] = runner }
     end
 
+    require 'opal/cli_runners/cmd'
+
     autoload :Applescript, 'opal/cli_runners/applescript'
     autoload :Chrome,      'opal/cli_runners/chrome'
     autoload :Nashorn,     'opal/cli_runners/nashorn'

--- a/lib/opal/cli_runners.rb
+++ b/lib/opal/cli_runners.rb
@@ -52,8 +52,6 @@ module Opal
       0
     }
 
-
-
     # Legacy runners
 
     def self.register_legacy_runner(klass_name, *names)
@@ -79,5 +77,26 @@ module Opal
     register_legacy_runner :Nashorn,     :nashorn
     register_legacy_runner :Nodejs,      :nodejs, :node
     register_legacy_runner :Server,      :server
+
+    # @elia Is this what you had in mind ?
+=begin
+    node_runner = -> data {
+
+      NODE_PATH = File.expand_path('../stdlib/nodejs/node_modules', ::Opal.gem_dir)
+      paths = ENV['NODE_PATH'].to_s.split(':')
+      paths << NODE_PATH unless paths.include? NODE_PATH
+      node_modules = paths.join(':')
+
+      command_options = {:name => 'nodejs', :env => {'NODE_PATH' => node_modules}, :cmd => 'node'}
+      command_options[:options] = data[:options] || {}
+      cmd = Cmd.new(command_options)
+
+      cmd.run(data[:builder].to_s, data[:argv])
+      cmd.exit_status
+    }
+    register_runner :nodejs, node_runner
+    register_runner :node, node_runner
+=end
+
   end
 end

--- a/lib/opal/cli_runners/applescript.rb
+++ b/lib/opal/cli_runners/applescript.rb
@@ -7,52 +7,28 @@ module Opal
         unless system('which osalang > /dev/null')
           raise MissingJavaScriptSupport, 'JavaScript Automation is only supported by OS X Yosemite and above.'
         end
-
-        @output = options.fetch(:output, $stdout)
+        command_options = {:name => 'applescript', :cmd => ['osascript', '-l', 'JavaScript']}
+        command_options[:options] = options
+        @cmd = Cmd.new(command_options)
       end
-      attr_reader :output, :exit_status
 
       def puts(*args)
-        output.puts(*args)
+        @cmd.puts(args)
       end
 
       def run(code, argv)
-        require 'tempfile'
-        tempfile = Tempfile.new('opal-applescript-runner-')
-        # tempfile = File.new('opal-applescript-runner.js', 'w') # for debugging
-        tempfile.puts code
-        tempfile.puts "'';" # OSAScript will output the last thing
-        tempfile.close
-        _successful = system_with_output('osascript', '-l', 'JavaScript', tempfile.path , *argv)
+        osascript_code = "#{code}\n'';" # OSAScript will output the last thing
+        @cmd.run(osascript_code, argv)
       rescue Errno::ENOENT
         raise MissingAppleScript, 'AppleScript is only available on Mac OS X.'
       end
 
-      # Let's support fake IO objects like StringIO
-      def system_with_output(env, *cmd)
-        if (_io_output = IO.try_convert(output))
-          system(env,*cmd)
-          @exit_status = $?.exitstatus
-          return
-        end
+      def output
+        @cmd.output
+      end
 
-        if RUBY_PLATFORM == 'java'
-          # JRuby has issues in dealing with subprocesses (at least up to 1.7.15)
-          # @headius told me it's mostly fixed on master, but while we wait for it
-          # to ship here's a tempfile workaround.
-          require 'tempfile'
-          require 'shellwords'
-          tempfile = Tempfile.new('opal-applescript-output')
-          system(env,cmd.shelljoin+" > #{tempfile.path}")
-          @exit_status = $?.exitstatus
-          captured_output = File.read tempfile.path
-          tempfile.close
-        else
-          require 'open3'
-          captured_output, status = Open3.capture2(env,*cmd)
-          @exit_status = status.exitstatus
-        end
-        output.write captured_output
+      def exit_status
+        @cmd.exit_status
       end
 
       class MissingJavaScriptSupport < RunnerError

--- a/lib/opal/cli_runners/cmd.rb
+++ b/lib/opal/cli_runners/cmd.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+require 'shellwords'
+
+module Opal
+  module CliRunners
+    class Cmd
+      def initialize(options, name, env, *cmd)
+        @output = options.fetch(:output, $stdout)
+        @name = name
+        @env = env
+        @cmd = *cmd
+      end
+      attr_reader :output, :exit_status
+
+      def puts(*args)
+        output.puts(*args)
+      end
+
+      def run(code, argv)
+        require 'tempfile'
+        tempfile = Tempfile.new("opal-#{@name}-runner")
+        # tempfile = File.new("opal-#{@name}-runner.js", 'w') # for debugging
+        tempfile.write code
+        tempfile.close
+        system_with_output(@env, *@cmd, tempfile.path, *argv)
+      end
+
+      # Let's support fake IO objects like StringIO
+      def system_with_output(env, *cmd)
+        if IO.try_convert(output)
+          system(env,*cmd)
+          @exit_status = $?.exitstatus
+          return
+        end
+
+        if RUBY_PLATFORM == 'java'
+          # JRuby has issues in dealing with subprocesses (at least up to 1.7.15)
+          # @headius told me it's mostly fixed on master, but while we wait for it
+          # to ship here's a tempfile workaround.
+          require 'tempfile'
+          tempfile = Tempfile.new("opal-#{@name}-runner")
+          system(env,cmd.shelljoin+" > #{tempfile.path}")
+          @exit_status = $?.exitstatus
+          captured_output = File.read tempfile.path
+          tempfile.close
+        else
+          require 'open3'
+          captured_output, status = Open3.capture2(env,*cmd)
+          @exit_status = status.exitstatus
+        end
+
+        output.write captured_output
+      end
+    end
+  end
+end

--- a/lib/opal/cli_runners/nashorn.rb
+++ b/lib/opal/cli_runners/nashorn.rb
@@ -1,54 +1,16 @@
 # frozen_string_literal: true
-require 'opal/paths'
 
 module Opal
   module CliRunners
-    class Nashorn
+    class Nashorn < Cmd
       def initialize(options)
-        @output = options.fetch(:output, $stdout)
-      end
-      attr_reader :output, :exit_status
-
-      def puts(*args)
-        output.puts(*args)
+        super(options, 'nashorn', {}, 'jjs')
       end
 
       def run(code, argv)
-        require 'tempfile'
-        tempfile = Tempfile.new('opal-nashorn-runner-')
-        tempfile.write code
-        tempfile.close
-        system_with_output({}, 'jjs', tempfile.path , *argv)
+        super(code, argv)
       rescue Errno::ENOENT
         raise MissingNashorn, 'Please install JDK to be able to run Opal scripts.'
-      end
-
-      # Let's support fake IO objects like StringIO
-      def system_with_output(env, *cmd)
-        if IO.try_convert(output)
-          system(env,*cmd)
-          @exit_status = $?.exitstatus
-          return
-        end
-
-        if RUBY_PLATFORM == 'java'
-          # JRuby has issues in dealing with subprocesses (at least up to 1.7.15)
-          # @headius told me it's mostly fixed on master, but while we wait for it
-          # to ship here's a tempfile workaround.
-          require 'tempfile'
-          require 'shellwords'
-          tempfile = Tempfile.new('opal-nashorn-output')
-          system(env,cmd.shelljoin+" > #{tempfile.path}")
-          @exit_status = $?.exitstatus
-          captured_output = File.read tempfile.path
-          tempfile.close
-        else
-          require 'open3'
-          captured_output, status = Open3.capture2(env,*cmd)
-          @exit_status = status.exitstatus
-        end
-
-        output.write captured_output
       end
 
       class MissingNashorn < RunnerError

--- a/lib/opal/cli_runners/nashorn.rb
+++ b/lib/opal/cli_runners/nashorn.rb
@@ -2,15 +2,25 @@
 
 module Opal
   module CliRunners
-    class Nashorn < Cmd
+    class Nashorn
       def initialize(options)
-        super(options, 'nashorn', {}, 'jjs')
+        command_options = {:name => 'nashorn', :cmd => 'jjs'}
+        command_options[:options] = options
+        @cmd = Cmd.new(command_options)
       end
 
       def run(code, argv)
-        super(code, argv)
+        @cmd.run(code, argv)
       rescue Errno::ENOENT
         raise MissingNashorn, 'Please install JDK to be able to run Opal scripts.'
+      end
+
+      def output
+        @cmd.output
+      end
+
+      def exit_status
+        @cmd.exit_status
       end
 
       class MissingNashorn < RunnerError

--- a/lib/opal/cli_runners/nodejs.rb
+++ b/lib/opal/cli_runners/nodejs.rb
@@ -3,25 +3,37 @@ require 'opal/paths'
 
 module Opal
   module CliRunners
-    class Nodejs < Cmd
+    class Nodejs
       NODE_PATH = File.expand_path('../stdlib/nodejs/node_modules', ::Opal.gem_dir)
 
       def initialize(options)
-        super(options, 'nodejs', {'NODE_PATH' => node_modules}, 'node')
+        command_options = {:name => 'nodejs', :env => {'NODE_PATH' => node_modules}, :cmd => 'node'}
+        command_options[:options] = options
+        @cmd = Cmd.new(command_options)
       end
 
       def puts(*args)
-        output.puts(*args)
+        @cmd.puts(*args)
       end
 
       def node_modules
-        NODE_PATH
+        paths = ENV['NODE_PATH'].to_s.split(':')
+        paths << NODE_PATH unless paths.include? NODE_PATH
+        paths.join(':')
       end
 
       def run(code, argv)
-        super(code, argv)
+        @cmd.run(code, argv)
       rescue Errno::ENOENT
         raise MissingNodeJS, 'Please install Node.js to be able to run Opal scripts.'
+      end
+
+      def output
+        @cmd.output
+      end
+
+      def exit_status
+        @cmd.exit_status
       end
 
       class MissingNodeJS < RunnerError

--- a/lib/opal/cli_runners/nodejs.rb
+++ b/lib/opal/cli_runners/nodejs.rb
@@ -1,64 +1,27 @@
 # frozen_string_literal: true
 require 'opal/paths'
-require 'shellwords'
 
 module Opal
   module CliRunners
-    class Nodejs
+    class Nodejs < Cmd
       NODE_PATH = File.expand_path('../stdlib/nodejs/node_modules', ::Opal.gem_dir)
 
       def initialize(options)
-        @output = options.fetch(:output, $stdout)
+        super(options, 'nodejs', {'NODE_PATH' => node_modules}, 'node')
       end
-      attr_reader :output, :exit_status
 
       def puts(*args)
         output.puts(*args)
       end
 
       def node_modules
-        paths = ENV['NODE_PATH'].to_s.split(':')
-        paths << NODE_PATH unless paths.include? NODE_PATH
-        paths.join(':')
+        NODE_PATH
       end
 
       def run(code, argv)
-        require 'tempfile'
-        tempfile = Tempfile.new('opal-nodejs-runner-')
-        # tempfile = File.new('opal-nodejs-runner.js', 'w') # for debugging
-        tempfile.write code
-        tempfile.close
-        system_with_output({'NODE_PATH' => node_modules}, 'node', tempfile.path, *argv)
+        super(code, argv)
       rescue Errno::ENOENT
         raise MissingNodeJS, 'Please install Node.js to be able to run Opal scripts.'
-      end
-
-      # Let's support fake IO objects like StringIO
-      def system_with_output(env, *cmd)
-        if IO.try_convert(output)
-          system(env,*cmd)
-          @exit_status = $?.exitstatus
-          return
-        end
-
-        if RUBY_PLATFORM == 'java'
-          # JRuby has issues in dealing with subprocesses (at least up to 1.7.15)
-          # @headius told me it's mostly fixed on master, but while we wait for it
-          # to ship here's a tempfile workaround.
-          require 'tempfile'
-          require 'shellwords'
-          tempfile = Tempfile.new('opal-node-output')
-          system(env,cmd.shelljoin+" > #{tempfile.path}")
-          @exit_status = $?.exitstatus
-          captured_output = File.read tempfile.path
-          tempfile.close
-        else
-          require 'open3'
-          captured_output, status = Open3.capture2(env,*cmd)
-          @exit_status = status.exitstatus
-        end
-
-        output.write captured_output
       end
 
       class MissingNodeJS < RunnerError

--- a/lib/opal/cli_runners/server.rb
+++ b/lib/opal/cli_runners/server.rb
@@ -9,7 +9,7 @@ module Opal
         @port = options.fetch(:port, ENV['OPAL_CLI_RUNNERS_SERVER_PORT'] || 3000).to_i
 
         @static_folder = options[:static_folder] || ENV['OPAL_CLI_RUNNERS_SERVER_STATIC_FOLDER']
-        @static_folder = @static_folder == true ? 'public' : @static_folder
+        @static_folder = @static_folder ? 'public' : @static_folder
         @static_folder = File.expand_path(@static_folder) if @static_folder
       end
       attr_reader :output, :port, :server, :static_folder


### PR DESCRIPTION
Code Climate is unhappy about the code duplication in runners.

We should probably use composition over inheritance but I didn't want to introduce too much changes.
Also `applescript.rb` has pretty much the same logic so we could refactor this file to use `cmd.rb`.