### PR TITLE
optimize Regexp#match and Regexp#match? when pos is undefined

### DIFF
--- a/opal/corelib/regexp.rb
+++ b/opal/corelib/regexp.rb
@@ -161,10 +161,17 @@ class Regexp < `RegExp`
       }
 
       if (pos === undefined) {
-        pos = 0;
-      } else {
-        pos = #{Opal.coerce_to(pos, Integer, :to_int)};
+        if (string === nil) return #{$~ = nil};
+        var m = self.exec(#{Opal.coerce_to(string, String, :to_str)});
+        if (m) {
+          #{$~ = MatchData.new(`self`, `m`)};
+          return block === nil ? #{$~} : #{yield $~};
+        } else {
+          return #{$~ = nil};
+        }
       }
+
+      pos = #{Opal.coerce_to(pos, Integer, :to_int)};
 
       if (string === nil) {
         return #{$~ = nil};
@@ -196,7 +203,7 @@ class Regexp < `RegExp`
           return #{$~ = nil};
         }
         if (md.index >= pos) {
-          #{$~ = MatchData.new(`re`, `md`)}
+          #{$~ = MatchData.new(`re`, `md`)};
           return block === nil ? #{$~} : #{yield $~};
         }
         re.lastIndex = md.index + 1;
@@ -211,10 +218,10 @@ class Regexp < `RegExp`
       }
 
       if (pos === undefined) {
-        pos = 0;
-      } else {
-        pos = #{Opal.coerce_to(pos, Integer, :to_int)};
+        return string === nil ? false : self.test(#{Opal.coerce_to(string, String, :to_str)});
       }
+
+      pos = #{Opal.coerce_to(pos, Integer, :to_int)};
 
       if (string === nil) {
         return false;

--- a/spec/opal/core/regexp/match_spec.rb
+++ b/spec/opal/core/regexp/match_spec.rb
@@ -1,0 +1,78 @@
+describe 'Regexp#match' do
+  describe 'when pos is not specified' do
+    it 'calls .exec only once on the current object' do
+      regexp = /test/
+      calls = 0
+      %x(
+        regexp._exec = regexp.exec;
+        regexp.exec = function(str) {
+          var match = this._exec(str);
+          calls++;
+          return match;
+        }
+      )
+      result = regexp.match('test test')
+      calls.should == 1
+      result.begin(0).should == 0
+      result[0].should == 'test'
+    end
+  end
+
+  describe 'when pos is specified' do
+    it 'does not call .exec on the current object' do
+      regexp = /test/
+      calls = 0
+      %x(
+        regexp._exec = regexp.exec;
+        regexp.exec = function(str) {
+          var match = this._exec(str);
+          calls++;
+          return match;
+        }
+      )
+      result = regexp.match('test test', 1)
+      calls.should == 0
+      result[0].should == 'test'
+      result.begin(0).should == 5
+    end
+  end
+end
+
+describe 'Regexp#match?' do
+  describe 'when pos is not specified' do
+    it 'calls .test on the current object' do
+      regexp = /test/
+      calls = 0
+      %x(
+        regexp._test = regexp.test;
+        regexp.test = function(str) {
+          var verdict = this._test(str);
+          calls++;
+          return verdict;
+        }
+      )
+      result = regexp.match?('test test')
+      calls.should == 1
+      result.should == true
+    end
+  end
+
+  describe 'when pos is specified' do
+    it 'does not call .test on the current object' do
+      regexp = /test/
+      calls = 0
+      %x(
+        regexp._test = regexp.test;
+        regexp.test = function(str) {
+          var verdict = this._test(str);
+          calls++;
+          return verdict;
+        }
+      )
+      result = regexp.match?('test test', 1)
+      calls.should == 0
+      # FIXME pos is not yet supported by Opal's Regexp#match?
+      #result.should == true
+    end
+  end
+end


### PR DESCRIPTION
- use original regexp when pos is not defined