### PR TITLE
Throw a NotImplementedError from the String#[]= method.

### DIFF
--- a/opal/corelib/unsupported.rb
+++ b/opal/corelib/unsupported.rb
@@ -102,6 +102,10 @@ class String
   def prepend(*)
     raise NotImplementedError, `ERROR` % 'prepend'
   end
+
+  def []=(*)
+    raise NotImplementedError, `ERROR` % '[]='
+  end
 end
 
 module Kernel


### PR DESCRIPTION
Closes https://github.com/opal/opal/issues/1805
It may potentially break some tests, so I'd like to get results from the travis.