### PR TITLE
fix String.encoding for "use strict"

### DIFF
--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -54,6 +54,9 @@
   // The Opal object that is exposed globally
   var Opal = this.Opal = {};
 
+  // in strict mode eval doesn't introduce a new variable into the outer context.
+  Opal.in_strict_mode = (eval("var __temp = null"), (typeof __temp === "undefined"));
+
   // This is a useful reference to global object inside ruby files
   Opal.global = global_object;
   global_object.Opal = Opal;

--- a/opal/corelib/string/encoding.rb
+++ b/opal/corelib/string/encoding.rb
@@ -163,7 +163,7 @@ end
 
 class String
   attr_reader :encoding
-  `Opal.defineProperty(String.prototype, 'encoding', #{Encoding::UTF_16LE})`
+  `Opal.defineProperty(String.prototype, 'encoding', { value: #{Encoding::UTF_16LE}})`
 
   def bytes
     each_byte.to_a
@@ -187,14 +187,15 @@ class String
 
   def force_encoding(encoding)
     %x{
-      if (encoding === self.encoding) { return self; }
+      if (encoding === self.encoding.value) { return self; }
 
       encoding = #{Opal.coerce_to!(encoding, String, :to_s)};
       encoding = #{Encoding.find(encoding)};
 
-      if (encoding === self.encoding) { return self; }
+      if (encoding === self.encoding.value) { return self; }
 
-      self.encoding = encoding;
+      self.encoding.value = encoding;
+
       return self;
     }
   end

--- a/opal/corelib/string/encoding.rb
+++ b/opal/corelib/string/encoding.rb
@@ -162,7 +162,6 @@ Encoding.register 'ASCII-8BIT', aliases: ['BINARY', 'US-ASCII', 'ASCII'], ascii:
 end
 
 class String
-  attr_reader :encoding
   `Opal.defineProperty(String.prototype, 'encoding', { value: #{Encoding::UTF_16LE}})`
 
   def bytes
@@ -170,19 +169,23 @@ class String
   end
 
   def bytesize
-    @encoding.bytesize(self)
+    encoding.bytesize(self)
   end
 
   def each_byte(&block)
     return enum_for :each_byte unless block_given?
 
-    @encoding.each_byte(self, &block)
+    encoding.each_byte(self, &block)
 
     self
   end
 
   def encode(encoding)
     dup.force_encoding(encoding)
+  end
+
+  def encoding
+    `self.encoding.value`
   end
 
   def force_encoding(encoding)
@@ -201,7 +204,7 @@ class String
   end
 
   def getbyte(idx)
-    @encoding.getbyte(self, idx)
+    encoding.getbyte(self, idx)
   end
 
   # stub

--- a/opal/corelib/string/encoding.rb
+++ b/opal/corelib/string/encoding.rb
@@ -162,7 +162,8 @@ Encoding.register 'ASCII-8BIT', aliases: ['BINARY', 'US-ASCII', 'ASCII'], ascii:
 end
 
 class String
-  `Opal.defineProperty(String.prototype, 'encoding', { value: #{Encoding::UTF_16LE}})`
+  attr_reader :encoding
+  `Opal.defineProperty(String.prototype, 'encoding', #{Encoding::UTF_16LE})`
 
   def bytes
     each_byte.to_a
@@ -184,21 +185,17 @@ class String
     dup.force_encoding(encoding)
   end
 
-  def encoding
-    `self.encoding.value`
-  end
-
   def force_encoding(encoding)
     %x{
-      if (encoding === self.encoding.value) { return self; }
+      if (encoding === self.encoding) { return self; }
 
       encoding = #{Opal.coerce_to!(encoding, String, :to_s)};
       encoding = #{Encoding.find(encoding)};
 
-      if (encoding === self.encoding.value) { return self; }
+      if (encoding === self.encoding) { return self; }
 
       // doesn't work in ES5, primitive properties are read only
-      // self.encoding.value = encoding;
+      // self.encoding = encoding;
       return self;
     }
   end

--- a/opal/corelib/string/encoding.rb
+++ b/opal/corelib/string/encoding.rb
@@ -194,8 +194,11 @@ class String
 
       if (encoding === self.encoding) { return self; }
 
-      // doesn't work in ES5, primitive properties are read only
-      // self.encoding = encoding;
+      if (Opal.in_strict_mode) {
+        console.warn('Changing the String encoding is currently not supported in Javascripts "strict" mode.')
+      } else {
+        self.encoding = encoding;
+      }
       return self;
     }
   end

--- a/opal/corelib/string/encoding.rb
+++ b/opal/corelib/string/encoding.rb
@@ -197,8 +197,8 @@ class String
 
       if (encoding === self.encoding.value) { return self; }
 
-      self.encoding.value = encoding;
-
+      // doesn't work in ES5, primitive properties are read only
+      // self.encoding.value = encoding;
       return self;
     }
   end


### PR DESCRIPTION
ES5/"use strict"; make properties of primitives read only, assigning to encoding fails with a TypeError, assignment to read only property.

This patch works around this restriction by using a simple proxy object for encoding.