### PR TITLE
Remove workaround targeted at JRuby 1.7

### DIFF
--- a/lib/opal/cli_runners/applescript.rb
+++ b/lib/opal/cli_runners/applescript.rb
@@ -36,22 +36,10 @@ module Opal
           return
         end
 
-        if RUBY_PLATFORM == 'java'
-          # JRuby has issues in dealing with subprocesses (at least up to 1.7.15)
-          # @headius told me it's mostly fixed on master, but while we wait for it
-          # to ship here's a tempfile workaround.
-          require 'tempfile'
-          require 'shellwords'
-          tempfile = Tempfile.new('opal-applescript-output')
-          system(env, cmd.shelljoin + " > #{tempfile.path}")
-          @exit_status = $?.exitstatus
-          captured_output = File.read tempfile.path
-          tempfile.close
-        else
-          require 'open3'
-          captured_output, status = Open3.capture2(env, *cmd)
-          @exit_status = status.exitstatus
-        end
+        require 'open3'
+        captured_output, status = Open3.capture2(env, *cmd)
+        @exit_status = status.exitstatus
+
         output.write captured_output
       end
 

--- a/lib/opal/cli_runners/nashorn.rb
+++ b/lib/opal/cli_runners/nashorn.rb
@@ -36,22 +36,9 @@ module Opal
           return
         end
 
-        if RUBY_PLATFORM == 'java'
-          # JRuby has issues in dealing with subprocesses (at least up to 1.7.15)
-          # @headius told me it's mostly fixed on master, but while we wait for it
-          # to ship here's a tempfile workaround.
-          require 'tempfile'
-          require 'shellwords'
-          tempfile = Tempfile.new('opal-nashorn-output')
-          system(env, cmd.shelljoin + " > #{tempfile.path}")
-          @exit_status = $?.exitstatus
-          captured_output = File.read tempfile.path
-          tempfile.close
-        else
-          require 'open3'
-          captured_output, status = Open3.capture2(env, *cmd)
-          @exit_status = status.exitstatus
-        end
+        require 'open3'
+        captured_output, status = Open3.capture2(env, *cmd)
+        @exit_status = status.exitstatus
 
         output.write captured_output
       end

--- a/lib/opal/cli_runners/nodejs.rb
+++ b/lib/opal/cli_runners/nodejs.rb
@@ -42,22 +42,9 @@ module Opal
           return
         end
 
-        if RUBY_PLATFORM == 'java'
-          # JRuby has issues in dealing with subprocesses (at least up to 1.7.15)
-          # @headius told me it's mostly fixed on master, but while we wait for it
-          # to ship here's a tempfile workaround.
-          require 'tempfile'
-          require 'shellwords'
-          tempfile = Tempfile.new('opal-node-output')
-          system(env, cmd.shelljoin + " > #{tempfile.path}")
-          @exit_status = $?.exitstatus
-          captured_output = File.read tempfile.path
-          tempfile.close
-        else
-          require 'open3'
-          captured_output, status = Open3.capture2(env, *cmd)
-          @exit_status = status.exitstatus
-        end
+        require 'open3'
+        captured_output, status = Open3.capture2(env, *cmd)
+        @exit_status = status.exitstatus
 
         output.write captured_output
       end


### PR DESCRIPTION
At this moment the current JRuby version is 9.2.8.0, so should be safe
to assume we're good now.