### PR TITLE
source map line number 0 is illegal and fails webpack source map veri…

### DIFF
--- a/lib/opal/source_map.rb
+++ b/lib/opal/source_map.rb
@@ -19,7 +19,7 @@ module Opal
 
         mappings = @fragments.map do |fragment|
           mapping = nil
-          source_line   = fragment.line
+          source_line   = (fragment.line && fragment.line > 0) ? fragment.line : 1
           source_column = fragment.column
           source_code   = fragment.code
 

--- a/lib/opal/source_map.rb
+++ b/lib/opal/source_map.rb
@@ -19,7 +19,10 @@ module Opal
 
         mappings = @fragments.map do |fragment|
           mapping = nil
-          source_line   = (fragment.line && fragment.line > 0) ? fragment.line : 1
+          source_line   = fragment.line
+          # source map validators enforce line numbers starting with 1
+          source_line   = 1 if source_line.nil? || source_line.zero?
+
           source_column = fragment.column
           source_code   = fragment.code
 
@@ -49,7 +52,8 @@ module Opal
 
         # Ensure mappings isn't empty: https://github.com/maccman/sourcemap/issues/11
         unless mappings.any?
-          zero_offset = ::SourceMap::Offset.new(0, 0)
+          # source map validators enforce line numbers starting with 1
+          zero_offset = ::SourceMap::Offset.new(1, 0)
           mappings = [::SourceMap::Mapping.new(source_file, zero_offset, zero_offset)]
         end
 


### PR DESCRIPTION
opal sometimes creates source maps with indices that point to line 0 of the original source.
spec says, lines count from 1, so 0 line is illegal and fails webpack source map verification.
fragments seem to have no line number if they don't belong to a sexp.
Thats ok, so if line is nil or 0, this just puts a 1 instead as fix.
So all generated line indices are legal, webpack is happy.