### PR TITLE
Revert "Implement binread (mimic ASCII-8BIT encoding)"

### DIFF
--- a/stdlib/nodejs/io.rb
+++ b/stdlib/nodejs/io.rb
@@ -36,7 +36,7 @@ class IO
   end
 
   def self.binread(path)
-    `return executeIOAction(function(){return __fs__.readFileSync(#{path}).toString('utf-8')})`
+    `return executeIOAction(function(){return __fs__.readFileSync(#{path}).toString('binary')})`
   end
 end
 

--- a/test/nodejs/test_io.rb
+++ b/test/nodejs/test_io.rb
@@ -15,10 +15,4 @@ class TestNodejsIO < Test::Unit::TestCase
       IO.binread('tmp/nonexistent')
     end
   end
-
-  def test_binread_encoding
-    File.write('tmp/foo', 'Le français c\'est compliqué :)\n')
-    assert_equal("Le fran\xC3\xA7ais c'est compliqu\xC3\xA9 :)\\n", IO.binread('tmp/foo'))
-    assert_equal("Le français c'est compliqué :)\\n", IO.binread('tmp/foo'))
-  end
 end


### PR DESCRIPTION
Reverts opal/opal#1824

@elia Or maybe force push HEAD~1 to the master? That's a bad idea if somebody is using Opal directly from the master branch, so I think reverting is better.