### PR TITLE
Fixed Kernel#public_methods to return instance methods if argument is false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ Whitespace conventions:
 - Fixed `pattern` argument handling for `Enumerable#grep` and `Enumerable#grep_v`. (#1757)
 - Raise `ArgumentError` instead of `TypeError` from `Numeric#step` when step is not a number. (#1757)
 - At run-time `LoadError` wasn't being raised even with `Opal.config.missing_require_severity;` set to `'error'`.
+- Fixed `Kernel#public_methods` to return instance methods if the argument is set to false.
 
 
 ## [0.11.0] - 2017-12-08

--- a/opal/corelib/kernel.rb
+++ b/opal/corelib/kernel.rb
@@ -52,7 +52,15 @@ module Kernel
     }
   end
 
-  alias public_methods methods
+  def public_methods(all = true)
+    %x{
+      if (#{Opal.truthy?(all)}) {
+        return Opal.methods(self);
+      } else {
+        return Opal.receiver_methods(self);
+      }
+    }
+  end
 
   def Array(object)
     %x{

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -763,8 +763,9 @@
   }
 
   Opal.receiver_methods = function(obj) {
-    var singleton_methods = Opal.own_instance_methods(Opal.get_singleton_class(obj));
-    var instance_methods = Opal.own_instance_methods(obj.$$class);
+    var mod = Opal.get_singleton_class(obj);
+    var singleton_methods = Opal.own_instance_methods(mod);
+    var instance_methods = Opal.own_instance_methods(mod.$$super);
     return singleton_methods.concat(instance_methods);
   }
 

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -762,6 +762,12 @@
     return Opal.own_instance_methods(Opal.get_singleton_class(obj));
   }
 
+  Opal.receiver_methods = function(obj) {
+    var singleton_methods = Opal.own_instance_methods(Opal.get_singleton_class(obj));
+    var instance_methods = Opal.own_instance_methods(obj.$$class);
+    return singleton_methods.concat(instance_methods);
+  }
+
   // Returns an object containing all pairs of names/values
   // for all class variables defined in provided +module+
   // and its ancestors.

--- a/spec/filters/bugs/kernel.rb
+++ b/spec/filters/bugs/kernel.rb
@@ -50,7 +50,6 @@ opal_filter "Kernel" do
   fails "Kernel#public_method returns a method object for a valid method"
   fails "Kernel#public_method returns a method object for a valid singleton method"
   fails "Kernel#public_method returns a method object if we repond_to_missing? method"
-  fails "Kernel#public_methods returns a list of the names of publicly accessible methods in the object"
   fails "Kernel#public_methods when passed false returns a list of public methods in without its ancestors"
   fails "Kernel#public_methods when passed nil returns a list of public methods in without its ancestors"
   fails "Kernel#public_methods returns a list of names without protected accessible methods in the object"

--- a/spec/opal/core/kernel/public_methods_spec.rb
+++ b/spec/opal/core/kernel/public_methods_spec.rb
@@ -1,0 +1,25 @@
+module PublicMethodsSpecs
+  class Parent
+    def parent_method
+    end
+  end
+
+  class Child < Parent
+    def child_method
+    end
+  end
+end
+
+describe "Kernel#public_methods" do
+  it "lists methods available on an object" do
+    child = PublicMethodsSpecs::Child.new
+    child.public_methods.include?("parent_method").should == true
+    child.public_methods.include?("child_method").should == true
+  end
+
+  it "lists only those methods in the receiver if false is passed" do
+    child = PublicMethodsSpecs::Child.new
+    def child.singular_method; 1123; end
+    child.public_methods(false).sort.should == ["child_method", "singular_method"]
+  end
+end


### PR DESCRIPTION
`Kernel#public_methods` is a alias of `Kernel#methods` in opal (#909). But their behavior is not same in MRI. This PR fixed it.

Here is an example.
``` ruby
class Child
  def foo
    "foo"
  end
end

c = Child.new

def c.bar
  "bar"
end


p c.public_methods(false) #=> [:bar, :foo]
p c.methods(false)        #=> [:foo]
```

`methods(false)` returns only singular methods, but`public_methods(false)` returns singular methods and instance methods.

### ruby-doc
- [Object#public_methods](https://ruby-doc.org/core-2.5.1/Object.html#method-i-public_methods)
- [Object#methods](https://ruby-doc.org/core-2.5.1/Object.html#method-i-methods)