### PR TITLE
Builder fix and allow for .rb.erb

### DIFF
--- a/lib/opal/builder_processors.rb
+++ b/lib/opal/builder_processors.rb
@@ -20,7 +20,7 @@ module Opal
       def self.handles(*extensions)
         @extensions = extensions
         matches = extensions.join('|')
-        matches = "(#{matches})" if extensions.size == 1
+        matches = "(#{matches})" if extensions.size > 1
         @match_regexp = Regexp.new "\\.#{matches}#{REGEXP_END}"
 
         ::Opal::Builder.register_processor(self, extensions)


### PR DESCRIPTION
.rb.erb is required to make ruby-hyperloop work with electron-opal
ruby-hyperloop cant use .opalerb because the files are required server (matz ruby) and client side (opal ruby) the same
