### PR TITLE
Pass parameters & arity info from method to proc

### DIFF
--- a/opal/corelib/method.rb
+++ b/opal/corelib/method.rb
@@ -43,6 +43,8 @@ class Method
       var proc = self.$call.bind(self);
       proc.$$unbound = #{@method};
       proc.$$is_lambda = true;
+      proc.$$arity = #{@method}.$$arity;
+      proc.$$parameters = #{@method}.$$parameters;
       return proc;
     }
   end

--- a/spec/filters/bugs/method.rb
+++ b/spec/filters/bugs/method.rb
@@ -45,7 +45,6 @@ opal_filter "Method" do
   fails "Method#super_method returns nil when the parent's method is removed"
   fails "Method#super_method returns nil when there's no super method in the parent"
   fails "Method#super_method returns the method that would be called by super in the method"
-  fails "Method#to_proc returns a Proc object with the correct arity"
   fails "Method#to_proc returns a proc that can be used by define_method"
   fails "Method#to_proc returns a proc that can receive a block"
   fails "Method#to_proc returns a proc whose binding has the same receiver as the method" # NoMethodError: undefined method `receiver' for nil


### PR DESCRIPTION
Fixes https://github.com/opal/opal/issues/762

After this:

```
$ bin/opal -Ae 'def foo(a,b,*c);end; p method(:foo).to_proc.parameters'
[["req", "a"], ["req", "b"], ["rest", "c"]]
```