### PR TITLE
Fix PathReader when a file is missing

### DIFF
--- a/lib/opal/builder.rb
+++ b/lib/opal/builder.rb
@@ -195,16 +195,8 @@ module Opal
 
       source = stub?(rel_path) ? '' : read(rel_path)
 
-      if source.nil?
-        message = "can't find file: #{rel_path.inspect}"
-        case missing_require_severity
-        when :error   then raise LoadError, message
-        when :warning then warn "can't find file: #{rel_path.inspect}"
-        when :ignore  then # noop
-        end
-
-        return # the handling is delegated to the runtime
-      end
+      # The handling is delegated to the runtime
+      return if source.nil?
 
       abs_path = expand_path(rel_path)
       rel_path = expand_ext(rel_path)

--- a/lib/opal/path_reader.rb
+++ b/lib/opal/path_reader.rb
@@ -17,7 +17,7 @@ module Opal
     def read(path)
       full_path = expand(path)
       return nil if full_path.nil?
-      File.open(full_path, 'rb:UTF-8', &:read)
+      File.open(full_path, 'rb:UTF-8', &:read) if File.exist?(full_path)
     end
 
     def expand(path)


### PR DESCRIPTION
When a file is missing and hasn't been stubbed the builder will try to read it anyway instead of relying on the "missing_require_severity" configuration value.