### PR TITLE
Fix parsing unicode on v1.0

### DIFF
--- a/lib/opal/parser/patch.rb
+++ b/lib/opal/parser/patch.rb
@@ -1,6 +1,21 @@
 # frozen_string_literal: true
 
 if RUBY_ENGINE == 'opal'
+  class Parser::Lexer
+    def source_buffer=(source_buffer)
+      @source_buffer = source_buffer
+
+      if @source_buffer
+        source = @source_buffer.source
+        # Force UTF8 unpacking even if JS works with UTF-16/UCS-2
+        # See: https://mathiasbynens.be/notes/javascript-encoding
+        @source_pts = source.unpack('U*')
+      else
+        @source_pts = nil
+      end
+    end
+  end
+
   class Parser::Lexer::Literal
     undef :extend_string
 

--- a/spec/opal/compiler/unicode_spec.rb
+++ b/spec/opal/compiler/unicode_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+require 'opal-parser'
+
+describe Opal::Compiler do
+  describe "unicode support" do
+    it 'can compile code containing Unicode characters' do
+      -> { Opal::Compiler.new("'こんにちは'; p 1").compile }.should_not raise_error
+    end
+  end
+end


### PR DESCRIPTION
_backport of #2073_

JavaScript works with UTF-16/UCS-2 and the strings we're passing to
the lexer ar not UTF-8, so the lexer tries to unpack them as 8-bit
chars, messing up the source ranges in which to look for pieces of
code and ultimately shifting all source lookups after having
encountered a unicode string.

E.g.:

```rb
  # the string '5' is reported at index 10 when using C*, 6 with U*
  "123️⃣45".unpack('C*').index('5'.unpack('C*').first) # => 10
  "123️⃣45".unpack('U*').index('5'.unpack('U*').first) # => 6
```