### PR TITLE
Fix guides, docs and tutorials

### DIFF
--- a/docs/jquery.md
+++ b/docs/jquery.md
@@ -30,26 +30,53 @@ gem 'opal-jquery'
 
 #### Usage
 
-`opal-jquery` can now be easily added to your opal application sources using a
-standard require:
+`opal-jquery` can now be easily added to your opal application sources:
 
 ```ruby
 # app/application.rb
-require 'opal'
-require 'jquery'
-require 'opal-jquery'
+require 'opal/jquery'
 
 alert "Hello from jquery + opal"
 ```
 
-NOTE: this file requires two important dependencies, `jquery` and `opal-jquery`.
-You need to bring your own `jquery.js` file as the gem does not include one. If
-you are using the asset pipeline with rails, then this should be available
-already, otherwise download a copy and place it into `app/` or whichever directory
-you are compiling assets from. You can alternatively require a zepto instance.
-
 The `#alert` method is provided by `opal-jquery`. If the message displays, then
 `jquery` support should be working.
+
+When compiling your application to javascript, you must be sure to include both
+Opal and Opal-JQuery so they'll be available to your application:
+
+```ruby
+require 'opal'
+require 'opal-jquery'
+
+builder = Opal::Builder.new
+builder.build('opal')
+builder.build('opal-jquery')
+builder.build('./app/application.rb')
+
+File.write('application.js', builder.to_s)
+```
+
+then simply load the compiled file in your html:
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src='https://code.jquery.com/jquery-3.3.1.min.js' integrity='sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=' crossorigin='anonymous'></script> 
+    <script type='text/javascript' src='./application.js'></script>
+  </head>
+  <body></body>
+</html>
+```
+
+NOTE: opal-jquery expects a jquery library to be loaded. This example loads it
+remotely from jquery.com, but a locally downloaded copy works just as well, or- 
+if you're using rails- jquery may be included automatically.
+
+This example builds opal, opal-jquery and the application into a single `.js` file, 
+but you may build them separately, if you so choose. Just remember to include 
+each respective script in your html!
 
 ### How does opal-jquery work
 

--- a/docs/rails.md
+++ b/docs/rails.md
@@ -1,26 +1,30 @@
 # Opal in a Rails application
 
-Add Opal to your Gemfile:
+Add Opal to your Rails app's Gemfile:
 
 ``` ruby
 gem 'opal-rails'
 ```
 
-Or to start off with Opal when you build your new Rails app:
-
-```bash
-rails new <app-name> --javascript=opal
-```
-
 ## Basic usage through the asset pipeline
 
-```js
-// app/assets/application.js.rb
+To configure your asset pipeline to use opal-rails, make sure to `bundle install`, then rename 
+`app/assets/application.js` to `app/assets/application.js.rb` and set its contents to: 
 
-//= require opal
-//= require opal_ujs
-//= require turbolinks
-//= require_tree .
+```ruby
+# app/assets/application.js.rb
+
+# Require the opal runtime and core library
+require 'opal'
+
+# For Rails 5.1 and above, otherwise use 'opal_ujs'
+require 'rails_ujs'
+
+# Require of JS libraries will be forwarded to sprockets as is
+require 'turbolinks'
+
+# a Ruby equivalent of the require_tree Sprockets directive is available
+require_tree '.'
 ```
 
 Opal requires are forwarded to the Asset Pipeline at compile time (similarly to what happens for RubyMotion). You can use either the `.rb` or `.opal` extension:

--- a/docs/using_sprockets.md
+++ b/docs/using_sprockets.md
@@ -1,19 +1,20 @@
 # Opal & Sprockets
 
-Opal comes with built-in sprockets support, and provides a simple `Opal::Server`
-class to make it easy to get a rack server up and running for trying out opal.
-This server will automatically recompile ruby sources when they change, meaning
-you just need to refresh your page to autorun.
+The `opal-sprockets` gem adds sprockets support to Opal, providing a simple
+`Opal::Sprockets::server` class to make it easy to get a rack server up and 
+running for trying out opal. This server will automatically recompile ruby 
+sources when they change, meaning you just need to refresh your page to autorun.
 
 ## Getting setup
 
-Add `opal` to a `Gemfile`:
+Add `rack` & `opal-sprockets` to your `Gemfile`:
 
 ```ruby
 #Gemfile
 source 'https://rubygems.org'
 
-gem 'opal', '>= 0.6.0'
+gem 'rack'
+gem 'opal-sprockets'
 ```
 
 And install with `bundle install`.
@@ -28,17 +29,21 @@ require 'opal'
 puts "hello world"
 ```
 
-Finally, we need a html page to run, so create `index.html`:
+
+If we do not provide an HTML index, sprockets will generate one automatically; 
+however, it is often useful to override the default with a custom `erb` file: 
 
 ```html
+<%# index.erb %>
 <!DOCTYPE html>
 <html>
   <head>
     <meta charset="utf-8">
     <title>opal server example</title>
-    <script src="/assets/application.js"></script>
+    <%= javascript_include_tag @server.main %>
   </head>
   <body>
+    you've reached the custom index!
   </body>
 </html>
 ```
@@ -49,15 +54,15 @@ Finally, we need a html page to run, so create `index.html`:
 
 ```ruby
 # config.ru
-require 'bundler'
-Bundler.require
+require 'opal-sprockets'
 
 run Opal::Server.new { |s|
   s.append_path 'app'
 
   s.main = 'application'
 
-  s.index_path = 'index.html'
+  # override the default index with our custom index
+  s.index_path = 'index.erb'
 }
 ```
 

--- a/tasks/building.rake
+++ b/tasks/building.rake
@@ -35,9 +35,9 @@ task :dist do
       log << "* building #{lib}...".ljust(width+'* building ... '.size)
       $stdout.flush
 
-      # Set requirable to true to be consistent with previous builds, generated
-      # with sprockets.
-      src = Opal::Builder.build(lib, requirable: true).to_s
+      # Set requirable to true, unless building opal. This allows opal to be auto-loaded.
+      requirable = (lib != 'opal')
+      src = Opal::Builder.build(lib, requirable: requirable).to_s
       min = Opal::Util.uglify src
       gzp = Opal::Util.gzip min
 


### PR DESCRIPTION
Various code samples from guides, docs, tutorials, etc have fallen out of date and no longer work. I've tweaked the samples to make them work. 

The goal was to get the code to a point where new users can get samples to work by copy / pasting, but I am very open to reviewing and refactoring this code to make it more proper.

Changes:
- [x] Make the dist task build an "auto-loadable" version of Opal, so CDN links work properly again. This is how Opal Sprockets used to work before we switched to Opal Builder.
- [x] Update JQuery guide to load dependencies properly
- [x] Remove -j use from Rails guides (Rails dropped support for that option)
- [x] Fix index example in "Using Sprockets" (I feel like there's an easier way)
- [x] Update Sinatra doc to use Opal-Sprockets (This was messy because Opal-Sprockets doesn't make source maps readily available)