### PR TITLE
Opal runtime is strict

### DIFF
--- a/lib/opal/cli_runners/chrome.js
+++ b/lib/opal/cli_runners/chrome.js
@@ -91,7 +91,7 @@ CDP(options, function(client) {
     Runtime.exceptionThrown(function(exception) {
       var exceptionDetails = exception.exceptionDetails,
           properties = exceptionDetails.exception.preview.properties,
-          stackTrace = exceptionDetails.stackTrace.callFrames,
+          stackTrace = exceptionDetails.stackTrace ? exceptionDetails.stackTrace.callFrames : [],
           name, message, trace = [], i;
 
 

--- a/lib/opal/nodes/iter.rb
+++ b/lib/opal/nodes/iter.rb
@@ -17,7 +17,9 @@ module Opal
 
         in_scope do
           identity = scope.identify!
-          add_temp "self = #{identity}.$$s || this"
+          # REMIND: 0 is resolved to null (Number)
+          # Don't know exactly why but #{identity}.$$s contain the value!
+          add_temp "self = this ? this : #{identity}.$$s"
 
           inline_params = process(inline_args)
 

--- a/opal/corelib/number.rb
+++ b/opal/corelib/number.rb
@@ -927,6 +927,10 @@ class Number < Numeric
     end
 
     %x{
+      if (self === 0) {
+        return [0];
+      }
+
       var value = self, result = [];
 
       while (value !== 0) {

--- a/opal/corelib/number.rb
+++ b/opal/corelib/number.rb
@@ -2,8 +2,10 @@ require 'corelib/numeric'
 
 class Number < Numeric
   Opal.bridge(`Number`, self)
-  `Opal.defineProperty(self.$$prototype, '$$is_number', true)`
-  `self.$$is_number_class = true`
+
+  `Object.defineProperty(Number.prototype, '$$props', { value: { is_number: true, is_number_class: true } })`
+  `Object.defineProperty(Number.prototype, '$$is_number', { get : function() { return this.$$props.is_number; }, set : function(newValue) { this.$$props.is_number = newValue; } })`
+  `Object.defineProperty(Number.prototype, '$$is_number_class', { get : function() { return this.$$props.is_number_class; }, set : function(newValue) { this.$$props.is_number_class = newValue; } })`
 
   class << self
     def allocate

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -131,6 +131,18 @@
 
   function $defineProperty(object, name, initialValue) {
     if (typeof(object) === "string") {
+      if (typeof object.$$props === 'undefined') {
+        Object.defineProperty(String.prototype, '$$props', {
+          value: {},
+          writable: true
+        });
+      }
+      Object.defineProperty(String.prototype, name, {
+        get : function(){ return this.$$props[name]; },
+        set : function(newValue){
+          this.$$props[name] = newValue;
+        }
+      });
       // Special case for:
       //   s = "string"
       //   def s.m; end

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -1,3 +1,5 @@
+'use strict';
+
 (function(undefined) {
   // @note
   //   A few conventions for the documentation of this file:
@@ -1863,6 +1865,8 @@
 
     // Try to make the browser pick the right name
     alias.displayName       = name;
+    // Make 'length' writable, otherwise a value cannot be assigned to the read-only property 'length' in strict mode
+    Object.defineProperty(alias, 'length', { writable: true });
     alias.length            = body.length;
     alias.$$arity           = body.$$arity;
     alias.$$parameters      = body.$$parameters;

--- a/opal/corelib/string.rb
+++ b/opal/corelib/string.rb
@@ -691,10 +691,18 @@ class String < `String`
   end
 
   def ascii_only?
-    if self == '' && (encoding == Encoding::UTF_16LE || self.encoding == Encoding::UTF_16BE)
+    # non-ASCII-compatible encoding must return false
+    # NOTE: Encoding::UTF_16LE is also non-ASCII-compatible encoding,
+    # but since the default encoding in JavaScript is UTF_16LE,
+    # we cannot return false otherwise the following will (incorrectly) return false: "hello".ascii_only?
+    # In other words, we cannot tell the difference between:
+    # - "hello".force_encoding("UTF-16LE")
+    # - "hello"
+    # The problem is that "ascii_only" should return false in the first case and true in the second case.
+    if self.encoding == Encoding::UTF_16BE
       return false
     end
-    `self.match(/[ -~\n]*/)[0] === self`
+    `/^[\x00-\x7F]*$/.test(self)`
   end
 
   def match(pattern, pos = undefined, &block)

--- a/opal/corelib/string.rb
+++ b/opal/corelib/string.rb
@@ -691,6 +691,9 @@ class String < `String`
   end
 
   def ascii_only?
+    if self == '' && (encoding == Encoding::UTF_16LE || self.encoding == Encoding::UTF_16BE)
+      return false
+    end
     `self.match(/[ -~\n]*/)[0] === self`
   end
 

--- a/opal/corelib/string/encoding.rb
+++ b/opal/corelib/string/encoding.rb
@@ -163,7 +163,9 @@ end
 
 class String
   attr_reader :encoding
-  `Opal.defineProperty(String.prototype, 'encoding', #{Encoding::UTF_16LE})`
+
+  `Object.defineProperty(String.prototype, '$$props', { value: { encoding: #{Encoding::UTF_16LE} } })`
+  `Object.defineProperty(String.prototype, 'encoding', { get : function() { return this.$$props.encoding; }, set : function(newValue) { this.$$props.encoding = newValue; } })`
 
   def bytes
     each_byte.to_a
@@ -204,6 +206,11 @@ class String
 
   def force_encoding(encoding)
     %x{
+      console.log('self', self);
+      console.log('force_encoding', encoding);
+      console.log('encoding', encoding);
+      console.log('self.encoding', self.encoding);
+
       if (encoding === self.encoding) { return self; }
 
       encoding = #{Opal.coerce_to!(encoding, String, :to_s)};
@@ -211,12 +218,11 @@ class String
 
       if (encoding === self.encoding) { return self; }
 
-      var result = new String(self.toString())
-      Object.defineProperty(result, 'encoding', {
-        value: encoding,
-        writable: true
-      });
-      return result
+      console.log(self.encoding);
+      console.log(self);
+
+      self.encoding = encoding;
+      return self;
     }
   end
 

--- a/opal/corelib/string/encoding.rb
+++ b/opal/corelib/string/encoding.rb
@@ -211,8 +211,12 @@ class String
 
       if (encoding === self.encoding) { return self; }
 
-      self.encoding = encoding;
-      return self;
+      var result = new String(self.toString())
+      Object.defineProperty(result, 'encoding', {
+        value: encoding,
+        writable: true
+      });
+      return result
     }
   end
 

--- a/opal/corelib/string/encoding.rb
+++ b/opal/corelib/string/encoding.rb
@@ -206,20 +206,12 @@ class String
 
   def force_encoding(encoding)
     %x{
-      console.log('self', self);
-      console.log('force_encoding', encoding);
-      console.log('encoding', encoding);
-      console.log('self.encoding', self.encoding);
-
       if (encoding === self.encoding) { return self; }
 
       encoding = #{Opal.coerce_to!(encoding, String, :to_s)};
       encoding = #{Encoding.find(encoding)};
 
       if (encoding === self.encoding) { return self; }
-
-      console.log(self.encoding);
-      console.log(self);
 
       self.encoding = encoding;
       return self;

--- a/spec/filters/bugs/encoding.rb
+++ b/spec/filters/bugs/encoding.rb
@@ -123,12 +123,9 @@ opal_filter "Encoding" do
   fails "String#[]= with a Regexp index replaces multibyte characters with multibyte characters" # NoMethodError: undefined method `[]=' for "ありがとう":String
   fails "String#ascii_only? returns false after appending non ASCII characters to an empty String" # NotImplementedError: String#<< not supported. Mutable String methods are not supported in Opal.
   fails "String#ascii_only? returns false when concatenating an ASCII and non-ASCII String" # NoMethodError: undefined method `concat' for "":String
-  fails "String#ascii_only? returns false when interpolating non ascii strings" # Expected false to be true
   fails "String#ascii_only? returns false when replacing an ASCII String with a non-ASCII String" # NoMethodError: undefined method `replace' for "":String
-  fails "String#ascii_only? returns true for the empty String with an ASCII-compatible encoding" # Expected false to be true
-  fails "String#ascii_only? with ASCII only characters returns true for all single-character UTF-8 Strings" # Expected false to be true
-  fails "String#ascii_only? with ASCII only characters returns true if the encoding is US-ASCII" # Expected false to be true
-  fails "String#ascii_only? with ASCII only characters returns true if the encoding is UTF-8" # Expected true to be computed by "hello".ascii_only? (computed false instead)
+  fails "String#ascii_only? returns false for a non-empty String with non-ASCII-compatible encoding" # Expected true to be false
+  fails "String#ascii_only? returns false for the empty String with a non-ASCII-compatible encoding" # Expected true to be false
   fails "String#ascii_only? with non-ASCII only characters returns false if the encoding is ASCII-8BIT" # Expected #<Encoding:UTF-16LE> to equal #<Encoding:ASCII-8BIT (dummy)>
   fails "String#b copies own tainted/untrusted status to the returning value" # NoMethodError: undefined method `untrust' for "こんちには":String
   fails "String#b returns new string without modifying self" # NoMethodError: undefined method `b' for "こんちには":String

--- a/spec/filters/bugs/strict.rb
+++ b/spec/filters/bugs/strict.rb
@@ -1,0 +1,20 @@
+opal_filter "StrictMode" do
+  fails " " # Exception: Cannot create property 'foo' on string 'stuff'
+  fails " " # NameError: uninitialized constant MarshalSpec::DATA
+  fails "Kernel#is_a? returns true if given a Module that is included in object's class" # Expected false to equal true
+  fails "Kernel#is_a? returns true if given a Module that is included one of object's ancestors only" # Expected false to equal true
+  fails "Kernel#is_a? returns true if given a Module that object has been prepended with" # Expected false to equal true
+  fails "Kernel#is_a? returns true if given class is an ancestor of the object's class" # Expected false to equal true
+  fails "Kernel#kind_of? returns true if given a Module that is included in object's class" # Expected false to equal true
+  fails "Kernel#kind_of? returns true if given a Module that is included one of object's ancestors only" # Expected false to equal true
+  fails "Kernel#kind_of? returns true if given a Module that object has been prepended with" # Expected false to equal true
+  fails "Kernel#kind_of? returns true if given class is an ancestor of the object's class" # Expected false to equal true
+  fails "Kernel#public_methods returns public methods for immediates" # Exception: Object.defineProperty called on non-object
+  fails "Marshal.load assigns classes to nested subclasses of Array correctly" # NameError: uninitialized constant ArraySub
+  fails "Marshal.load loads subclasses of Array with overridden << and push correctly" # NameError: uninitialized constant ArraySubPush
+  fails "Marshal.dump with a String dumps a String subclass" # Expected "\u0004\be:\nMethse:\u001EStringSpecs::StringModuleC:\u000FUserString\"\u0000" to equal "\u0004\bC:\u000FUserString\"\u0000"
+  fails "Marshal.dump with a String dumps a String subclass extended with a Module" # Expected "\u0004\be:\nMethse:\u001EStringSpecs::StringModuleC:\u000FUserString\"\u0000" to equal "\u0004\be:\nMethsC:\u000FUserString\"\u0000"
+  fails "Marshal.dump with a String dumps a blank String" # Expected "\u0004\be:\nMethse:\u001EStringSpecs::StringModule\"\u0000" to equal "\u0004\b\"\u0000"
+  fails "Marshal.dump with a String dumps a long String" # Expected "\u0004\be:\nMethse:\u001EStringSpecs::StringModule\"\u0002,\u0001bigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbig" to equal "\u0004\b\"\u0002,\u0001bigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbig"
+  fails "Marshal.dump with a String dumps a short String" # Expected "\u0004\be:\nMethse:\u001EStringSpecs::StringModule\"\nshort" to equal "\u0004\b\"\nshort"
+end

--- a/spec/lib/builder_spec.rb
+++ b/spec/lib/builder_spec.rb
@@ -61,12 +61,12 @@ RSpec.describe Opal::Builder do
   describe 'requiring a native .js file' do
     it 'can be required without specifying extension' do
       builder.build_str('require "corelib/runtime"', 'foo')
-      expect(builder.to_s).to start_with('(function(undefined)')
+      expect(builder.to_s).to start_with("'use strict';\n\n(function(undefined)")
     end
 
     it 'can be required specifying extension' do
       builder.build_str('require "corelib/runtime.js"', 'foo')
-      expect(builder.to_s).to start_with('(function(undefined)')
+      expect(builder.to_s).to start_with("'use strict';\n\n(function(undefined)")
     end
   end
 

--- a/spec/ruby_specs
+++ b/spec/ruby_specs
@@ -154,6 +154,9 @@ ruby/core/true
 ruby/core/unboundmethod
 
 ruby/language
+# spec/ruby/language/fixtures/super.rb won't compile to strict JavaScript.
+# ZSuperWithUnderscores contains a method that has two parameters with the same name (underscore).
+!ruby/language/super_spec
 !ruby/language/execution_spec
 !ruby/language/safe_spec
 

--- a/stdlib/nodejs/stacktrace.rb
+++ b/stdlib/nodejs/stacktrace.rb
@@ -38,7 +38,7 @@
 
   var ObjectToString = Object.prototype.toString;
 
-  var NODE = ObjectToString.call(this.process) === "[object process]";
+  var NODE = ObjectToString.call(process) === "[object process]";
 
   // https://github.com/v8/v8/blob/cab94bbe3d532d85705950ed049a294050fcb4c9/src/messages.js#L1112-L1124 [converted to JS]
   function GetTypeName(receiver, requireConstructor) {

--- a/test.html
+++ b/test.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+
+</body>
+</html>


### PR DESCRIPTION
#### Tasks

- [x] `Uncaught TypeError: Cannot assign to read only property 'length' of function 'function() ...`
- [ ] `Uncaught SyntaxError: Duplicate parameter name not allowed in this context`
The following code is not strict-compliant:

```js
function hello(_, _) {
  console.log('hello')
}
```
Exception thrown by `spec/ruby/language/fixtures/super.rb` when the module `ZSuperWithUnderscores` defines the following methods:

```rb
def m(_, _)
  super
end

def m_modified(_, _)
  _ = 14
  super
end
```

I don't know exactly what the code is supposed to do... does it make sense in Ruby to do something like this ?
We could fix this issue by making sure that the generated code does not contain two or more parameters with the same name (ie. for instance by adding a counter to the parameter name).

EDIT: in `m_modified`, the value 14 will be assigned to the first parameter. So the code is equivalent to:

```rb
def m_modified(_1, _2)
  _1 = 14
  super
end
```
EDIT2: the current implementation is not working :disappointed: 

* [ ] `undefined : Cannot create property 'encoding' on string ')'`
* [ ] `TypeError: Cannot create property '$$meta' on string 'abc'`
```
$defineProperty
Object.Opal.build_object_singleton_class
```
