### PR TITLE
Remove Marshal::BinaryString

### DIFF
--- a/opal/corelib/marshal.rb
+++ b/opal/corelib/marshal.rb
@@ -5,18 +5,6 @@ module Marshal
   MAJOR_VERSION = 4
   MINOR_VERSION = 8
 
-  # For simulating binary strings
-  #
-  class BinaryString < String
-    def encoding
-      Encoding::BINARY
-    end
-
-    def +(other)
-      BinaryString.new(super)
-    end
-  end
-
   class << self
     def dump(object)
       WriteBuffer.new(object).write

--- a/opal/corelib/marshal/write_buffer.rb
+++ b/opal/corelib/marshal/write_buffer.rb
@@ -182,9 +182,17 @@ module Marshal
   class WriteBuffer
     attr_reader :buffer
 
+    %x{
+      function binaryString(s) {
+        s = new String(s);
+        s.encoding = #{Encoding::BINARY};
+        return s;
+      }
+    }
+
     def initialize(object)
       @object = object
-      @buffer = BinaryString.new
+      @buffer = ''
       @cache = []
       @extends = Hash.new { |h, k| h[k] = [] }
       append(version)
@@ -212,7 +220,7 @@ module Marshal
         end
       end
 
-      @buffer
+      `binaryString(#{@buffer})`
     end
 
     def write_fixnum(n)
@@ -398,7 +406,7 @@ module Marshal
     end
 
     def append(s)
-      @buffer += s
+      `#{@buffer} += #{s}`
     end
 
     def version


### PR DESCRIPTION
Replace the custom (hackish) class with a simple (hackish) helper function.
This has the advantage of having one less Opal-specific class and avoids the
call to `super` when doing `String#+`.