### PR TITLE
whitequark/parser requires String#unpack

### DIFF
--- a/stdlib/opal-builder.rb
+++ b/stdlib/opal-builder.rb
@@ -1,2 +1,3 @@
 require 'opal/builder'
 require 'opal/builder_processors'
+require 'corelib/string/unpack'


### PR DESCRIPTION
Therefore `opal-builder.js` needs to require 'corelib/string/unpack'

See: https://github.com/whitequark/parser/blob/v2.4.0.2/lib/parser/lexer.rl#L186