### PR TITLE
Add Date#to_n (in native.rb)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Whitespace conventions:
 
 ### Added
 
+- Added `Date#to_n` that returns the JavaScript Date object (in native.rb). (#1779)
 - Added `Array#pack` (supports only `C, S, L, Q, c, s, l, q, A, a` formats). (#1723)
 - Added `String#unpack` (supports only `C, S, L, Q, S>, L>, Q>, c, s, l, q, n, N, v, V, U, w, A, a, Z, B, b, H, h, u, M, m` formats). (#1723)
 - Added `File#symlink?` for Node.js. (#1725)

--- a/spec/opal/stdlib/native/date_spec.rb
+++ b/spec/opal/stdlib/native/date_spec.rb
@@ -1,0 +1,12 @@
+require 'native'
+require 'date'
+
+describe Date do
+  describe '#to_n' do
+    it 'returns native JS date object' do
+      date = Date.new(1984, 1, 24)
+      native = date.to_n
+      expect(`#{native}.toISOString()`).to eq '1984-01-24T00:00:00.000Z'
+    end
+  end
+end

--- a/stdlib/date.rb
+++ b/stdlib/date.rb
@@ -598,6 +598,10 @@ class Date
     Time.new(year, month, day)
   end
 
+  def to_n
+    @date
+  end
+
   def tuesday?
     wday == 2
   end


### PR DESCRIPTION
I expected Date to have a `to_n` method as it has an obvious JS equivalent, so I added it on @elia's suggestion. Time already has a `to_n` so this seems reasonable.

I grepped the codebase for `def to_n` and they're all in the native.rb file so that's where I put this for consistency.