### PR TITLE
Move IO methods that rely on path to File

### DIFF
--- a/stdlib/nodejs/file.rb
+++ b/stdlib/nodejs/file.rb
@@ -175,6 +175,47 @@ class File < IO
 
   attr_reader :path
 
+  def read
+    if @eof
+      ''
+    else
+      res = `executeIOAction(function(){return __fs__.readFileSync(#{@path}).toString()})`
+      @eof = true
+      @lineno = res.size
+      res
+    end
+  end
+
+  def each_line(separator = $/, &block)
+    if @eof
+      return block_given? ? self : [].to_enum
+    end
+
+    if block_given?
+      lines = File.read(@path)
+      %x{
+        self.eof = false;
+        self.lineno = 0;
+        var chomped  = #{lines.chomp},
+            trailing = lines.length != chomped.length,
+            splitted = chomped.split(separator);
+        for (var i = 0, length = splitted.length; i < length; i++) {
+          self.lineno += 1;
+          if (i < length - 1 || trailing) {
+            #{yield `splitted[i] + separator`};
+          }
+          else {
+            #{yield `splitted[i]`};
+          }
+        }
+        self.eof = true;
+      }
+      self
+    else
+      read.each_line
+    end
+  end
+
   def write(string)
     `executeIOAction(function(){return __fs__.writeSync(#{@fd}, #{string})})`
   end

--- a/stdlib/nodejs/io.rb
+++ b/stdlib/nodejs/io.rb
@@ -35,47 +35,6 @@ class IO
     File.read(path)
   end
 
-  def read
-    if @eof
-      ''
-    else
-      res = `executeIOAction(function(){return __fs__.readFileSync(#{@path}).toString()})`
-      @eof = true
-      @lineno = res.size
-      res
-    end
-  end
-
-  def each_line(separator = $/, &block)
-    if @eof
-      return block_given? ? self : [].to_enum
-    end
-
-    if block_given?
-      lines = File.read(@path)
-      %x{
-        self.eof = false;
-        self.lineno = 0;
-        var chomped  = #{lines.chomp},
-            trailing = lines.length != chomped.length,
-            splitted = chomped.split(separator);
-        for (var i = 0, length = splitted.length; i < length; i++) {
-          self.lineno += 1;
-          if (i < length - 1 || trailing) {
-            #{yield `splitted[i] + separator`};
-          }
-          else {
-            #{yield `splitted[i]`};
-          }
-        }
-        self.eof = true;
-      }
-      self
-    else
-      read.each_line
-    end
-  end
-
   def self.binread(path)
     `return executeIOAction(function(){return __fs__.readFileSync(#{path}).toString('binary')})`
   end


### PR DESCRIPTION
`read` and `each_line` rely on the `@path` attribute (which is only define on a `File` class). When working with a `StringIO` in a Node.js environment, if Opal try to use `read` or `each_file` an exception will be thrown because `@path` is undefined (`Opal.nil`).

In this pull request, I've moved these two methods on the `File` class.