### PR TITLE
Fix Struct#dup by copying `$$data` with initialize_copy

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -7,6 +7,7 @@ Whitespace conventions:
 
 ### Fixed
 
+- Struct#dup (#1995)
 - Integer#gcdlcm (#1972)
 - Enumerable#to_h (#1979)
 - Enumerator#size (#1980)

--- a/opal/corelib/struct.rb
+++ b/opal/corelib/struct.rb
@@ -101,6 +101,17 @@ class Struct
     end
   end
 
+  def initialize_copy(from)
+    %x{
+      self.$$data = {}
+      var keys = Object.keys(from.$$data), i, max, name;
+      for (i = 0, max = keys.length; i < max; i++) {
+        name = keys[i];
+        self.$$data[name] = from.$$data[name];
+      }
+    }
+  end
+
   def members
     self.class.members
   end

--- a/spec/opal/core/struct/dup_spec.rb
+++ b/spec/opal/core/struct/dup_spec.rb
@@ -1,0 +1,11 @@
+describe "Struct#dup" do
+  it "should return another struct instance" do
+    klass = Struct.new("Klass", :foo)
+    a = klass.new(1)
+    b = a.dup
+    b.foo = 2
+
+    a.foo.should == 1
+    b.foo.should == 2
+  end
+end


### PR DESCRIPTION
# Problem


Opal raises TypeError when it accesses to duplicated Struct instance.


```ruby
C = Struct.new(:a)
a = C.new(1)
d = a.dup
p a
p d
```

```bash
$ bin/opal test.rb
#<struct C a=1>
/tmp/opal-nodejs-runner-20190713-10833-yax7b8:21715
        if(!self.$$data.hasOwnProperty(name)) {
                        ^

TypeError: Cannot read property 'hasOwnProperty' of undefined
    at constructor.$Struct_$$$17 (/tmp/opal-nodejs-runner-20190713-10833-yax7b8:21715:25)
    at $$26 (/tmp/opal-nodejs-runner-20190713-10833-yax7b8:21871:54)
    at Object.Opal.yield1 (/tmp/opal-nodejs-runner-20190713-10833-yax7b8:1452:14)
    at Array.$$each (/tmp/opal-nodejs-runner-20190713-10833-yax7b8:12590:26)
    at Opal.send (/tmp/opal-nodejs-runner-20190713-10833-yax7b8:1671:19)
    at constructor.$$each_pair (/tmp/opal-nodejs-runner-20190713-10833-yax7b8:21864:7)
    at constructor.$$__send__ (/tmp/opal-nodejs-runner-20190713-10833-yax7b8:3717:21)
    at Opal.send (/tmp/opal-nodejs-runner-20190713-10833-yax7b8:1671:19)
    at constructor.$$each (/tmp/opal-nodejs-runner-20190713-10833-yax7b8:10542:14)
    at constructor.$$collect (/tmp/opal-nodejs-runner-20190713-10833-yax7b8:8767:12)
```

`$$data` is assigned by `new` class method, but it is not assigned with `Struct#dup`.


# Solution


Copy `$$data` with `Struct#initialize_copy` method.


# Note


We have a TODO of `Struct#dup` https://github.com/opal/opal/blob/2775e1b6e3066b4cd6ee4c3c1f4df365339f7115/spec/filters/bugs/struct.rb#L3

But this pull request does not solve the todo.