### PR TITLE
Fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 
-sudo: false
+sudo: required
 
 dist: trusty
 
@@ -95,6 +95,9 @@ before_install:
   - which google-chrome-stable
   - google-chrome-stable --version
   - export RUBYOPT=-w
+  # Wokraround from https://github.com/travis-ci/travis-ci/issues/9024#issuecomment-356282802
+  - sudo chown root /opt/google/chrome/chrome-sandbox
+  - sudo chmod 4755 /opt/google/chrome/chrome-sandbox
 
 script:
   - "bundle exec rake $RUN"

--- a/lib/opal/cli_runners/chrome.rb
+++ b/lib/opal/cli_runners/chrome.rb
@@ -73,6 +73,7 @@ module Opal
       rescue Timeout::Error
         puts 'Failed to start chrome server'
         puts 'Make sure that you have it installed and that its version is > 59'
+        exit(1)
       ensure
         Process.kill('HUP', chrome_pid) if chrome_pid
       end

--- a/opal/corelib/kernel.rb
+++ b/opal/corelib/kernel.rb
@@ -191,7 +191,7 @@ module Kernel
         status = 0
       } else if (status.$$is_boolean) {
         status = status ? 0 : 1;
-      } else if (status.$$is_numeric) {
+      } else if (status.$$is_number) {
         status = status.$to_i();
       } else {
         status = 0


### PR DESCRIPTION
Before this PR `opal -rnodejs -e "exit(1)"` always exited with 0. Also there were some issues with chrome executables on travis. We have to change the owner and mode of the `/opt/google/chrome/chrome-sandbox`. And again, the build was green because `exit` was broken.
