### PR TITLE
Bump parser to 2.5.3 for Ruby 2.3.8, 2.4.5 and 2.5.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,12 +63,6 @@ matrix:
     - rvm: 2.3.7
       env: RUN=rspec
 
-    - rvm: 2.2.10
-      env: RUN=rspec TILT_VERSION=2.0.1 SPROCKETS_VERSION='~> 3.7'
-
-    - rvm: 2.1.10
-      env: RUN=rspec RACK_VERSION='< 2.0'
-
     - rvm: jruby-9.2.0.0
       env: RUN=rspec
 

--- a/Gemfile
+++ b/Gemfile
@@ -51,5 +51,5 @@ group :doc do
 end
 
 platforms :ruby, :mswin, :mswin64, :mingw, :x64_mingw do
-  gem 'c_lexer', '2.5.1.0.pre2' unless RUBY_ENGINE == 'truffleruby'
+  gem 'c_lexer', '2.5.3.0' unless RUBY_ENGINE == 'truffleruby'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -51,5 +51,5 @@ group :doc do
 end
 
 platforms :ruby, :mswin, :mswin64, :mingw, :x64_mingw do
-  gem 'c_lexer', '2.5.3.0' unless RUBY_ENGINE == 'truffleruby'
+  gem 'c_lexer', '2.5.3.0.0' unless RUBY_ENGINE == 'truffleruby'
 end

--- a/examples/rack/Gemfile.lock
+++ b/examples/rack/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     opal (0.11.1.dev)
       ast (>= 2.3.0)
       hike (~> 1.2)
-      parser (= 2.5.3.0)
+      parser (= 2.5.1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/examples/rack/Gemfile.lock
+++ b/examples/rack/Gemfile.lock
@@ -4,14 +4,14 @@ PATH
     opal (0.11.1.dev)
       ast (>= 2.3.0)
       hike (~> 1.2)
-      parser (= 2.5.3.0)
+      parser (= 2.5.1.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
     hike (1.2.3)
-    parser (2.5.3.0)
+    parser (2.5.1.0)
       ast (~> 2.4.0)
     rack (2.0.1)
 

--- a/examples/rack/Gemfile.lock
+++ b/examples/rack/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     opal (0.11.1.dev)
       ast (>= 2.3.0)
       hike (~> 1.2)
-      parser (= 2.5.1.0)
+      parser (= 2.5.3.0)
 
 GEM
   remote: https://rubygems.org/

--- a/examples/rack/Gemfile.lock
+++ b/examples/rack/Gemfile.lock
@@ -4,14 +4,14 @@ PATH
     opal (0.11.1.dev)
       ast (>= 2.3.0)
       hike (~> 1.2)
-      parser (= 2.5.1.0)
+      parser (= 2.5.3.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
     hike (1.2.3)
-    parser (2.5.1.0)
+    parser (2.5.3.0)
       ast (~> 2.4.0)
     rack (2.0.1)
 

--- a/examples/sinatra/Gemfile.lock
+++ b/examples/sinatra/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     opal (0.11.99.dev)
       ast (>= 2.3.0)
-      parser (= 2.5.1.0)
+      parser (= 2.5.3.0)
 
 GEM
   remote: https://rubygems.org/
@@ -14,7 +14,7 @@ GEM
       opal (~> 0.11.0)
       sprockets (~> 3.1)
       tilt (>= 1.4)
-    parser (2.5.1.0)
+    parser (2.5.3.0)
       ast (~> 2.4.0)
     puma (3.12.0)
     rack (1.5.2)

--- a/examples/sinatra/Gemfile.lock
+++ b/examples/sinatra/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
       opal (~> 0.11.0)
       sprockets (~> 3.1)
       tilt (>= 1.4)
-    parser (2.5.3.0)
+    parser (2.5.1.0)
       ast (~> 2.4.0)
     puma (3.12.0)
     rack (1.5.2)

--- a/opal.gemspec
+++ b/opal.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.0.0'
 
   spec.add_dependency 'ast', '>= 2.3.0'
-  spec.add_dependency 'parser', '= 2.5.1.0'
+  spec.add_dependency 'parser', '= 2.5.3.0'
 
   spec.add_development_dependency 'sourcemap', '~> 0.1.0'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
Parser has added support for Ruby 2.3.7, Ruby 2.4.5 and Ruby 2.5.3. Currently the version of Parser that's required by Opal support only up to Ruby 2.4.4, this should take care of that.

See: https://github.com/whitequark/parser/pull/528

Also do note that the latest Opal 0.11.4 still has `spec.add_dependency 'parser', '= 2.3.3.1'` even though the bump to a 2.5.x version was made 8 months ago, and 0.11.4 was released less than a month ago.