### PR TITLE
Allow to change Nashorn path if using GraalVM

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -26,3 +26,8 @@ Whitespace conventions:
 - Range#each (#1991)
 - Enumerable#zip (#1986)
 - Struct#dup not copying `$$data` (#1995)
+
+
+### Changed
+
+- Nashorn has been deprecated but GraalVM still supports it (#1997)

--- a/lib/opal/cli_runners/nashorn.rb
+++ b/lib/opal/cli_runners/nashorn.rb
@@ -15,13 +15,17 @@ module Opal
       end
 
       def run(code, argv)
+        # Allow to change path if using GraalVM, see:
+        # https://github.com/graalvm/graaljs/blob/master/docs/user/NashornMigrationGuide.md#launcher-name-js
+        exe = ENV['NASHORN_PATH'] || 'jjs'
+
         require 'tempfile'
         tempfile = Tempfile.new('opal-nashorn-runner-')
         tempfile.write code
         tempfile.close
-        system_with_output({}, 'jjs', tempfile.path, *argv)
+        system_with_output({}, exe, tempfile.path, *argv)
       rescue Errno::ENOENT
-        raise MissingNashorn, 'Please install JDK to be able to run Opal scripts.'
+        raise MissingNashorn, 'Please install JDK or GraalVM to be able to run Opal scripts.'
       end
 
       # Let's support fake IO objects like StringIO


### PR DESCRIPTION
See also:
- https://github.com/graalvm/graaljs/blob/master/docs/user/NashornMigrationGuide.md#launcher-name-js
- https://medium.com/graalvm/oracle-graalvm-announces-support-for-nashorn-migration-c04810d75c1f
- https://www.graalvm.org/docs/reference-manual/languages/js/

Fixes #1971