### PR TITLE
Bump parser to 2.6 for rubocop-support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,5 +51,5 @@ group :doc do
 end
 
 platforms :ruby, :mswin, :mswin64, :mingw, :x64_mingw do
-  gem 'c_lexer', '2.5.3.0.0' unless RUBY_ENGINE == 'truffleruby'
+  gem 'c_lexer', '~> 2.6' unless RUBY_ENGINE == 'truffleruby'
 end

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -5,3 +5,6 @@ Whitespace conventions:
 - 1 spaces before normal text
 -->
 
+### Changed
+
+- Relaxed parser version requirement (#2013)

--- a/opal.gemspec
+++ b/opal.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3'
 
   spec.add_dependency 'ast', '>= 2.3.0'
-  spec.add_dependency 'parser', '= 2.5.3.0'
+  spec.add_dependency 'parser', '~> 2.6'
 
   spec.add_development_dependency 'sourcemap', '~> 0.1.0'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
Backport of #2013 