### PR TITLE
check for chromium-browser binary in chrome cli runner

### DIFF
--- a/lib/opal/cli_runners/chrome.rb
+++ b/lib/opal/cli_runners/chrome.rb
@@ -96,6 +96,7 @@ module Opal
             %w[
               google-chrome-stable
               chromium
+              chromium-browser
             ].each do |name|
               next unless system('sh', '-c', "command -v #{name.shellescape}", out: '/dev/null')
               return name


### PR DESCRIPTION
On Fedora, the name of the Chromium binary is chromium-browser.