### PR TITLE
Add per-file "use strict" support

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -9,7 +9,7 @@ Whitespace conventions:
 
 - Basic support for `uplevel:` keyword argument in `Kernel#warn` (#2006)
 - Added a `#respond_to_missing?` implementation for `BasicObject`, `Delegator`, `OpenStruct`, that's meant for future support in the Opal runtime, which currently ignores it (#2007)
-- `Opal::Compiler#magic_comment_flags` that allows to access magic-comments format and converts it to a hash
+- `Opal::Compiler#magic_comments` that allows to access magic-comments format and converts it to a hash
 
 ### Fixed
 

--- a/benchmark-ips/class_shovel_vs_singleton_class.rb
+++ b/benchmark-ips/class_shovel_vs_singleton_class.rb
@@ -1,0 +1,16 @@
+o = nil
+Benchmark.ips do |x|
+  x.report('shovel') do
+    o = Object.new
+    class << o
+      attr_accessor :foo
+    end
+  end
+
+  x.report('singleton_class') do
+    o2 = Object.new
+    o2.singleton_class.attr_accessor :foo
+  end
+
+  x.compare!
+end

--- a/lib/opal/compiler.rb
+++ b/lib/opal/compiler.rb
@@ -164,7 +164,7 @@ module Opal
     attr_reader :comments
 
     # Magic comment flags extracted from the leading comments
-    attr_reader :magic_comment_flags
+    attr_reader :magic_comments
 
     def initialize(source, options = {})
       @source = source
@@ -173,6 +173,7 @@ module Opal
       @options = options
       @comments = Hash.new([])
       @case_stmt = nil
+      @magic_comments = {}
     end
 
     # Compile some ruby code to a string.
@@ -197,7 +198,7 @@ module Opal
 
       @sexp = s(:top, sexp || s(:nil))
       @comments = ::Parser::Source::Comment.associate_locations(sexp, comments)
-      @magic_comment_flags = MagicComments.parse(sexp, comments)
+      @magic_comments = MagicComments.parse(sexp, comments)
       @eof_content = EofContent.new(tokens, @source).eof
     end
 

--- a/lib/opal/compiler.rb
+++ b/lib/opal/compiler.rb
@@ -61,6 +61,7 @@ module Opal
     # Defines a compiler option.
     # @option as: [Symbol] uses a different method name, e.g. with a question mark for booleans
     # @option default: [Object] the default value for the option
+    # @option magic_comment: [Bool] allows magic-comments to override the option value
     def self.compiler_option(name, config = {})
       method_name = config.fetch(:as, name)
       define_method(method_name) { option_value(name, config) }
@@ -72,8 +73,13 @@ module Opal
 
       default_value = config[:default]
       valid_values  = config[:valid_values]
+      magic_comment = config[:magic_comment]
 
       value = @options.fetch(name, default_value)
+
+      if magic_comment && @magic_comments.key?(name)
+        value = @magic_comments.fetch(name)
+      end
 
       if valid_values && !valid_values.include?(value)
         raise(
@@ -152,7 +158,7 @@ module Opal
     # @!method use_strict?
     #
     # Adds source_location for every method definition
-    compiler_option :use_strict, default: false, as: :use_strict?
+    compiler_option :use_strict, default: false, as: :use_strict?, magic_comment: true
 
     # @!method parse_comments?
     #

--- a/lib/opal/compiler.rb
+++ b/lib/opal/compiler.rb
@@ -58,18 +58,32 @@ module Opal
       Pathname(path).cleanpath.to_s
     end
 
-    # defines a compiler option, also creating method of form 'name?'
-    def self.compiler_option(name, default_value, options = {})
-      mid          = options[:as]
-      valid_values = options[:valid_values]
-      define_method(mid || name) do
-        value = @options.fetch(name) { default_value }
-        if valid_values && !valid_values.include?(value)
-          raise ArgumentError, "invalid value #{value.inspect} for option #{name.inspect} " \
-                               "(valid values: #{valid_values.inspect})"
-        end
-        value
+    # Defines a compiler option.
+    # @option as: [Symbol] uses a different method name, e.g. with a question mark for booleans
+    # @option default: [Object] the default value for the option
+    def self.compiler_option(name, config = {})
+      method_name = config.fetch(:as, name)
+      define_method(method_name) { option_value(name, config) }
+    end
+
+    # Fetches and memoizes the value for an option.
+    def option_value(name, config)
+      return @option_values[name] if @option_values.key? name
+
+      default_value = config[:default]
+      valid_values  = config[:valid_values]
+
+      value = @options.fetch(name, default_value)
+
+      if valid_values && !valid_values.include?(value)
+        raise(
+          ArgumentError,
+          "invalid value #{value.inspect} for option #{name.inspect} " \
+          "(valid values: #{valid_values.inspect})"
+        )
       end
+
+      @option_values[name] = value
     end
 
     # @!method file
@@ -78,21 +92,21 @@ module Opal
     # as well as finding relative require()
     #
     # @return [String]
-    compiler_option :file, '(file)'
+    compiler_option :file, default: '(file)'
 
     # @!method method_missing?
     #
     # adds method stubs for all used methods in file
     #
     # @return [Boolean]
-    compiler_option :method_missing, true, as: :method_missing?
+    compiler_option :method_missing, default: true, as: :method_missing?
 
     # @!method arity_check?
     #
     # adds an arity check to every method definition
     #
     # @return [Boolean]
-    compiler_option :arity_check, false, as: :arity_check?
+    compiler_option :arity_check, default: false, as: :arity_check?
 
     # @deprecated
     # @!method freezing?
@@ -100,50 +114,50 @@ module Opal
     # stubs out #freeze and #frozen?
     #
     # @return [Boolean]
-    compiler_option :freezing, true, as: :freezing?
+    compiler_option :freezing, default: true, as: :freezing?
 
     # @deprecated
     # @!method tainting?
     #
     # stubs out #taint, #untaint and #tainted?
-    compiler_option :tainting, true, as: :tainting?
+    compiler_option :tainting, default: true, as: :tainting?
 
     # @!method irb?
     #
     # compile top level local vars with support for irb style vars
-    compiler_option :irb, false, as: :irb?
+    compiler_option :irb, default: false, as: :irb?
 
     # @!method dynamic_require_severity
     #
     # how to handle dynamic requires (:error, :warning, :ignore)
-    compiler_option :dynamic_require_severity, :ignore, valid_values: %i[error warning ignore]
+    compiler_option :dynamic_require_severity, default: :ignore, valid_values: %i[error warning ignore]
 
     # @!method requirable?
     #
     # Prepare the code for future requires
-    compiler_option :requirable, false, as: :requirable?
+    compiler_option :requirable, default: false, as: :requirable?
 
     # @!method inline_operators?
     #
     # are operators compiled inline
-    compiler_option :inline_operators, true, as: :inline_operators?
+    compiler_option :inline_operators, default: true, as: :inline_operators?
 
-    compiler_option :eval, false, as: :eval?
+    compiler_option :eval, default: false, as: :eval?
 
     # @!method enable_source_location?
     #
     # Adds source_location for every method definition
-    compiler_option :enable_source_location, false, as: :enable_source_location?
+    compiler_option :enable_source_location, default: false, as: :enable_source_location?
 
     # @!method use_strict?
     #
     # Adds source_location for every method definition
-    compiler_option :use_strict, false, as: :use_strict?
+    compiler_option :use_strict, default: false, as: :use_strict?
 
     # @!method parse_comments?
     #
     # Adds comments for every method definition
-    compiler_option :parse_comments, false, as: :parse_comments?
+    compiler_option :parse_comments, default: false, as: :parse_comments?
 
     # @return [String] The compiled ruby code
     attr_reader :result
@@ -173,6 +187,7 @@ module Opal
       @options = options
       @comments = Hash.new([])
       @case_stmt = nil
+      @option_values = {}
       @magic_comments = {}
     end
 

--- a/lib/opal/compiler.rb
+++ b/lib/opal/compiler.rb
@@ -135,6 +135,11 @@ module Opal
     # Adds source_location for every method definition
     compiler_option :enable_source_location, false, as: :enable_source_location?
 
+    # @!method use_strict?
+    #
+    # Adds source_location for every method definition
+    compiler_option :use_strict, false, as: :use_strict?
+
     # @!method parse_comments?
     #
     # Adds comments for every method definition

--- a/lib/opal/nodes/iter.rb
+++ b/lib/opal/nodes/iter.rb
@@ -17,7 +17,7 @@ module Opal
 
         in_scope do
           identity = scope.identify!
-          add_temp "self = #{identity}.$$s || this"
+          add_temp "self = #{identity}.$$s == null ? this : #{identity}.$$s"
 
           inline_params = process(inline_args)
 

--- a/lib/opal/nodes/literal.rb
+++ b/lib/opal/nodes/literal.rb
@@ -66,7 +66,8 @@ module Opal
           encoding = string_value.encoding
 
           unless encoding == Encoding::UTF_8
-            push '.$force_encoding("', encoding.name, '")'
+            helper :enc
+            wrap "$enc(", ", \"#{encoding.name}\")"
           end
         end
       end

--- a/lib/opal/nodes/literal.rb
+++ b/lib/opal/nodes/literal.rb
@@ -55,8 +55,6 @@ module Opal
 
       def compile
         string_value = value
-        encoding = string_value.encoding
-        should_encode = encoding != Encoding::UTF_8
 
         sanitized_value = string_value.inspect.gsub(/\\u\{([0-9a-f]+)\}/) do
           code_point = Regexp.last_match(1).to_i(16)
@@ -64,8 +62,12 @@ module Opal
         end
         push translate_escape_chars(sanitized_value)
 
-        if should_encode && RUBY_ENGINE != 'opal'
-          push '.$force_encoding("', encoding.name, '")'
+        if RUBY_ENGINE != 'opal'
+          encoding = string_value.encoding
+
+          unless encoding == Encoding::UTF_8
+            push '.$force_encoding("', encoding.name, '")'
+          end
         end
       end
 

--- a/lib/opal/nodes/top.rb
+++ b/lib/opal/nodes/top.rb
@@ -17,6 +17,8 @@ module Opal
 
         opening
         in_scope do
+          line '"use strict";' if compiler.use_strict?
+
           body_code = stmt(stmts)
           body_code = [body_code] unless body_code.is_a?(Array)
 

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -2346,6 +2346,34 @@
   };
 
 
+  // Strings
+  // -------
+
+  Opal.encodings = Object.create(null);
+
+  // Sets the encoding on a string, will treat string literals as frozen strings
+  // raising a FrozenError.
+  // @param str [String] the string on which the encoding should be set.
+  // @param name [String] the canonical name of the encoding
+  Opal.set_encoding = function(str, name) {
+    if (typeof str === 'string')
+      throw Opal.FrozenError.$new("can't modify frozen String");
+
+    var encoding = Opal.encodings[name];
+
+    if (encoding === str.encoding) { return str; }
+
+    str.encoding = encoding;
+
+    return str;
+  };
+
+  // @returns a String object with the encoding set from a string literal
+  Opal.enc = function(str, name) {
+    return Opal.set_encoding(new String(str), name);
+  }
+
+
   // Initialization
   // --------------
   function $BasicObject() {}

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -135,7 +135,7 @@
       // String class is the only class that:
       // + compiles to JS primitive
       // + allows method definition directly on instances
-      // numbers, true, false and nil do not support it.
+      // numbers, true, false and null do not support it.
       object[name] = initialValue;
     } else {
       Object.defineProperty(object, name, {

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -1,4 +1,6 @@
 (function() {
+  "use_strict";
+
   // @note
   //   A few conventions for the documentation of this file:
   //   1. Always use "//" (in contrast with "/**/")

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -1861,9 +1861,13 @@
       return Opal.send(this, body, args, block);
     };
 
+    // Assign the 'length' value with defineProperty because
+    // in strict mode the property is not writable.
+    Object.defineProperty(alias, 'length', { value: body.length });
+
     // Try to make the browser pick the right name
     alias.displayName       = name;
-    alias.length            = body.length;
+
     alias.$$arity           = body.$$arity;
     alias.$$parameters      = body.$$parameters;
     alias.$$source_location = body.$$source_location;

--- a/opal/corelib/string.rb
+++ b/opal/corelib/string.rb
@@ -344,14 +344,14 @@ class String < `String`
   end
 
   def clone
-    copy = `self.slice()`
+    copy = `new String(self)`
     copy.copy_singleton_methods(self)
     copy.initialize_clone(self)
     copy
   end
 
   def dup
-    copy = `self.slice()`
+    copy = `new String(self)`
     copy.initialize_dup(self)
     copy
   end

--- a/opal/corelib/string/encoding.rb
+++ b/opal/corelib/string/encoding.rb
@@ -1,24 +1,22 @@
 require 'corelib/string'
 
 class Encoding
-  `Opal.defineProperty(self, '$$register', {})`
-
   def self.register(name, options = {}, &block)
     names    = [name] + (options[:aliases] || [])
     encoding = Class.new(self, &block)
                     .new(name, names, options[:ascii] || false, options[:dummy] || false)
 
-    register = self.JS['$$register']
+    register = `Opal.encodings`
     names.each do |encoding_name|
       const_set encoding_name.sub('-', '_'), encoding
-      register.JS["$$#{encoding_name}"] = encoding
+      register.JS[encoding_name] = encoding
     end
   end
 
   def self.find(name)
     return default_external if name == :default_external
-    register = self.JS['$$register']
-    encoding = register.JS["$$#{name}"] || register.JS["$$#{name.upcase}"]
+    register = `Opal.encodings`
+    encoding = register.JS[name] || register.JS[name.upcase]
     raise ArgumentError, "unknown encoding name - #{name}" unless encoding
     encoding
   end
@@ -208,7 +206,8 @@ class String
 
       if (encoding === self.encoding) { return self; }
 
-      self.encoding = encoding;
+      Opal.set_encoding(self, encoding);
+
       return self;
     }
   end

--- a/opal/corelib/string/encoding.rb
+++ b/opal/corelib/string/encoding.rb
@@ -23,9 +23,7 @@ class Encoding
     encoding
   end
 
-  class << self
-    attr_accessor :default_external
-  end
+  singleton_class.attr_accessor :default_external
 
   attr_reader :name, :names
 

--- a/opal/corelib/string/encoding.rb
+++ b/opal/corelib/string/encoding.rb
@@ -2,9 +2,12 @@ require 'corelib/string'
 
 class Encoding
   def self.register(name, options = {}, &block)
-    names    = [name] + (options[:aliases] || [])
-    encoding = Class.new(self, &block)
-                    .new(name, names, options[:ascii] || false, options[:dummy] || false)
+    names = [name] + (options[:aliases] || [])
+    ascii = options[:ascii] || false
+    dummy = options[:dummy] || false
+
+    encoding = new(name, names, ascii, dummy)
+    encoding.instance_eval(&block)
 
     register = `Opal.encodings`
     names.each do |encoding_name|

--- a/spec/lib/compiler_spec.rb
+++ b/spec/lib/compiler_spec.rb
@@ -464,9 +464,9 @@ RSpec.describe Opal::Compiler do
     end
   end
 
-  describe '#magic_comment_flags' do
+  describe '#magic_comments' do
     def expect_magic_comments_for(*lines)
-      expect(compiler_for(lines.join("\n")).magic_comment_flags)
+      expect(compiler_for(lines.join("\n")).magic_comments)
     end
 
     it 'extracts them in a hash' do

--- a/spec/lib/compiler_spec.rb
+++ b/spec/lib/compiler_spec.rb
@@ -582,14 +582,15 @@ RSpec.describe Opal::Compiler do
       context 'valid sequence' do
         let(:string) { "\xFF" }
 
-        include_examples 'it compiles the string as', '"\xFF".$force_encoding("ASCII-8BIT")'
+        include_examples 'it compiles the string as', '$enc("\xFF", "ASCII-8BIT")'
         include_examples 'it does not print any warnings'
       end
 
       context 'unicode sequence' do
         let(:string) { 'λ' }
+        encoded_string = 'λ'.force_encoding("ascii-8bit")
 
-        include_examples 'it compiles the string as', 'λ'.force_encoding("ascii-8bit").inspect + '.$force_encoding("ASCII-8BIT")'
+        include_examples 'it compiles the string as', "$enc(#{encoded_string.inspect}, \"ASCII-8BIT\")"
         include_examples 'it does not print any warnings'
       end
     end

--- a/spec/opal/core/runtime/string_spec.rb
+++ b/spec/opal/core/runtime/string_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe "Runtime String helpers" do
+  context 'Opal.enc' do
+    it 'sets the encoding boxing literal strings' do
+      -> {
+        `Opal.enc("foo", 'UTF-8')`
+      }.should_not raise_error
+    end
+  end
+
+  context 'Opal.set_encoding' do
+    it 'sets the encoding for boxed strings' do
+      expect(`Opal.set_encoding(new String("foo"), 'UTF-8')`.encoding).to eq(Encoding::UTF_8)
+      expect(`Opal.set_encoding("foo".$dup(), 'UTF-8')`.encoding).to eq(Encoding::UTF_8)
+      expect(`Opal.set_encoding("foo".$clone(), 'UTF-8')`.encoding).to eq(Encoding::UTF_8)
+    end
+
+    it 'raises FrozenError when provided a literal' do
+      -> {
+        `Opal.set_encoding("foo", 'UTF-8')`
+      }.should raise_error(FrozenError)
+    end
+  end
+end


### PR DESCRIPTION
_Continuing work from #1959_

Strict-mode is now a compiler option that can be enabled via magic comments and will default to `true` in a future version.

Code to set the encoding of a String has been moved to the runtime and used in the compiler as a helper. String literals will now raise FrozenError when trying to set the encoding on them.