### PR TITLE
benchmarking.rake - bench:ips - correct a path to benchmarks

### DIFF
--- a/tasks/benchmarking.rake
+++ b/tasks/benchmarking.rake
@@ -103,7 +103,7 @@ namespace :bench do
   end
 
   task :ips do
-    files = Dir[ENV['FILE'] || "#{__dir__}/benchmark-ips/bm_*.rb"]
+    files = Dir[ENV['FILE'] || "#{__dir__}/../benchmark-ips/bm_*.rb"]
     raise ArgumentError, "no files provided" if files.empty?
     puts "=== Files: #{files.join ', '}"
     files.each do |bm_path|


### PR DESCRIPTION
This instruction was probably originally in a Rakefile and so it referenced `__dir__` correctly. After moving it to tasks/, the `__dir__` reference changed. This commit corrects the path.