### PR TITLE
fix corelib/string

### DIFF
--- a/opal/corelib/string.rb
+++ b/opal/corelib/string.rb
@@ -280,8 +280,8 @@ class String < `String`
     return self if `width <= self.length`
 
     %x{
-      var ljustified = #{ljust ((width + @length) / 2).ceil, padstr},
-          rjustified = #{rjust ((width + @length) / 2).floor, padstr};
+      var ljustified = #{ljust ((width + `self.length`) / 2).ceil, padstr},
+          rjustified = #{rjust ((width + `self.length`) / 2).floor, padstr};
 
       return self.$$cast(rjustified + ljustified.slice(self.length));
     }


### PR DESCRIPTION
with @length generated code tries to assign nil to read only property length, `self.length`works correct