### PR TITLE
Fix Date#to_n spec.

### DIFF
--- a/spec/opal/stdlib/native/date_spec.rb
+++ b/spec/opal/stdlib/native/date_spec.rb
@@ -6,7 +6,7 @@ describe Date do
     it 'returns native JS date object' do
       date = Date.new(1984, 1, 24)
       native = date.to_n
-      expect(`#{native}.toISOString()`).to eq '1984-01-24T00:00:00.000Z'
+      expect(`#{native}.toDateString()`).to eq 'Tue Jan 24 1984'
     end
   end
 end


### PR DESCRIPTION
For more information - https://github.com/opal/opal/issues/1788#issuecomment-376011523
Closes https://github.com/opal/opal/issues/1788

`Date.prototype.toISOString` relies on the timezone, so sometimes the spec was failing.
`Date.prototype.toDateString` doesn't care about TZ, that's exactly what we need.