### PR TITLE
chomp must return an empty String when arg == self

### DIFF
--- a/opal/corelib/string.rb
+++ b/opal/corelib/string.rb
@@ -307,7 +307,7 @@ class String < `String`
       else if (separator === "") {
         result = self.replace(/(\r?\n)+$/, '');
       }
-      else if (self.length > separator.length) {
+      else if (self.length >= separator.length) {
         var tail = self.substr(self.length - separator.length, separator.length);
 
         if (tail === separator) {


### PR DESCRIPTION
New Ruby spec: https://github.com/ruby/spec/pull/653

Resolves #1902

