### PR TITLE
Use arity for block length if available

### DIFF
--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -1430,11 +1430,13 @@
     var has_mlhs = block.$$has_top_level_mlhs_arg,
         has_trailing_comma = block.$$has_trailing_comma_in_args;
 
-    if (block.length > 1 || ((has_mlhs || has_trailing_comma) && block.length === 1)) {
+    var block_length = (block.$$arity ? Math.abs(block.$$arity) : block.length)
+
+    if (block_length > 1 || ((has_mlhs || has_trailing_comma) && block_length === 1)) {
       arg = Opal.to_ary(arg);
     }
 
-    if ((block.length > 1 || (has_trailing_comma && block.length === 1)) && arg.$$is_array) {
+    if ((block_length > 1 || (has_trailing_comma && block_length === 1)) && arg.$$is_array) {
       return block.apply(null, arg);
     }
     else {

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -1430,13 +1430,13 @@
     var has_mlhs = block.$$has_top_level_mlhs_arg,
         has_trailing_comma = block.$$has_trailing_comma_in_args;
 
-    var block_length = (block.$$arity ? Math.abs(block.$$arity) : block.length)
+    var required_arg_count = block.$$arity ? (block.$$arity < 0 ? -block.$$arity + 1 : block.$$arity) : block.length
 
-    if (block_length > 1 || ((has_mlhs || has_trailing_comma) && block_length === 1)) {
+    if (required_arg_count > 1 || ((has_mlhs || has_trailing_comma) && required_arg_count === 1)) {
       arg = Opal.to_ary(arg);
     }
 
-    if ((block_length > 1 || (has_trailing_comma && block_length === 1)) && arg.$$is_array) {
+    if ((required_arg_count > 1 || (has_trailing_comma && required_arg_count === 1)) && arg.$$is_array) {
       return block.apply(null, arg);
     }
     else {


### PR DESCRIPTION
This pull request aims to solve issue #1907. By checking to see if `block.$$arity` is available, we ensure that any block parameters containing a splat operator will have the correct length. JavaScript functions will continue to use `block.length`.