### PR TITLE
fix: fix broken sinatra example

### DIFF
--- a/examples/sinatra/Gemfile
+++ b/examples/sinatra/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'opal', :path => '../..'
+gem 'opal-sprockets'
 gem 'puma' # webrick has a bug with safari
 gem 'sinatra'

--- a/examples/sinatra/Gemfile.lock
+++ b/examples/sinatra/Gemfile.lock
@@ -1,16 +1,19 @@
 PATH
   remote: ../..
   specs:
-    opal (0.11.1.dev)
+    opal (0.11.99.dev)
       ast (>= 2.3.0)
-      hike (~> 1.2)
       parser (= 2.5.1.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
-    hike (1.2.3)
+    concurrent-ruby (1.0.5)
+    opal-sprockets (0.4.2.0.11.0.3.1)
+      opal (~> 0.11.0)
+      sprockets (~> 3.1)
+      tilt (>= 1.4)
     parser (2.5.1.0)
       ast (~> 2.4.0)
     puma (3.12.0)
@@ -21,6 +24,9 @@ GEM
       rack (~> 1.4)
       rack-protection (~> 1.4)
       tilt (~> 1.3, >= 1.3.4)
+    sprockets (3.7.2)
+      concurrent-ruby (~> 1.0)
+      rack (> 1, < 3)
     tilt (1.4.1)
 
 PLATFORMS
@@ -28,6 +34,7 @@ PLATFORMS
 
 DEPENDENCIES
   opal!
+  opal-sprockets
   puma
   sinatra
 

--- a/examples/sinatra/config.ru
+++ b/examples/sinatra/config.ru
@@ -1,22 +1,13 @@
-require 'opal'
+require 'opal/sprockets'
 require 'sinatra'
 
-opal = Opal::Server.new {|s|
+opal = Opal::Sprockets::Server.new {|s|
   s.append_path 'app'
   s.main = 'application'
 }
 
 sprockets   = opal.sprockets
 prefix      = '/assets'
-maps_prefix = '/__OPAL_SOURCE_MAPS__'
-maps_app    = Opal::SourceMapServer.new(sprockets, maps_prefix)
-
-# Monkeypatch sourcemap header support into sprockets
-::Opal::Sprockets::SourceMapHeaderPatch.inject!(maps_prefix)
-
-map maps_prefix do
-  run maps_app
-end
 
 map prefix do
   run sprockets


### PR DESCRIPTION
I tried to run an example Sinatra app but I got a following error.

```sh
$ cd ./opal/examples/sinatra
$ bundle install
$ bundle exec rackup config.ru
DEPRECATION WARNING: `require 'opal/server` and `Opal::Server` are deprecated in favor of `require 'opal/sprockets/server'` and `Opal::Sprockets::Server` (now part of the opal-sprockets gem).
! Unable to load application: LoadError: cannot load such file -- opal/sprockets/server
```

I guess that the example code doesn't catch up to the latest version.
This PR fixes this issue (and I think it also fixes #1830).