### PR TITLE
Used parser version is incompatible with rubocop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,5 +51,5 @@ group :doc do
 end
 
 platforms :ruby, :mswin, :mswin64, :mingw, :x64_mingw do
-  gem 'c_lexer', '2.5.3.0.0' unless RUBY_ENGINE == 'truffleruby'
+  gem 'c_lexer', '~> 2.6' unless RUBY_ENGINE == 'truffleruby'
 end

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -37,6 +37,7 @@ Whitespace conventions:
 
 ### Changed
 
+- Updated outdated parser version (#2013)
 - Nashorn has been deprecated but GraalVM still supports it (#1997)
 - "opal/mini" now includes "opal/io" (#2002)
 - Regexps assigned to constants are now frozen (#2007)

--- a/opal.gemspec
+++ b/opal.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3'
 
   spec.add_dependency 'ast', '>= 2.3.0'
-  spec.add_dependency 'parser', '= 2.5.3.0'
+  spec.add_dependency 'parser', '~> 2.6'
 
   spec.add_development_dependency 'sourcemap', '~> 0.1.0'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
While updating to rails 6:

```
Bundler could not find compatible versions for gem "parser":
  In Gemfile:
    my_project_a was resolved to 0.9.1, which depends on
      opal-rails (~> 1.0) was resolved to 1.0.1, which depends on
        opal (~> 1.0.0) was resolved to 1.0.0, which depends on
          parser (= 2.5.3.0)

    my_project_b was resolved to 0.13.1, which depends on
      rubocop (~> 0.74, < 0.75) was resolved to 0.74.0, which depends on
        parser (>= 2.6)
```