### PR TITLE
Resolves #1883, use require directly instead of the require_node method

### DIFF
--- a/stdlib/nodejs/dir.rb
+++ b/stdlib/nodejs/dir.rb
@@ -1,6 +1,6 @@
 class Dir
-  @__glob__ = node_require :glob
-  @__fs__ = node_require :fs
+  @__glob__ = `require('glob')`
+  @__fs__ = `require('fs')`
   `var __glob__ = #{@__glob__}`
   `var __fs__ = #{@__fs__}`
 

--- a/stdlib/nodejs/file.rb
+++ b/stdlib/nodejs/file.rb
@@ -50,8 +50,8 @@ class File < IO
   include ::IO::Writable
   include ::IO::Readable
 
-  @__fs__ = node_require :fs
-  @__path__ = node_require :path
+  @__fs__ = `require('fs')`
+  @__path__ = `require('path')`
   `var __fs__ = #{@__fs__}`
   `var __path__ = #{@__path__}`
 
@@ -238,7 +238,7 @@ class File < IO
 end
 
 class File::Stat
-  @__fs__ = node_require :fs
+  @__fs__ = `require('fs')`
   `var __fs__ = #{@__fs__}`
 
   def initialize(path)

--- a/stdlib/nodejs/io.rb
+++ b/stdlib/nodejs/io.rb
@@ -16,7 +16,7 @@
 }
 
 class IO
-  @__fs__ = node_require :fs
+  @__fs__ = `require('fs')`
   `var __fs__ = #{@__fs__}`
 
   attr_reader :eof

--- a/stdlib/nodejs/kernel.rb
+++ b/stdlib/nodejs/kernel.rb
@@ -18,7 +18,7 @@ module Kernel
 
   # @deprecated Please use `require('module')` instead
   def node_require(path)
-    warn '[DEPRECATION] node_require is deprecated.  Please use `require(\'module\')` instead.'
+    warn '[DEPRECATION] node_require is deprecated. Please use `require(\'module\')` instead.'
     `#{NODE_REQUIRE}(#{path.to_str})`
   end
 end

--- a/stdlib/nodejs/kernel.rb
+++ b/stdlib/nodejs/kernel.rb
@@ -16,6 +16,7 @@ module Kernel
     }
   end
 
+  # @deprecated Please use `require('module')` instead
   def node_require(path)
     `#{NODE_REQUIRE}(#{path.to_str})`
   end

--- a/stdlib/nodejs/kernel.rb
+++ b/stdlib/nodejs/kernel.rb
@@ -18,7 +18,7 @@ module Kernel
 
   # @deprecated Please use `require('module')` instead
   def node_require(path)
-    warn '[DEPRECATION] `node_require` is deprecated.  Please use `require(\'module\')` instead.'
+    warn '[DEPRECATION] node_require is deprecated.  Please use `require(\'module\')` instead.'
     `#{NODE_REQUIRE}(#{path.to_str})`
   end
 end

--- a/stdlib/nodejs/kernel.rb
+++ b/stdlib/nodejs/kernel.rb
@@ -18,6 +18,7 @@ module Kernel
 
   # @deprecated Please use `require('module')` instead
   def node_require(path)
+    warn '[DEPRECATION] `node_require` is deprecated.  Please use `require(\'module\')` instead.'
     `#{NODE_REQUIRE}(#{path.to_str})`
   end
 end

--- a/stdlib/nodejs/open-uri.rb
+++ b/stdlib/nodejs/open-uri.rb
@@ -1,5 +1,5 @@
 module OpenURI
-  @__xmlhttprequest__ = node_require :xmlhttprequest
+  @__xmlhttprequest__ = `require('xmlhttprequest')`
   `var __XMLHttpRequest__ = #{@__xmlhttprequest__}.XMLHttpRequest`
 
   def self.request(uri)


### PR DESCRIPTION
Static tools should now be able to resolve dependencies.