### PR TITLE
Allocate a class object for bridged classes

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle update
+
+git submodule update --init

--- a/lib/opal/nodes/base.rb
+++ b/lib/opal/nodes/base.rb
@@ -169,7 +169,7 @@ module Opal
         cvar_scope = scope
         nesting_level = 0
 
-        while cvar_scope && !(cvar_scope.class_scope?)
+        while cvar_scope && !cvar_scope.class_scope?
           # Needs only `class << self`, `module`, and `class`
           # can increase nesting, but `class` & `module` are
           # covered by `class_scope?`.

--- a/lib/opal/nodes/class.rb
+++ b/lib/opal/nodes/class.rb
@@ -19,7 +19,6 @@ module Opal
 
         in_scope do
           scope.name = name
-          add_temp "#{scope.proto} = self.prototype"
           add_temp '$nesting = [self].concat($parent_nesting)'
 
           body_code = self.body_code

--- a/lib/opal/nodes/class.rb
+++ b/lib/opal/nodes/class.rb
@@ -14,8 +14,7 @@ module Opal
         helper :klass
 
         push '(function($base, $super, $parent_nesting) {'
-        line "  function $#{name}(){};"
-        line "  var self = $#{name} = $klass($base, $super, '#{name}', $#{name});"
+        line "  var self = $klass($base, $super, '#{name}');"
 
         in_scope do
           scope.name = name

--- a/lib/opal/nodes/module.rb
+++ b/lib/opal/nodes/module.rb
@@ -14,8 +14,7 @@ module Opal
         helper :module
 
         push '(function($base, $parent_nesting) {'
-        line "  function $#{name}() {};"
-        line "  var self = $#{name} = $module($base, '#{name}', $#{name});"
+        line "  var self = $module($base, '#{name}');"
 
         in_scope do
           scope.name = name

--- a/lib/opal/nodes/module.rb
+++ b/lib/opal/nodes/module.rb
@@ -19,7 +19,6 @@ module Opal
 
         in_scope do
           scope.name = name
-          add_temp "#{scope.proto} = self.prototype"
           add_temp '$nesting = [self].concat($parent_nesting)'
 
           body_code = stmt(body || s(:nil))

--- a/lib/opal/nodes/scope.rb
+++ b/lib/opal/nodes/scope.rb
@@ -108,13 +108,6 @@ module Opal
         !@defs && @type == :def && @parent && @parent.class?
       end
 
-      # Inside a class or module scope, the javascript variable name returned
-      # by this function points to the classes' prototype. This is the target
-      # to where methods are actually added inside a class body.
-      def proto
-        'def'
-      end
-
       ##
       # Vars to use inside each scope
       def to_vars
@@ -135,8 +128,7 @@ module Opal
         str += "#{indent}#{gv.join indent}" unless gvars.empty?
 
         if class? && !@proto_ivars.empty?
-          # raise "FIXME to_vars"
-          pvars = @proto_ivars.map { |i| "#{proto}#{i}" }.join(' = ')
+          pvars = @proto_ivars.map { |i| "self.prototype#{i}" }.join(' = ')
           result = "#{str}\n#{indent}#{pvars} = nil;"
         else
           result = str

--- a/lib/opal/nodes/scope.rb
+++ b/lib/opal/nodes/scope.rb
@@ -128,7 +128,7 @@ module Opal
         str += "#{indent}#{gv.join indent}" unless gvars.empty?
 
         if class? && !@proto_ivars.empty?
-          pvars = @proto_ivars.map { |i| "self.prototype#{i}" }.join(' = ')
+          pvars = @proto_ivars.map { |i| "self.$$prototype#{i}" }.join(' = ')
           result = "#{str}\n#{indent}#{pvars} = nil;"
         else
           result = str

--- a/lib/opal/nodes/singleton_class.rb
+++ b/lib/opal/nodes/singleton_class.rb
@@ -13,7 +13,6 @@ module Opal
         push '(function(self, $parent_nesting) {'
 
         in_scope do
-          add_temp 'def = self.prototype'
           add_temp '$nesting = [self].concat($parent_nesting)'
 
           body_stmt = stmt(compiler.returns(body))

--- a/lib/opal/nodes/super.rb
+++ b/lib/opal/nodes/super.rb
@@ -73,7 +73,7 @@ module Opal
 
       def super_method_invocation
         if def_scope.defs
-          "Opal.find_super_dispatcher(self, '#{method_id}', #{def_scope_identity}, #{defined_check_param}, self.$$class.prototype)"
+          "Opal.find_super_dispatcher(self, '#{method_id}', #{def_scope_identity}, #{defined_check_param}, self.$$class.$$prototype)"
         else
           "Opal.find_super_dispatcher(self, '#{method_id}', #{def_scope_identity}, #{defined_check_param})"
         end

--- a/lib/opal/nodes/super.rb
+++ b/lib/opal/nodes/super.rb
@@ -73,8 +73,7 @@ module Opal
 
       def super_method_invocation
         if def_scope.defs
-          class_name = def_scope.parent.name ? "$#{def_scope.parent.name}" : 'self.$$class.prototype'
-          "Opal.find_super_dispatcher(self, '#{method_id}', #{def_scope_identity}, #{defined_check_param}, #{class_name})"
+          "Opal.find_super_dispatcher(self, '#{method_id}', #{def_scope_identity}, #{defined_check_param}, self.$$class.prototype)"
         else
           "Opal.find_super_dispatcher(self, '#{method_id}', #{def_scope_identity}, #{defined_check_param})"
         end

--- a/opal/corelib/array.rb
+++ b/opal/corelib/array.rb
@@ -5,7 +5,7 @@ class Array < `Array`
   include Enumerable
 
   # Mark all javascript arrays as being valid ruby arrays
-  `Opal.defineProperty(Array.prototype, '$$is_array', true)`
+  `Opal.defineProperty(self.$$prototype, '$$is_array', true)`
 
   %x{
     function toArraySubclass(obj, klass) {
@@ -2334,7 +2334,7 @@ class Array < `Array`
 
   def self.inherited(klass)
     %x{
-      klass.prototype.$to_a = function() {
+      klass.$$prototype.$to_a = function() {
         return this.slice(0, this.length);
       }
     }

--- a/opal/corelib/array.rb
+++ b/opal/corelib/array.rb
@@ -237,9 +237,9 @@ class Array < `Array`
           }
         }
 
-        if (array.constructor !== Array)
+        if (array.$$constructor !== Array)
           array = #{`array`.to_a};
-        if (other.constructor !== Array)
+        if (other.$$constructor !== Array)
           other = #{`other`.to_a};
 
         if (array.length !== other.length) {

--- a/opal/corelib/boolean.rb
+++ b/opal/corelib/boolean.rb
@@ -1,6 +1,6 @@
 class Boolean < `Boolean`
-  `Opal.defineProperty(Boolean.prototype, '$$is_boolean', true)`
-  `Opal.defineProperty(Boolean.prototype, '$$meta', #{self})`
+  `Opal.defineProperty(self.$$prototype, '$$is_boolean', true)`
+  `Opal.defineProperty(self.$$prototype, '$$meta', #{self})`
 
   class << self
     def allocate

--- a/opal/corelib/class.rb
+++ b/opal/corelib/class.rb
@@ -7,7 +7,7 @@ class Class
         throw Opal.TypeError.$new("superclass must be a Class");
       }
 
-      var klass = Opal.allocate_class(nil, superclass, function(){});
+      var klass = Opal.allocate_class(nil, superclass);
       superclass.$inherited(klass);
       #{`klass`.class_eval(&block) if block_given?}
       return klass;

--- a/opal/corelib/class.rb
+++ b/opal/corelib/class.rb
@@ -16,7 +16,7 @@ class Class
 
   def allocate
     %x{
-      var obj = new self();
+      var obj = new self.$$constructor();
       obj.$$id = Opal.uid();
       return obj;
     }

--- a/opal/corelib/enumerator.rb
+++ b/opal/corelib/enumerator.rb
@@ -3,7 +3,7 @@ require 'corelib/enumerable'
 class Enumerator
   include Enumerable
 
-  `self.prototype.$$is_enumerator = true`
+  `self.$$prototype.$$is_enumerator = true`
 
   def self.for(object, method = :each, *args, &block)
     %x{

--- a/opal/corelib/enumerator.rb
+++ b/opal/corelib/enumerator.rb
@@ -3,7 +3,7 @@ require 'corelib/enumerable'
 class Enumerator
   include Enumerable
 
-  `def.$$is_enumerator = true`
+  `self.prototype.$$is_enumerator = true`
 
   def self.for(object, method = :each, *args, &block)
     %x{

--- a/opal/corelib/error.rb
+++ b/opal/corelib/error.rb
@@ -5,7 +5,7 @@ class Exception < `Error`
   def self.new(*args)
     %x{
       var message   = (args.length > 0) ? args[0] : nil;
-      var error     = new self(message);
+      var error     = new self.$$constructor(message);
       error.name    = self.$$name;
       error.message = message;
       Opal.send(error, error.$initialize, args);

--- a/opal/corelib/hash.rb
+++ b/opal/corelib/hash.rb
@@ -12,7 +12,7 @@ class Hash
   include Enumerable
 
   # Mark all hash instances as valid hashes (used to check keyword args, etc)
-  `def.$$is_hash = true`
+  `self.prototype.$$is_hash = true`
 
   def self.[](*argv)
     %x{

--- a/opal/corelib/hash.rb
+++ b/opal/corelib/hash.rb
@@ -12,7 +12,7 @@ class Hash
   include Enumerable
 
   # Mark all hash instances as valid hashes (used to check keyword args, etc)
-  `self.prototype.$$is_hash = true`
+  `self.$$prototype.$$is_hash = true`
 
   def self.[](*argv)
     %x{

--- a/opal/corelib/hash.rb
+++ b/opal/corelib/hash.rb
@@ -65,7 +65,7 @@ class Hash
 
   def self.allocate
     %x{
-      var hash = new self();
+      var hash = new self.$$constructor();
 
       Opal.hash_init(hash);
 

--- a/opal/corelib/helpers.rb
+++ b/opal/corelib/helpers.rb
@@ -155,7 +155,7 @@ module Opal
       var method_name, method;
       for (var i = method_names.length - 1; i >= 0; i--) {
         method_name = method_names[i];
-        method = owner_class.prototype['$'+method_name];
+        method = owner_class.$$prototype['$'+method_name];
 
         if (method && !method.$$stub) {
           method.$$pristine = true;

--- a/opal/corelib/kernel.rb
+++ b/opal/corelib/kernel.rb
@@ -118,19 +118,19 @@ module Kernel
       if (other.hasOwnProperty('$$meta')) {
         var other_singleton_class = Opal.get_singleton_class(other);
         var self_singleton_class = Opal.get_singleton_class(self);
-        names = Object.getOwnPropertyNames(other_singleton_class.prototype);
+        names = Object.getOwnPropertyNames(other_singleton_class.$$prototype);
 
         for (i = 0, length = names.length; i < length; i++) {
           name = names[i];
           if (Opal.is_method(name)) {
-            self_singleton_class.prototype[name] = other_singleton_class.prototype[name];
+            self_singleton_class.$$prototype[name] = other_singleton_class.$$prototype[name];
           }
         }
 
         self_singleton_class.$$const = Object.assign({}, other_singleton_class.$$const);
         Object.setPrototypeOf(
-          self_singleton_class.prototype,
-          Object.getPrototypeOf(other_singleton_class.prototype)
+          self_singleton_class.$$prototype,
+          Object.getPrototypeOf(other_singleton_class.$$prototype)
         );
       }
 

--- a/opal/corelib/module.rb
+++ b/opal/corelib/module.rb
@@ -3,7 +3,7 @@ class Module
     %x{
       var module = Opal.allocate_module(nil, function(){});
       // Link the prototype of Module subclasses
-      if (self !== Opal.Module) Object.setPrototypeOf(module, self.prototype);
+      if (self !== Opal.Module) Object.setPrototypeOf(module, self.$$prototype);
       return module;
     }
   end
@@ -111,7 +111,7 @@ class Module
 
   def attr_reader(*names)
     %x{
-      var proto = self.prototype;
+      var proto = self.$$prototype;
 
       for (var i = names.length - 1; i >= 0; i--) {
         var name = names[i],
@@ -146,7 +146,7 @@ class Module
 
   def attr_writer(*names)
     %x{
-      var proto = self.prototype;
+      var proto = self.$$prototype;
 
       for (var i = names.length - 1; i >= 0; i--) {
         var name = names[i],
@@ -431,7 +431,7 @@ class Module
 
   def instance_method(name)
     %x{
-      var meth = self.prototype['$' + name];
+      var meth = self.$$prototype['$' + name];
 
       if (!meth || meth.$$stub) {
         #{raise NameError.new("undefined method `#{name}' for class `#{self.name}'", name)};
@@ -523,7 +523,7 @@ class Module
 
   def method_defined?(method)
     %x{
-      var body = self.prototype['$' + method];
+      var body = self.$$prototype['$' + method];
       return (!!body) && !body.$$stub;
     }
   end
@@ -537,7 +537,7 @@ class Module
         for (var i = 0, length = methods.length; i < length; i++) {
           var meth = methods[i],
               id   = '$' + meth,
-              func = self.prototype[id];
+              func = self.$$prototype[id];
 
           Opal.defs(self, id, func);
         }

--- a/opal/corelib/nil.rb
+++ b/opal/corelib/nil.rb
@@ -1,5 +1,5 @@
 class NilClass
-  `self.prototype.$$meta = #{self}`
+  `self.$$prototype.$$meta = #{self}`
 
   class << self
     def allocate

--- a/opal/corelib/nil.rb
+++ b/opal/corelib/nil.rb
@@ -1,5 +1,5 @@
 class NilClass
-  `def.$$meta = #{self}`
+  `self.prototype.$$meta = #{self}`
 
   class << self
     def allocate

--- a/opal/corelib/number.rb
+++ b/opal/corelib/number.rb
@@ -2,7 +2,7 @@ require 'corelib/numeric'
 
 class Number < Numeric
   Opal.bridge(`Number`, self)
-  `Opal.defineProperty(Number.prototype, '$$is_number', true)`
+  `Opal.defineProperty(self.$$prototype, '$$is_number', true)`
   `self.$$is_number_class = true`
 
   class << self

--- a/opal/corelib/proc.rb
+++ b/opal/corelib/proc.rb
@@ -1,6 +1,6 @@
 class Proc < `Function`
-  `Opal.defineProperty(Function.prototype, '$$is_proc', true)`
-  `Opal.defineProperty(Function.prototype, '$$is_lambda', false)`
+  `Opal.defineProperty(self.$$prototype, '$$is_proc', true)`
+  `Opal.defineProperty(self.$$prototype, '$$is_lambda', false)`
 
   def self.new(&block)
     unless block

--- a/opal/corelib/range.rb
+++ b/opal/corelib/range.rb
@@ -3,7 +3,7 @@ require 'corelib/enumerable'
 class Range
   include Enumerable
 
-  `self.prototype.$$is_range = true`
+  `self.$$prototype.$$is_range = true`
 
   attr_reader :begin, :end
 

--- a/opal/corelib/range.rb
+++ b/opal/corelib/range.rb
@@ -3,7 +3,7 @@ require 'corelib/enumerable'
 class Range
   include Enumerable
 
-  `def.$$is_range = true`
+  `self.prototype.$$is_range = true`
 
   attr_reader :begin, :end
 

--- a/opal/corelib/regexp.rb
+++ b/opal/corelib/regexp.rb
@@ -5,7 +5,7 @@ class Regexp < `RegExp`
   EXTENDED = 2
   MULTILINE = 4
 
-  `Opal.defineProperty(RegExp.prototype, '$$is_regexp', true)`
+  `Opal.defineProperty(self.$$prototype, '$$is_regexp', true)`
 
   class << self
     def allocate

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -406,7 +406,7 @@
       // calling original JS constructors
       constructor = function() {
         var args = $slice.call(arguments),
-            self = new ($bind.apply(superclass, [null].concat(args)))();
+            self = new ($bind.apply(superclass.$$constructor, [null].concat(args)))();
 
         // and replacing a __proto__ manually
         $setPrototype(self, klass.$$prototype);
@@ -420,6 +420,7 @@
       $defineProperty(constructor, 'displayName', '::'+name);
 
     $defineProperty(klass, '$$name', name);
+    $defineProperty(klass, '$$constructor', constructor);
     $defineProperty(klass, '$$prototype', constructor.prototype);
     $defineProperty(klass, '$$const', {});
     $defineProperty(klass, '$$is_class', true);
@@ -1186,6 +1187,9 @@
     $defineProperty(constructor, '$$ancestors', []);
     $defineProperty(constructor, '$$ancestors_cache_version', null);
     $setPrototype(constructor, Opal.Class.prototype);
+    $defineProperty(constructor, '$$bridge', klass);
+    $defineProperty(klass, 'constructor', constructor);
+    $defineProperty(klass, '$$constructor', constructor);
   };
 
   function protoToModule(proto) {

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -398,13 +398,13 @@
   //
   // @return new [Class]  or existing ruby class
   //
-  Opal.allocate_class = function(name, superclass, constructor) {
-    var klass = constructor;
+  Opal.allocate_class = function(name, superclass) {
+    var constructor;
 
     if (superclass != null && superclass.$$bridge) {
       // Inheritance from bridged classes requires
       // calling original JS constructors
-      klass = function SubclassOfNativeClass() {
+      constructor = function() {
         var args = $slice.call(arguments),
             self = new ($bind.apply(superclass, [null].concat(args)))();
 
@@ -412,7 +412,12 @@
         $setPrototype(self, klass.prototype);
         return self;
       }
+    } else {
+      constructor = function(){};
     }
+
+    if (name)
+      $defineProperty(constructor, 'displayName', '::'+name);
 
     $defineProperty(klass, '$$name', name);
     $defineProperty(klass, '$$const', {});
@@ -469,7 +474,7 @@
     }
   }
 
-  Opal.klass = function(scope, superclass, name, constructor) {
+  Opal.klass = function(scope, superclass, name) {
     var bridged;
 
     if (scope == null) {
@@ -509,7 +514,7 @@
       Opal.const_set(scope, name, klass);
     } else {
       // Create the class object (instance of Class)
-      klass = Opal.allocate_class(name, superclass, constructor);
+      klass = Opal.allocate_class(name, superclass);
       Opal.const_set(scope, name, klass);
       // Call .inherited() hook with new class on the superclass
       if (superclass.$inherited) {
@@ -540,7 +545,11 @@
   // @param  id   [String] the name of the new (or existing) module
   //
   // @return [Module]
-  Opal.allocate_module = function(name, constructor) {
+  Opal.allocate_module = function(name) {
+    var constructor = function(){};
+    if (name)
+      $defineProperty(constructor, 'displayName', name+'.$$constructor');
+
     var module = constructor;
 
     if (name)
@@ -575,7 +584,7 @@
     return module;
   }
 
-  Opal.module = function(scope, name, constructor) {
+  Opal.module = function(scope, name) {
     var module;
 
     if (scope == null) {

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -70,6 +70,7 @@
   var $bind         = Function.prototype.bind;
   var $setPrototype = Object.setPrototypeOf;
   var $slice        = Array.prototype.slice;
+  var $splice       = Array.prototype.splice;
 
   // Nil object id is always 4
   var nil_id = 4;
@@ -1610,7 +1611,7 @@
   Opal.extract_kwargs = function(parameters) {
     var kwargs = parameters[parameters.length - 1];
     if (kwargs != null && kwargs['$respond_to?']('to_hash', true)) {
-      Array.prototype.splice.call(parameters, parameters.length - 1, 1);
+      $splice.call(parameters, parameters.length - 1, 1);
       return kwargs.$to_hash();
     }
     else {

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -400,7 +400,7 @@
   // @return new [Class]  or existing ruby class
   //
   Opal.allocate_class = function(name, superclass) {
-    var constructor;
+    var klass, constructor;
 
     if (superclass != null && superclass.$$bridge) {
       // Inheritance from bridged classes requires
@@ -417,10 +417,11 @@
       constructor = function(){};
     }
 
-    if (name)
+    if (name) {
       $defineProperty(constructor, 'displayName', '::'+name);
+    }
 
-    var klass = constructor;
+    klass = constructor;
 
     $defineProperty(klass, '$$name', name);
     $defineProperty(klass, '$$constructor', constructor);
@@ -550,8 +551,9 @@
   // @return [Module]
   Opal.allocate_module = function(name) {
     var constructor = function(){};
-    if (name)
+    if (name) {
       $defineProperty(constructor, 'displayName', name+'.$$constructor');
+    }
 
     var module = constructor;
 
@@ -606,7 +608,7 @@
     }
 
     // Module doesnt exist, create a new one...
-    module = Opal.allocate_module(name, constructor);
+    module = Opal.allocate_module(name);
     Opal.const_set(scope, name, module);
 
     return module;

--- a/opal/corelib/string.rb
+++ b/opal/corelib/string.rb
@@ -5,9 +5,9 @@ class String < `String`
   include Comparable
 
   %x{
-    Opal.defineProperty(String.prototype, '$$is_string', true);
+    Opal.defineProperty(#{self}.$$prototype, '$$is_string', true);
 
-    Opal.defineProperty(String.prototype, '$$cast', function(string) {
+    Opal.defineProperty(#{self}.$$prototype, '$$cast', function(string) {
       var klass = this.$$class;
       if (klass === String) {
         return string;

--- a/opal/corelib/string.rb
+++ b/opal/corelib/string.rb
@@ -9,10 +9,10 @@ class String < `String`
 
     Opal.defineProperty(#{self}.$$prototype, '$$cast', function(string) {
       var klass = this.$$class;
-      if (klass === String) {
+      if (klass.$$constructor === String) {
         return string;
       } else {
-        return new klass(string);
+        return new klass.$$constructor(string);
       }
     });
   }
@@ -29,7 +29,7 @@ class String < `String`
 
   def self.new(str = '')
     str = Opal.coerce_to(str, String, :to_str)
-    `new self(str)`
+    `new self.$$constructor(str)`
   end
 
   def initialize(str = undefined)

--- a/spec/lib/compiler_spec.rb
+++ b/spec/lib/compiler_spec.rb
@@ -65,12 +65,6 @@ RSpec.describe Opal::Compiler do
     expect_compiled("undef a,b").to match(/Opal.udef\(self, '\$' \+ "a"\);.*Opal.udef\(self, '\$' \+ "b"\);/m)
   end
 
-  describe "class names" do
-    it "generates a named function for class using $ prefix" do
-      expect_compiled("class Foo; end").to include("function $Foo")
-    end
-  end
-
   describe "method names" do
     it "generates a named function for method" do
       expect_compiled("def test_method; end").to include("function $$test_method()")

--- a/spec/opal/core/language_spec.rb
+++ b/spec/opal/core/language_spec.rb
@@ -21,3 +21,9 @@ describe "generated method names" do
     }
   end
 end
+
+describe "Bridging" do
+  it "does not remove singleton methods of bridged classes" do
+    `typeof(String.call)`.should == "function"
+  end
+end

--- a/stdlib/nodejs/stacktrace.rb
+++ b/stdlib/nodejs/stacktrace.rb
@@ -87,7 +87,7 @@
 
     var line = "";
     var func = this.getFunction();
-    var customName = func.displayName;
+    if (func) var customName = func.displayName;
     if (NODE && customName) {
       if (customName && func.$$owner) {
         var customNameOwner;


### PR DESCRIPTION
Fixes https://github.com/opal/opal/issues/1846

Basically creates class objects for bridged classes instead of using the native constructor.

_I'll refine the commits once the PR is working properly and the solution is confirmed_

