### PR TITLE
Reduce size of compiled code skipping unused helpers

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,8 @@ Whitespace conventions:
 - Basic support for `uplevel:` keyword argument in `Kernel#warn` (#2006)
 - Added a `#respond_to_missing?` implementation for `BasicObject`, `Delegator`, `OpenStruct`, that's meant for future support in the Opal runtime, which currently ignores it (#2007)
 - `Opal::Compiler#magic_comments` that allows to access magic-comments format and converts it to a hash
+- Use magic-comments to declare helpers required by the file
+
 
 ### Fixed
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -11,6 +11,8 @@ Whitespace conventions:
 - Added a `#respond_to_missing?` implementation for `BasicObject`, `Delegator`, `OpenStruct`, that's meant for future support in the Opal runtime, which currently ignores it (#2007)
 - `Opal::Compiler#magic_comments` that allows to access magic-comments format and converts it to a hash
 - Use magic-comments to declare helpers required by the file
+- `Opal.$$` is now a shortcut for `Opal.const_get_relative`
+- `Opal.$$$` is now a shortcut for `Opal.const_get_qualified`
 
 
 ### Fixed
@@ -44,4 +46,5 @@ Whitespace conventions:
 - Nashorn has been deprecated but GraalVM still supports it (#1997)
 - "opal/mini" now includes "opal/io" (#2002)
 - Regexps assigned to constants are now frozen (#2007)
-
+- `Opal.$$` changed from being the constant cache of Object to being a shortcut
+  for `Opal.const_get_relative`

--- a/lib/opal/compiler.rb
+++ b/lib/opal/compiler.rb
@@ -238,7 +238,10 @@ module Opal
     #
     # @return [Set<Symbol>]
     def helpers
-      @helpers ||= Set.new(%i[breaker slice])
+      @helpers ||= Set.new(
+        %i[breaker slice] +
+        magic_comments[:helpers].to_s.split(',').map { |h| h.strip.to_sym }
+      )
     end
 
     # Operator helpers

--- a/lib/opal/compiler.rb
+++ b/lib/opal/compiler.rb
@@ -239,7 +239,6 @@ module Opal
     # @return [Set<Symbol>]
     def helpers
       @helpers ||= Set.new(
-        %i[breaker slice] +
         magic_comments[:helpers].to_s.split(',').map { |h| h.strip.to_sym }
       )
     end

--- a/lib/opal/magic_comments.rb
+++ b/lib/opal/magic_comments.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module Opal::MagicComments
-  MAGIC_COMMENT_RE = /\A# *(\w+) *: *(\w+) *$/.freeze
-  EMACS_MAGIC_COMMENT_RE = /\A# *-\*- *(\w+) *: *(\w+) *-\*- *$/.freeze
+  MAGIC_COMMENT_RE = /\A# *(\w+) *: *(\S+.*?) *$/.freeze
+  EMACS_MAGIC_COMMENT_RE = /\A# *-\*- *(\w+) *: *(\S+.*?) *-\*- *$/.freeze
 
   def self.parse(sexp, comments)
     flags = {}

--- a/lib/opal/nodes/logic.rb
+++ b/lib/opal/nodes/logic.rb
@@ -85,6 +85,7 @@ module Opal
       end
 
       def compile_iter
+        helper :slice
         push "return #{scope.identity}.apply(null, $slice.call(arguments))"
       end
     end

--- a/lib/opal/nodes/masgn.rb
+++ b/lib/opal/nodes/masgn.rb
@@ -51,6 +51,7 @@ module Opal
 
           if post_splat.empty? # trailing splat
             if part = splat.children[0]
+              helper :slice
               part = part.dup << s(:js_tmp, "$slice.call(#{array}, #{pre_splat.size})")
               push ', '
               push expr(part)
@@ -61,6 +62,7 @@ module Opal
             push ", #{tmp} = (#{tmp} < #{pre_splat.size}) ? #{pre_splat.size} : #{tmp}"
 
             if part = splat.children[0]
+              helper :slice
               part = part.dup << s(:js_tmp, "$slice.call(#{array}, #{pre_splat.size}, #{tmp})")
               push ', '
               push expr(part)

--- a/lib/opal/nodes/top.rb
+++ b/lib/opal/nodes/top.rb
@@ -29,8 +29,8 @@ module Opal
             add_temp '$nesting = []'
           end
           add_temp 'nil = Opal.nil'
-          add_temp '$$$ = Opal.const_get_qualified'
-          add_temp '$$ = Opal.const_get_relative'
+          add_temp '$$$ = Opal.$$$'
+          add_temp '$$ = Opal.$$'
 
           add_used_helpers
           add_used_operators

--- a/lib/opal/nodes/top.rb
+++ b/lib/opal/nodes/top.rb
@@ -77,8 +77,7 @@ module Opal
       end
 
       def add_used_helpers
-        helpers = compiler.helpers.to_a
-        helpers.to_a.each { |h| add_temp "$#{h} = Opal.#{h}" }
+        compiler.helpers.to_a.each { |h| add_temp "$#{h} = Opal.#{h}" }
       end
 
       def add_used_operators

--- a/opal/corelib/enumerator.rb
+++ b/opal/corelib/enumerator.rb
@@ -1,3 +1,5 @@
+# helpers: breaker, slice
+
 require 'corelib/enumerable'
 
 class Enumerator

--- a/opal/corelib/proc.rb
+++ b/opal/corelib/proc.rb
@@ -1,3 +1,5 @@
+# helpers: slice
+
 class Proc < `Function`
   `Opal.defineProperty(self.$$prototype, '$$is_proc', true)`
   `Opal.defineProperty(self.$$prototype, '$$is_lambda', false)`

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -372,6 +372,10 @@
     throw Opal.NameError.$new("constant "+cref+"::"+cref.$name()+" not defined");
   };
 
+  // Setup some shortcuts to reduce compiled size
+  Opal.$$ = Opal.const_get_relative;
+  Opal.$$$ = Opal.const_get_qualified;
+
 
   // Modules & Classes
   // -----------------
@@ -2423,11 +2427,6 @@
   // Make Kernel#require immediately available as it's needed to require all the
   // other corelib files.
   $defineProperty(_Object.$$prototype, '$require', Opal.require);
-
-  // Add a short helper to navigate constants manually.
-  // @example
-  //   Opal.$$.Regexp.$$.IGNORECASE
-  Opal.$$ = _Object.$$;
 
   // Instantiate the main object
   Opal.top = new _Object();

--- a/opal/corelib/time.rb
+++ b/opal/corelib/time.rb
@@ -1,3 +1,5 @@
+# helpers: slice
+
 require 'corelib/comparable'
 
 class Time < `Date`

--- a/spec/lib/compiler_spec.rb
+++ b/spec/lib/compiler_spec.rb
@@ -507,6 +507,20 @@ RSpec.describe Opal::Compiler do
         biz: "boz"
       )
     end
+
+    it 'accepts complex values' do
+      expect_magic_comments_for("").to eq({})
+
+      expect_magic_comments_for(
+        "#baz:  qux,naz!",
+        "#biz : boz?  ,bux,   []=",
+        "#buz  :<<,+,!@",
+      ).to eq(
+        baz: "qux,naz!",
+        biz: "boz?  ,bux,   []=",
+        buz: "<<,+,!@",
+      )
+    end
   end
 
   describe 'magic encoding comment' do

--- a/spec/lib/source_map/file_spec.rb
+++ b/spec/lib/source_map/file_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Opal::SourceMap::File do
       fragment(line: nil, column: nil, source_map_name: nil, code: "\n", sexp_type: :top),
       fragment(line: nil, column: nil, source_map_name: nil, code: "(function(Opal) {", sexp_type: :top),
       fragment(line: nil, column: nil, source_map_name: nil, code: "\n  ", sexp_type: :top),
-      fragment(line: nil, column: nil, source_map_name: nil, code: "var self = Opal.top, $nesting = [], nil = Opal.nil, $$$ = Opal.const_get_qualified, $$ = Opal.const_get_relative, $breaker = Opal.breaker, $slice = Opal.slice;\n", sexp_type: :top),
+      fragment(line: nil, column: nil, source_map_name: nil, code: "var self = Opal.top, $nesting = [], nil = Opal.nil, $$$ = Opal.$$$, $$ = Opal.$$, $breaker = Opal.breaker, $slice = Opal.slice;\n", sexp_type: :top),
       fragment(line: nil, column: nil, source_map_name: nil, code: "\n  ", sexp_type: :top),
       fragment(line: nil, column: nil, source_map_name: nil, code: "Opal.add_stubs(['$puts']);", sexp_type: :top),
       fragment(line: nil, column: nil, source_map_name: nil, code: "\n  ", sexp_type: :top),


### PR DESCRIPTION
- Use magic-comments to require helpers, skip them otherwise (break, slice)
- Reduce the size of the constant getters Opal property name

I attempted to make `nil` into an optional helper, but it's so ubiquitous that I eventually gave up.