### PR TITLE
Fix Number#round for Integers

### DIFF
--- a/opal/corelib/number.rb
+++ b/opal/corelib/number.rb
@@ -631,7 +631,7 @@ class Number < Numeric
         }
 
         var f = Math.pow(10, ndigits),
-            x = Math.floor((Math.abs(x) + f / 2) / f) * f;
+            x = Math.floor((Math.abs(self) + f / 2) / f) * f;
 
         return self < 0 ? -x : x;
       }


### PR DESCRIPTION
Fixing a small mistake which triggered my closure compiler.

Was:
```
>> 8099.round(-1)
=> NaN
>>
``` 
Is:
```
>> 8099.round(-1)
=> 8100
>>
```