### PR TITLE
Restore .call(this) to restore minimal JS environment compatibility

### DIFF
--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -2454,4 +2454,4 @@
   Opal.breaker  = new Error('unexpected break (old)');
   Opal.returner = new Error('unexpected return');
   TypeError.$$super = Error;
-}).call();
+}).call(this);


### PR DESCRIPTION
Please read https://github.com/opal/opal/issues/2042 for description of the issue.