### PR TITLE
Switch to mini_racer to support Object.setPrototypeOf in the repl mode.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'tilt', tilt_version if tilt_version
 gem 'sprockets', sprockets_version if sprockets_version
 
 group :repl do
-  gem 'therubyracer', platform: :mri, require: false
+  gem 'mini_racer', platform: :mri, require: false
   gem 'therubyrhino', platform: :jruby, require: false
 end
 

--- a/exe/opal-repl
+++ b/exe/opal-repl
@@ -14,20 +14,12 @@ module Opal
       return if @v8
 
       begin
-        require 'v8'
+        require 'mini_racer'
       rescue LoadError
-        abort 'opal-repl depends on therubyracer gem, which is not currently installed'
+        abort 'opal-repl depends on mini_racer gem, which is not currently installed'
       end
 
-      # Patch V8::Object#respond_to? to avoid MRI warning
-      V8::Object.class_eval do
-        def respond_to?(method, private = false)
-          super or self[method] != nil
-        end
-      end
-
-      @v8 = V8::Context.new
-      @v8['console'] = self
+      @v8 = MiniRacer::Context.new
       @v8.eval Opal::Builder.new.build('opal').to_s
 
       if filename


### PR DESCRIPTION
rubyracer uses a very old version of V8 - https://github.com/cowboyd/therubyracer/blob/master/therubyracer.gemspec#L20 - which doesn't have `Object.setPrototypeOf`