### PR TITLE
Allow calling define_method from the top object

### DIFF
--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -2429,6 +2429,15 @@
   // Instantiate the main object
   Opal.top = new _Object();
   Opal.top.$to_s = Opal.top.$inspect = function() { return 'main' };
+  Opal.top.$define_method = top_define_method;
+
+  // Foward calls to define_method on the top object to Object
+  function top_define_method() {
+    var args = Opal.slice.call(arguments, 0, arguments.length);
+    var block = top_define_method.$$p;
+    top_define_method.$$p = null;
+    return Opal.send(_Object, 'define_method', args, block)
+  };
 
 
   // Nil

--- a/spec/opal/core/runtime/main_methods_spec.rb
+++ b/spec/opal/core/runtime/main_methods_spec.rb
@@ -10,8 +10,13 @@ def some_top_level_method_is_defined
   42
 end
 
+define_method :some_other_main_method do
+  0.1618
+end
+
 describe "Defining normal methods at the top level" do
   it "should define them on Object, not main" do
+    $OPAL_TOP_LEVEL_OBJECT.some_top_level_method_is_defined.should == 42
     Object.new.some_top_level_method_is_defined.should == 42
   end
 end
@@ -23,5 +28,12 @@ describe "Defining singleton methods on main" do
 
   it "should not define the method for all Objects" do
     lambda { Object.new.some_main_method }.should raise_error(NoMethodError)
+  end
+end
+
+describe "Defining methods on main with define_method" do
+  it "should define it on main directly" do
+    $OPAL_TOP_LEVEL_OBJECT.some_other_main_method.should == 0.1618
+    Object.new.some_other_main_method.should == 0.1618
   end
 end


### PR DESCRIPTION
MRI defines it on the singleton object and makes it a proxy for
Object.define_method. This implementation does not support wrapped
requires.

Fixes #2028 