### PR TITLE
Make Kernel#require overwritable.

### DIFF
--- a/opal/corelib/kernel.rb
+++ b/opal/corelib/kernel.rb
@@ -691,5 +691,9 @@ module Kernel
 end
 
 class Object
+  # Object.require has been set to runtime.js Opal.require
+  # Now we have Kernel, make sure Object.require refers to Kernel#require
+  # which is what ruby does and makes Kernel#require overwritable
+  `delete Opal.Object.$$prototype.$require`
   include Kernel
 end

--- a/opal/corelib/kernel.rb
+++ b/opal/corelib/kernel.rb
@@ -691,7 +691,7 @@ module Kernel
 end
 
 class Object
-  # Object.require has been set to runtime.js Opal.require
+  # Object#require has been set to runtime.js Opal.require
   # Now we have Kernel, make sure Object.require refers to Kernel#require
   # which is what ruby does and makes Kernel#require overwritable
   `delete Opal.Object.$$prototype.$require`

--- a/opal/corelib/kernel.rb
+++ b/opal/corelib/kernel.rb
@@ -692,7 +692,7 @@ end
 
 class Object
   # Object#require has been set to runtime.js Opal.require
-  # Now we have Kernel, make sure Object.require refers to Kernel#require
+  # Now Kernel is active, make sure Kernel#require is used
   # which is what ruby does and makes Kernel#require overwritable
   `delete Opal.Object.$$prototype.$require`
   include Kernel


### PR DESCRIPTION
Kernel#require was masked by Opal.require via Object#require.
This patch makes sure require is passed to Kernel#require, which can then be overwritten.
Overwriting Kernel#require is used by the (opal-)zeitwerk autoloader.