### PR TITLE
guard ancestors

### DIFF
--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -1177,6 +1177,8 @@
 
   // The Array of ancestors for a given module/class
   Opal.ancestors = function(module) {
+    if (!module) { return []; }
+
     if (module.$$ancestors_cache_version === Opal.const_cache_version) {
       return module.$$ancestors;
     }

--- a/spec/opal/core/runtime/is_a_spec.rb
+++ b/spec/opal/core/runtime/is_a_spec.rb
@@ -31,5 +31,9 @@ describe 'Opal.is_a' do
       `!!#{Integer}.$$is_number_class`.should == true
       `!!#{Float}.$$is_number_class`.should == true
     end
+
+    it 'works for non-Opal objects' do
+      `Opal.is_a({}, Opal.Array)`.should == false
+    end
   end
 end


### PR DESCRIPTION
otherwise `Opal.is_a({}, Opal.Array)` will fail
this was previously automatically guarded by a `while (module) {`