### PR TITLE
don't substitute . in regexp source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,8 @@ Whitespace conventions:
 
 ### Changed
 
+- **BREAKING** The dot (`.`) character is no longer replaced with [\s\S] in a multiline regexp passed to Regexp#match and Regexp#match?
+  * You're advised to always use [\s\S] instead of . in a multiline regexp, which is portable between Ruby and JavaScript
 - The internal API for CLI runners has changed, now it's just a callable object
 - The `--map` CLI option now works only in conjunction with `--compile` (or `--runner compiler`)
 - The `node` CLI runner now adds its `NODE_PATH` entry instead of replacing the ENV var altogether

--- a/opal/corelib/regexp.rb
+++ b/opal/corelib/regexp.rb
@@ -180,12 +180,7 @@ class Regexp < `RegExp`
       }
 
       var source = self.source;
-      var flags = 'g';
-      // m flag + a . in Ruby will match white space, but in JS, it only matches beginning/ending of lines, so we get the equivalent here
-      if (self.multiline) {
-        source = source.replace('.', "[\\s\\S]");
-        flags += 'm';
-      }
+      var flags = self.multiline ? 'gm' : 'g';
 
       // global RegExp maintains state, so not using self/this
       var md, re = new RegExp(source, flags + (self.ignoreCase ? 'i' : ''));
@@ -230,12 +225,7 @@ class Regexp < `RegExp`
       }
 
       var source = self.source;
-      var flags = 'g';
-      // m flag + a . in Ruby will match white space, but in JS, it only matches beginning/ending of lines, so we get the equivalent here
-      if (self.multiline) {
-        source = source.replace('.', "[\\s\\S]");
-        flags += 'm';
-      }
+      var flags = self.multiline ? 'gm' : 'g';
 
       // global RegExp maintains state, so not using self/this
       var md, re = new RegExp(source, flags + (self.ignoreCase ? 'i' : ''));


### PR DESCRIPTION
It's dangerous to blindly replace `.` (dot) with `[\s\S]` in the regexp source. For example, if a dot appears inside a character group (e.g., `[.]`), Opal will cause the regular expression to break.

The onus should be on the library author to use `[\s\S]` in place of `.` when writing multi-line regular expressions as this syntax is already portable between Ruby and JavaScript. Opal should not try to do surgery on the regular expression.