### PR TITLE
Unify Opal.def for :def nodes.

### DIFF
--- a/lib/opal/nodes/def.rb
+++ b/lib/opal/nodes/def.rb
@@ -120,16 +120,7 @@ module Opal
       end
 
       def wrap_with_definition
-        if    scope.iter?                   then unshift "Opal.def(self, '$#{mid}', "
-        elsif scope.module? || scope.class? then unshift "Opal.defn(self, '$#{mid}', "
-        elsif scope.sclass?                 then unshift "Opal.defn(self, '$#{mid}', "
-        elsif compiler.eval?                then unshift "Opal.def(self, '$#{mid}', "
-        elsif scope.top?                    then unshift "Opal.def(self, '$#{mid}', "
-        elsif scope.def?                    then unshift "Opal.def(self, '$#{mid}', "
-        else raise "Unsupported use of `def`; please file a bug at https://github.com/opal/opal/issues/new reporting this message."
-        end
-
-        push ')'
+        wrap "Opal.def(self, '$#{mid}', ", ')'
 
         if expr?
           wrap '(', ", nil) && '#{mid}'"


### PR DESCRIPTION
By they way, `raise` actually doesn't make sense as `case` covers all cases:
```
$ grep 'in_scope' lib -rFn
lib/opal/nodes/scope.rb:62:      def in_scope(&block)
lib/opal/nodes/module.rb:18:        in_scope do
lib/opal/nodes/class.rb:19:        in_scope do
lib/opal/nodes/singleton_class.rb:14:        in_scope do
lib/opal/nodes/top.rb:18:        in_scope do
lib/opal/nodes/def.rb:38:        in_scope do
lib/opal/nodes/iter.rb:23:        in_scope do
```