### PR TITLE
Fix Class#native_alias error message

### DIFF
--- a/spec/opal/stdlib/native/native_alias_spec.rb
+++ b/spec/opal/stdlib/native/native_alias_spec.rb
@@ -14,6 +14,13 @@ describe "Class#native_alias" do
   end
 
   it "raises if the aliased method isn't defined" do
-    lambda { Class.new { native_alias :a, :not_a_method } }.should raise_error(NameError)
+    Class.new do
+      lambda {
+        native_alias :a, :not_a_method
+      }.should raise_error(
+        NameError,
+        %r{undefined method `not_a_method' for class `#<Class:0x\w+>'}
+      )
+    end
   end
 end

--- a/stdlib/native.rb
+++ b/stdlib/native.rb
@@ -614,7 +614,7 @@ class Class
     %x{
       var aliased = #{self}.prototype['$' + #{existing_mid}];
       if (!aliased) {
-        #{raise NameError.new("undefined method `#{existing_mid}' for class `#{inspect}'", exiting_mid)};
+        #{raise NameError.new("undefined method `#{existing_mid}' for class `#{inspect}'", existing_mid)};
       }
       #{self}.prototype[#{new_jsid}] = aliased;
     }


### PR DESCRIPTION
A typo in the error message generation was raising the same error class we
were expecting, so this error went unnoticed for some time.