### PR TITLE
Backport fixes for method_missing_enabled = false

### DIFF
--- a/opal/corelib/array.rb
+++ b/opal/corelib/array.rb
@@ -871,7 +871,7 @@ class Array < `Array`
     %x{
       if (
         self.$$class === Opal.Array &&
-        self.$allocate.$$pristine &&
+        self.$$class.$allocate.$$pristine &&
         self.$copy_instance_variables.$$pristine &&
         self.$initialize_dup.$$pristine
       ) return self.slice(0);

--- a/opal/corelib/helpers.rb
+++ b/opal/corelib/helpers.rb
@@ -150,12 +150,15 @@ module Opal
   # @param owner_class [Class] the class owning the methods
   # @param method_names [Array<Symbol>] the list of methods names to mark
   # @return [nil]
-  def self.pristine owner_class, *method_names
+  def self.pristine(owner_class, *method_names)
     %x{
-      var method_name;
+      var method_name, method;
       for (var i = method_names.length - 1; i >= 0; i--) {
         method_name = method_names[i];
-        owner_class.$$proto['$'+method_name].$$pristine = true
+        method = owner_class.$$proto['$'+method_name];
+        if (method && !method.$$stub) {
+          method.$$pristine = true;
+        }
       }
     }
     nil


### PR DESCRIPTION
Fixes #1876 

The check on `$allocate` was done on a stub on the instance instead of the class