### PR TITLE
Add a failing test with binread and Base64

### DIFF
--- a/test/nodejs/test_io.rb
+++ b/test/nodejs/test_io.rb
@@ -21,4 +21,9 @@ class TestNodejsIO < Test::Unit::TestCase
     assert_equal("Le fran\xC3\xA7ais c'est compliqu\xC3\xA9 :)\\n", IO.binread('tmp/foo'))
     assert_equal("Le français c'est compliqué :)\\n", IO.binread('tmp/foo'))
   end
+
+  def test_binread_image
+    assert_equal("iVBORwoaCgAAAApJSERSAAAAEQAAABEIAgAAALQP0K0AAAAaSURBVCiRY/z//z8DiYCJVAqjekb1jOqBAwCKaAMf7iyZAAAAAABJRU5ErkJggg==",
+      Base64.strict_encode64(IO.binread('test/cruby/test/cgi/testdata/small.png')))
+  end
 end


### PR DESCRIPTION
I don't know how to solve this issue but the added test will throw an exception:

```
ArgumentError: invalid character (failed: The string to be encoded contains characters outside of the Latin1 range.)
```

Previously `binread` was using `toString('binary')` (alias for `latin1`) and Base64 was working.