### PR TITLE
Fix methods of `Comparable` when `<=>` does not return Numeric

### DIFF
--- a/spec/filters/bugs/comparable.rb
+++ b/spec/filters/bugs/comparable.rb
@@ -1,5 +1,0 @@
-opal_filter "Comparable" do
-  fails "Comparable#== when #<=> raises an exception if it is a StandardError lets it go through"
-  fails "Comparable#== when #<=> raises an exception if it is a subclass of StandardError lets it go through"
-  fails "Comparable#== when #<=> returns nor nil neither an Integer raises an ArgumentError"
-end


### PR DESCRIPTION
When `<=>` raises an exception, `Comparable#==` now lets it go
through.

Also, methods of `Comparable` now raises ArgumentError with a message
more similar to MRI when `<=>` does not return Integer.
```ruby
a = Object.new
a.extend Comparable
def a.<=>(other)
  nil
end

a < 1
#=> comparison of Object with Number failed (Opal)
#=> comparison of Object with 1 failed (MRI and Opal with this PR)
```