### PR TITLE
const_set before inherited

### DIFF
--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -502,16 +502,16 @@
     if (bridged) {
       Opal.bridge(bridged);
       klass = bridged;
+      Opal.const_set(scope, name, klass);
     } else {
       // Create the class object (instance of Class)
       klass = Opal.allocate_class(name, superclass, constructor);
+      Opal.const_set(scope, name, klass);
       // Call .inherited() hook with new class on the superclass
       if (superclass.$inherited) {
         superclass.$inherited(klass);
       }
     }
-
-    Opal.const_set(scope, name, klass);
 
     return klass;
 

--- a/spec/opal/core/class/inherited.rb
+++ b/spec/opal/core/class/inherited.rb
@@ -1,0 +1,18 @@
+module ModuleInheritedTestModule
+  class A
+    def self.inherited(subclass)
+      $ScratchPad << subclass.name
+    end
+  end
+end
+
+describe 'Class#inherited' do
+  it 'gets called after setting a base scope of the subclass' do
+    $ScratchPad = []
+    module ModuleInheritedTestModule
+      class B < A
+      end
+    end
+    $ScratchPad.should == ['ModuleInheritedTestModule::B']
+  end
+end


### PR DESCRIPTION
set const before calling inherited otherwise class.name leads to incorrect results and method_missing depending things misbehave, get called in wrong context