### PR TITLE
Fix ||= on constants

### DIFF
--- a/lib/opal/rewriters/logical_operator_assignment.rb
+++ b/lib/opal/rewriters/logical_operator_assignment.rb
@@ -20,6 +20,13 @@ module Opal
           get_node = lhs.updated(get_type)              # lhs
           condition_node = s(root_type, get_node, rhs)  # lhs || rhs
 
+          if get_type == :const && root_type == :or
+            # defined?(lhs)
+            defined_node = s(:defined?, get_node)
+            # LHS = defined?(LHS) ? (LHS || rhs) : rhs
+            condition_node = s(:if, defined_node, s(:begin, condition_node), rhs)
+          end
+
           lhs.updated(set_type, [*lhs, condition_node]) # lhs = lhs || rhs
         }
       }
@@ -33,7 +40,10 @@ module Opal
       InstanceVariableHandler = GET_SET[:ivar, :ivasgn]
 
       # Takes    `LHS ||= rhs`
-      # Produces `LHS = LHS || rhs`
+      # Produces `LHS = defined?(LHS) ? (LHS || rhs) : rhs`
+      #
+      # Takes    `LHS &&= rhs`
+      # Produces `LHS = LHS && rhs`
       ConstantHandler = GET_SET[:const, :casgn]
 
       # Takes    `$lhs ||= rhs`

--- a/spec/filters/bugs/language.rb
+++ b/spec/filters/bugs/language.rb
@@ -61,9 +61,6 @@ opal_filter "language" do
   fails "An instance method with a default argument shadows an existing method with the same name as the local"
   fails "Constant resolution within methods with dynamically assigned constants searches Object as a lexical scope only if Object is explicitly opened"
   fails "Constant resolution within methods with statically assigned constants searches Object as a lexical scope only if Object is explicitly opened"
-  fails "Constant resolution within methods with ||= assignes constant if previously undefined"
-  fails "Constant resolution within methods with ||= assigns a global constant if previously undefined" # NameError: uninitialized constant OpAssignGlobalUndefined
-  fails "Constant resolution within methods with ||= assigns a scoped constant if previously undefined" # NameError: uninitialized constant ConstantSpecs::OpAssignUndefined
   fails "Executing break from within a block returns from the original invoking method even in case of chained calls"
   fails "Execution variable $: is initialized to an array of strings"
   fails "Execution variable $: is read-only"

--- a/spec/lib/rewriters/logical_operator_assignment_spec.rb
+++ b/spec/lib/rewriters/logical_operator_assignment_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Opal::Rewriters::LogicalOperatorAssignment do
     end
 
     context 'constant' do
-      include_examples 'it rewrites', 'CONST ||= 1', 'CONST = CONST || 1'
+      include_examples 'it rewrites', 'CONST ||= 1', 'CONST = defined?(CONST) ? (CONST || 1) : 1'
       include_examples 'it rewrites', 'CONST &&= 1', 'CONST = CONST && 1'
     end
 


### PR DESCRIPTION
This is a special case where the assignment happens if either the constant has
a falsey value or the constant is not yet defined.

Fixes #672