### PR TITLE
Add Date#next_year and Date#prev_year to 0.10.x branch

### DIFF
--- a/spec/opal/core/date_spec.rb
+++ b/spec/opal/core/date_spec.rb
@@ -98,11 +98,25 @@ describe Date do
     end
   end
 
+  describe "#next_year" do
+    it "returns the date with the next calendar year from self" do
+      Date.new(2013, 2, 5).next_year.should == Date.new(2014, 2, 5)
+      Date.new(2013, 2, 5).next_year(3).should == Date.new(2016, 2, 5)
+    end
+  end
+
   describe "#prev_month" do
     it "returns the date with the previous calendar month" do
       Date.new(2013, 2, 9).prev_month.should == Date.new(2013, 1, 9)
       Date.new(2013, 7, 31).prev_month.should == Date.new(2013, 6, 30)
       Date.new(2013, 1, 3).prev_month.should == Date.new(2012, 12, 3)
+    end
+  end
+
+  describe "#prev_year" do
+    it "returns the date with the previous calendar year from self" do
+      Date.new(2013, 2, 5).prev_year.should == Date.new(2012, 2, 5)
+      Date.new(2013, 2, 5).prev_year(3).should == Date.new(2010, 2, 5)
     end
   end
 

--- a/stdlib/date.rb
+++ b/stdlib/date.rb
@@ -546,6 +546,10 @@ class Date
     }
   end
 
+  def next_year(years=1)
+    self.class.new(year + years, month, day)
+  end
+
   def prev_day(n=1)
     self - n
   end
@@ -558,6 +562,10 @@ class Date
       date.setDate(Math.min(cur, days_in_month(date.getFullYear(), date.getMonth())));
       return result;
     }
+  end
+
+  def prev_year(years=1)
+    self.class.new(year - years, month, day)
   end
 
   def saturday?


### PR DESCRIPTION
See ruby-doc.org/stdlib-2.5.0/libdoc/date/rdoc/Date.html#method-i-next_year

Just trying to make it easy to backport these methods because I still have apps on 0.10. :-)