### PR TITLE
Add Opal::Compiler#magic_comment_flags

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -117,6 +117,10 @@ Lint/LiteralAsCondition:
     - 'opal/**/*.rb'
     - 'stdlib/**/*.rb'
 
+# Allow the use of if/unless inside blocks
+Style/Next:
+  Enabled: false
+
 Lint/RescueException:
   Exclude:
     # That's what MRI does

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -9,6 +9,7 @@ Whitespace conventions:
 
 - Basic support for `uplevel:` keyword argument in `Kernel#warn` (#2006)
 - Added a `#respond_to_missing?` implementation for `BasicObject`, `Delegator`, `OpenStruct`, that's meant for future support in the Opal runtime, which currently ignores it (#2007)
+- `Opal::Compiler#magic_comment_flags` that allows to access magic-comments format and converts it to a hash
 
 ### Fixed
 

--- a/lib/opal/compiler.rb
+++ b/lib/opal/compiler.rb
@@ -6,6 +6,7 @@ require 'opal/fragment'
 require 'opal/nodes'
 require 'opal/eof_content'
 require 'opal/errors'
+require 'opal/magic_comments'
 
 module Opal
   # Compile a string of ruby code into javascript.
@@ -157,6 +158,9 @@ module Opal
     # Comments from the source code
     attr_reader :comments
 
+    # Magic comment flags extracted from the leading comments
+    attr_reader :magic_comment_flags
+
     def initialize(source, options = {})
       @source = source
       @indent = ''
@@ -188,6 +192,7 @@ module Opal
 
       @sexp = s(:top, sexp || s(:nil))
       @comments = ::Parser::Source::Comment.associate_locations(sexp, comments)
+      @magic_comment_flags = MagicComments.parse(sexp, comments)
       @eof_content = EofContent.new(tokens, @source).eof
     end
 

--- a/lib/opal/magic_comments.rb
+++ b/lib/opal/magic_comments.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Opal::MagicComments
+  MAGIC_COMMENT_RE = /\A# *([\w_]+) *: *([\w_]+) *$/.freeze
+  EMACS_MAGIC_COMMENT_RE = /\A# *-\*- *([\w_]+) *: *([\w_]+) *-\*- *$/.freeze
+
+  def self.parse(sexp, comments)
+    flags = {}
+
+    # We have an upper limit at the first line of code
+    if sexp
+      first_line = sexp.loc.line
+      comments = comments.take(first_line)
+    end
+
+    comments.each do |comment|
+      next if first_line && comment.loc.line >= first_line
+
+      if (parts = comment.text.scan(MAGIC_COMMENT_RE)).any? ||
+         (parts = comment.text.scan(EMACS_MAGIC_COMMENT_RE)).any?
+        parts.each do |key, value|
+          flags[key.to_sym] =
+            case value
+            when 'true' then true
+            when 'false' then false
+            else value
+            end
+        end
+      end
+    end
+
+    flags
+  end
+end

--- a/spec/lib/compiler_spec.rb
+++ b/spec/lib/compiler_spec.rb
@@ -464,6 +464,51 @@ RSpec.describe Opal::Compiler do
     end
   end
 
+  describe '#magic_comment_flags' do
+    def expect_magic_comments_for(*lines)
+      expect(compiler_for(lines.join("\n")).magic_comment_flags)
+    end
+
+    it 'extracts them in a hash' do
+      expect_magic_comments_for("").to eq({})
+
+      expect_magic_comments_for(
+        "",
+        "#     foo:true",
+        "",
+        "",
+        "",
+        "#bar : false",
+        "#baz  :qux",
+        "#biz  :boz",
+        "baz",
+      ).to eq(
+        foo: true,
+        bar: false,
+        baz: "qux",
+        biz: "boz"
+      )
+
+      expect_magic_comments_for(
+        "#baz  :qux",
+        "#biz  :boz",
+        "",
+        "baz",
+      ).to eq(
+        baz: "qux",
+        biz: "boz"
+      )
+
+      expect_magic_comments_for(
+        "#-*- baz  :qux-*-",
+        "#   -*-biz  :boz   -*-   ",
+      ).to eq(
+        baz: "qux",
+        biz: "boz"
+      )
+    end
+  end
+
   describe 'magic encoding comment' do
     let(:diagnostics) { [] }
 


### PR DESCRIPTION
Will allow access to magic-comments nicely converting them to a hash.