### PR TITLE
Try other names for chrome executable on linux

### DIFF
--- a/lib/opal/cli_runners/chrome.rb
+++ b/lib/opal/cli_runners/chrome.rb
@@ -93,14 +93,14 @@ module Opal
           when /darwin|mac os/
             '/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome'
           when /linux/
-            %w{
+            %w[
               google-chrome-stable
               chromium
-            }.each do |name|
+            ].each do |name|
               next unless system('sh', '-c', "command -v #{name.shellescape}", out: '/dev/null')
               return name
             end
-            raise "Cannot find chrome executable"
+            raise 'Cannot find chrome executable'
           when /solaris|bsd/
             raise 'Headless chrome is supported only by Mac OS and Linux'
           end

--- a/lib/opal/cli_runners/chrome.rb
+++ b/lib/opal/cli_runners/chrome.rb
@@ -93,7 +93,14 @@ module Opal
           when /darwin|mac os/
             '/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome'
           when /linux/
-            'google-chrome-stable'
+            %w{
+              google-chrome-stable
+              chromium
+            }.each do |name|
+              next unless system('sh', '-c', "command -v #{name.shellescape}", out: '/dev/null')
+              return name
+            end
+            raise "Cannot find chrome executable"
           when /solaris|bsd/
             raise 'Headless chrome is supported only by Mac OS and Linux'
           end


### PR DESCRIPTION
Not all distributions use `google-chrome-stable`, Archlinux for example packages `chromium`, which is basically chrom without branding. So let's try other names too so it works out-of-the-box on more systems.