### PR TITLE
Move some Opal helpers to the Runtime

### DIFF
--- a/lib/opal/nodes/args/arity_check.rb
+++ b/lib/opal/nodes/args/arity_check.rb
@@ -29,9 +29,10 @@ module Opal
         return unless compiler.arity_check?
 
         unless arity_checks.empty?
+          helper :ac
           meth = scope.mid.to_s.inspect
           line 'var $arity = arguments.length;'
-          push " if (#{arity_checks.join(' || ')}) { Opal.ac($arity, #{arity}, this, #{meth}); }"
+          push " if (#{arity_checks.join(' || ')}) { $ac($arity, #{arity}, this, #{meth}); }"
         end
       end
 

--- a/opal/corelib/array.rb
+++ b/opal/corelib/array.rb
@@ -1,4 +1,4 @@
-# helpers: truthy, falsy, hash_ids, yield1, hash_get, hash_put, hash_delete, coerce_to
+# helpers: truthy, falsy, hash_ids, yield1, hash_get, hash_put, hash_delete, coerce_to, respond_to
 
 require 'corelib/enumerable'
 require 'corelib/numeric'
@@ -260,7 +260,7 @@ class Array < `Array`
           return true;
 
         if (!other.$$is_array) {
-          if (#{Opal.respond_to? `other`, :to_ary}) {
+          if ($respond_to(other, '$to_ary')) {
             return #{`other` == `array`};
           } else {
             return false;
@@ -1117,7 +1117,7 @@ class Array < `Array`
         for (i = 0, length = array.length; i < length; i++) {
           item = array[i];
 
-          if (!#{Opal.respond_to? `item`, :to_ary, true}) {
+          if (!$respond_to(item, '$to_ary', true)) {
             result.push(item);
             continue;
           }
@@ -1324,7 +1324,7 @@ class Array < `Array`
       for (i = 0, length = self.length; i < length; i++) {
         item = self[i];
 
-        if (#{Opal.respond_to? `item`, :to_str}) {
+        if ($respond_to(item, '$to_str')) {
           tmp = #{`item`.to_str};
 
           if (tmp !== nil) {
@@ -1334,7 +1334,7 @@ class Array < `Array`
           }
         }
 
-        if (#{Opal.respond_to? `item`, :to_ary}) {
+        if ($respond_to(item, '$to_ary')) {
           tmp = #{`item`.to_ary};
 
           if (tmp === self) {
@@ -1348,7 +1348,7 @@ class Array < `Array`
           }
         }
 
-        if (#{Opal.respond_to? `item`, :to_s}) {
+        if ($respond_to(item, '$to_s')) {
           tmp = #{`item`.to_s};
 
           if (tmp !== nil) {

--- a/opal/corelib/array.rb
+++ b/opal/corelib/array.rb
@@ -1,4 +1,4 @@
-# helpers: truthy, falsy, hash_ids, yield1, hash_get, hash_put, hash_delete
+# helpers: truthy, falsy, hash_ids, yield1, hash_get, hash_put, hash_delete, coerce_to
 
 require 'corelib/enumerable'
 require 'corelib/numeric'
@@ -80,7 +80,7 @@ class Array < `Array`
         }
       }
 
-      size = #{Opal.coerce_to size, Integer, :to_int}
+      size = $coerce_to(size, #{Integer}, 'to_int');
 
       if (size < 0) {
         #{raise ArgumentError, 'negative array size'}
@@ -113,7 +113,7 @@ class Array < `Array`
     other = if Array === other
               other.to_a
             else
-              Opal.coerce_to(other, Array, :to_ary).to_a
+              `$coerce_to(other, #{Array}, 'to_ary')`.to_a
             end
 
     %x{
@@ -138,7 +138,7 @@ class Array < `Array`
     other = if Array === other
               other.to_a
             else
-              Opal.coerce_to(other, Array, :to_ary).to_a
+              `$coerce_to(other, #{Array}, 'to_ary')`.to_a
             end
 
     %x{
@@ -159,7 +159,7 @@ class Array < `Array`
   def *(other)
     return join(other.to_str) if other.respond_to? :to_str
 
-    other = Opal.coerce_to other, Integer, :to_int
+    other = `$coerce_to(other, #{Integer}, 'to_int')`
 
     if `other < 0`
       raise ArgumentError, 'negative argument'
@@ -181,7 +181,7 @@ class Array < `Array`
     other = if Array === other
               other.to_a
             else
-              Opal.coerce_to(other, Array, :to_ary).to_a
+              `$coerce_to(other, #{Array}, 'to_ary')`.to_a
             end
 
     `self.concat(other)`
@@ -191,7 +191,7 @@ class Array < `Array`
     other = if Array === other
               other.to_a
             else
-              Opal.coerce_to(other, Array, :to_ary).to_a
+              `$coerce_to(other, #{Array}, 'to_ary')`.to_a
             end
 
     return [] if `self.length === 0`
@@ -310,8 +310,8 @@ class Array < `Array`
           exclude, from, to, result;
 
       exclude = index.excl;
-      from    = Opal.Opal.$coerce_to(index.begin, Opal.Integer, 'to_int');
-      to      = Opal.Opal.$coerce_to(index.end, Opal.Integer, 'to_int');
+      from    = $coerce_to(index.begin, Opal.Integer, 'to_int');
+      to      = $coerce_to(index.end, Opal.Integer, 'to_int');
 
       if (from < 0) {
         from += size;
@@ -345,7 +345,7 @@ class Array < `Array`
       var size = self.length,
           exclude, from, to, result;
 
-      index = Opal.Opal.$coerce_to(index, Opal.Integer, 'to_int');
+      index = $coerce_to(index, Opal.Integer, 'to_int');
 
       if (index < 0) {
         index += size;
@@ -363,7 +363,7 @@ class Array < `Array`
         return self[index];
       }
       else {
-        length = Opal.Opal.$coerce_to(length, Opal.Integer, 'to_int');
+        length = $coerce_to(length, Opal.Integer, 'to_int');
 
         if (length < 0 || index > size || index < 0) {
           return nil;
@@ -402,8 +402,8 @@ class Array < `Array`
 
       %x{
         var exclude = index.excl,
-            from    = #{Opal.coerce_to `index.begin`, Integer, :to_int},
-            to      = #{Opal.coerce_to `index.end`, Integer, :to_int};
+            from    = $coerce_to(index.begin, #{Integer}, 'to_int'),
+            to      = $coerce_to(index.end, #{Integer}, 'to_int');
 
         if (from < 0) {
           from += size;
@@ -455,8 +455,8 @@ class Array < `Array`
       %x{
         var old;
 
-        index  = #{Opal.coerce_to index, Integer, :to_int};
-        length = #{Opal.coerce_to length, Integer, :to_int};
+        index  = $coerce_to(index, #{Integer}, 'to_int');
+        length = $coerce_to(length, #{Integer}, 'to_int');
 
         if (index < 0) {
           old    = index;
@@ -507,9 +507,9 @@ class Array < `Array`
   end
 
   def at(index)
-    index = Opal.coerce_to index, Integer, :to_int
-
     %x{
+      index = $coerce_to(index, #{Integer}, 'to_int')
+
       if (index < 0) {
         index += self.length;
       }
@@ -790,7 +790,7 @@ class Array < `Array`
       other = if Array === other
                 other.to_a
               else
-                Opal.coerce_to(other, Array, :to_ary).to_a
+                `$coerce_to(other, #{Array}, 'to_ary')`.to_a
               end
 
       if other.equal?(self)
@@ -836,7 +836,7 @@ class Array < `Array`
 
   def delete_at(index)
     %x{
-      index = #{Opal.coerce_to `index`, Integer, :to_int};
+      index = $coerce_to(index, #{Integer}, 'to_int');
 
       if (index < 0) {
         index += self.length;
@@ -976,7 +976,7 @@ class Array < `Array`
     %x{
       var original = index;
 
-      index = #{Opal.coerce_to `index`, Integer, :to_int};
+      index = $coerce_to(index, #{Integer}, 'to_int');
 
       if (index < 0) {
         index += self.length;
@@ -1031,22 +1031,22 @@ class Array < `Array`
     if Range === one
       raise TypeError, 'length invalid with range' if two
 
-      left   = Opal.coerce_to one.begin, Integer, :to_int
+      left   = `$coerce_to(one.begin, #{Integer}, 'to_int')`
       `left += this.length` if `left < 0`
       raise RangeError, "#{one.inspect} out of range" if `left < 0`
 
-      right = Opal.coerce_to one.end, Integer, :to_int
+      right = `$coerce_to(one.end, #{Integer}, 'to_int')`
       `right += this.length` if `right < 0`
       `right += 1` unless one.exclude_end?
 
       return self if `right <= left`
     elsif one
-      left   = Opal.coerce_to one, Integer, :to_int
+      left   = `$coerce_to(one, #{Integer}, 'to_int')`
       `left += this.length` if `left < 0`
       left   = 0 if `left < 0`
 
       if two
-        right = Opal.coerce_to two, Integer, :to_int
+        right = `$coerce_to(two, #{Integer}, 'to_int')`
 
         return self if `right == 0`
 
@@ -1095,7 +1095,7 @@ class Array < `Array`
         return self.length === 0 ? nil : self[0];
       }
 
-      count = #{Opal.coerce_to `count`, Integer, :to_int};
+      count = $coerce_to(count, #{Integer}, 'to_int');
 
       if (count < 0) {
         #{raise ArgumentError, 'negative array size'};
@@ -1152,7 +1152,7 @@ class Array < `Array`
       }
 
       if (level !== undefined) {
-        level = #{Opal.coerce_to(`level`, Integer, :to_int)};
+        level = $coerce_to(level, #{Integer}, 'to_int');
       }
 
       return toArraySubclass(_flatten(self, level), #{self.class});
@@ -1267,7 +1267,7 @@ class Array < `Array`
 
   def insert(index, *objects)
     %x{
-      index = #{Opal.coerce_to `index`, Integer, :to_int};
+      index = $coerce_to(index, #{Integer}, 'to_int');
 
       if (objects.length > 0) {
         if (index < 0) {
@@ -1382,7 +1382,7 @@ class Array < `Array`
         return self.length === 0 ? nil : self[self.length - 1];
       }
 
-      count = #{Opal.coerce_to `count`, Integer, :to_int};
+      count = $coerce_to(count, #{Integer}, 'to_int');
 
       if (count < 0) {
         #{raise ArgumentError, 'negative array size'};
@@ -1439,7 +1439,7 @@ class Array < `Array`
         num = self.length;
       }
       else {
-        num = #{ Opal.coerce_to num, Integer, :to_int }
+        num = $coerce_to(num, #{Integer}, 'to_int');
       }
 
       if (num < 0 || self.length < num) {
@@ -1525,7 +1525,7 @@ class Array < `Array`
       return `self.pop()`
     end
 
-    count = Opal.coerce_to count, Integer, :to_int
+    count = `$coerce_to(count, #{Integer}, 'to_int')`
 
     if `count < 0`
       raise ArgumentError, 'negative array size'
@@ -1551,7 +1551,7 @@ class Array < `Array`
 
       arrays[0] = self;
       for (i = 1; i < n; i++) {
-        arrays[i] = #{Opal.coerce_to(`args[i - 1]`, Array, :to_ary)};
+        arrays[i] = $coerce_to(args[i - 1], #{Array}, 'to_ary');
       }
 
       for (i = 0; i < n; i++) {
@@ -1650,7 +1650,7 @@ class Array < `Array`
     other = if Array === other
               other.to_a
             else
-              Opal.coerce_to(other, Array, :to_ary).to_a
+              `$coerce_to(other, #{Array}, 'to_ary')`.to_a
             end
 
     %x{
@@ -1716,9 +1716,10 @@ class Array < `Array`
   end
 
   def rotate(n = 1)
-    n = Opal.coerce_to n, Integer, :to_int
     %x{
       var ary, idx, firstPart, lastPart;
+
+      n = $coerce_to(n, #{Integer}, 'to_int')
 
       if (self.length === 1) {
         return self.slice();
@@ -1741,8 +1742,8 @@ class Array < `Array`
       if (self.length === 0 || self.length === 1) {
         return self;
       }
+      cnt = $coerce_to(cnt, #{Integer}, 'to_int');
     }
-    cnt = Opal.coerce_to cnt, Integer, :to_int
     ary = rotate(cnt)
     replace ary
   end
@@ -1753,7 +1754,7 @@ class Array < `Array`
     end
 
     def rand(size)
-      random = Opal.coerce_to @rng.rand(size), Integer, :to_int
+      random = `$coerce_to(#{@rng.rand(size)}, #{Integer}, 'to_int')`
       raise RangeError, 'random value must be >= 0' if `random < 0`
       raise RangeError, 'random value must be less than Array size' unless `random < size`
 
@@ -1770,11 +1771,11 @@ class Array < `Array`
         count = nil
       else
         options = nil
-        count = Opal.coerce_to count, Integer, :to_int
+        count = `$coerce_to(count, #{Integer}, 'to_int')`
       end
     else
-      count = Opal.coerce_to count, Integer, :to_int
-      options = Opal.coerce_to options, Hash, :to_hash
+      count = `$coerce_to(count, #{Integer}, 'to_int')`
+      options = `$coerce_to(options, #{Hash}, 'to_hash')`
     end
 
     if count && `count < 0`
@@ -1908,7 +1909,7 @@ class Array < `Array`
       return `self.shift()`
     end
 
-    count = Opal.coerce_to count, Integer, :to_int
+    count = `$coerce_to(count, #{Integer}, 'to_int')`
 
     if `count < 0`
       raise ArgumentError, 'negative array size'
@@ -1976,8 +1977,8 @@ class Array < `Array`
         range = index
         result = self[range]
 
-        range_start = Opal.coerce_to(range.begin, Integer, :to_int)
-        range_end = Opal.coerce_to(range.end, Integer, :to_int)
+        range_start = `$coerce_to(range.begin, #{Integer}, 'to_int')`
+        range_end = `$coerce_to(range.end, #{Integer}, 'to_int')`
 
         %x{
           if (range_start < 0) {
@@ -2005,7 +2006,7 @@ class Array < `Array`
           }
         }
       else
-        start = Opal.coerce_to(index, Integer, :to_int)
+        start = `$coerce_to(index, #{Integer}, 'to_int')`
         %x{
           if (start < 0) {
             start += self.length;
@@ -2025,8 +2026,8 @@ class Array < `Array`
         }
       end
     else
-      start = Opal.coerce_to(index, Integer, :to_int)
-      length = Opal.coerce_to(length, Integer, :to_int)
+      start = `$coerce_to(index, #{Integer}, 'to_int')`
+      length = `$coerce_to(length, #{Integer}, 'to_int')`
 
       %x{
         if (length < 0) {
@@ -2170,7 +2171,7 @@ class Array < `Array`
       row = if Array === row
               row.to_a
             else
-              Opal.coerce_to(row, Array, :to_ary).to_a
+              `$coerce_to(row, #{Array}, 'to_ary')`.to_a
             end
 
       max ||= `row.length`
@@ -2253,8 +2254,8 @@ class Array < `Array`
 
     args.each do |elem|
       if elem.is_a? Range
-        finish = Opal.coerce_to elem.last, Integer, :to_int
-        start = Opal.coerce_to elem.first, Integer, :to_int
+        finish = `$coerce_to(#{elem.last}, #{Integer}, 'to_int')`
+        start = `$coerce_to(#{elem.first}, #{Integer}, 'to_int')`
 
         %x{
           if (start < 0) {
@@ -2277,7 +2278,7 @@ class Array < `Array`
 
         start.upto(finish) { |i| out << at(i) }
       else
-        i = Opal.coerce_to elem, Integer, :to_int
+        i = `$coerce_to(elem, #{Integer}, 'to_int')`
         out << at(i)
       end
     end

--- a/opal/corelib/array/pack.rb
+++ b/opal/corelib/array/pack.rb
@@ -1,3 +1,5 @@
+# helpers: coerce_to
+
 require 'corelib/pack_unpack/format_string_parser'
 
 class Array
@@ -91,7 +93,7 @@ class Array
         var buffer = callback(data);
 
         return buffer.map(function(item) {
-          return #{Opal.coerce_to `item`, Integer, :to_int}
+          return $coerce_to(item, #{Integer}, 'to_int')
         });
       }
     }
@@ -101,7 +103,7 @@ class Array
         var buffer = callback(data);
 
         return buffer.map(function(item) {
-          return #{Opal.coerce_to `item`, String, :to_str}
+          return $coerce_to(item, #{String}, 'to_str')
         });
       }
     }
@@ -225,7 +227,7 @@ class Array
         } else if (source === undefined) {
           #{raise ArgumentError, 'too few arguments'};
         } else {
-          source = #{Opal.coerce_to `source`, String, :to_str};
+          source = $coerce_to(source, #{String}, 'to_str');
         }
 
         buffer = buffer.slice(1, buffer.length);

--- a/opal/corelib/enumerable.rb
+++ b/opal/corelib/enumerable.rb
@@ -1,4 +1,4 @@
-# helpers: falsy, truthy
+# helpers: falsy, truthy, coerce_to
 
 module Enumerable
   %x{
@@ -232,7 +232,7 @@ module Enumerable
   end
 
   def drop(number)
-    number = Opal.coerce_to number, Integer, :to_int
+    number = `$coerce_to(number, #{Integer}, 'to_int')`
 
     if `number < 0`
       raise ArgumentError, 'attempt to drop negative size'
@@ -348,7 +348,7 @@ module Enumerable
   end
 
   def each_slice(n, &block)
-    n = Opal.coerce_to n, Integer, :to_int
+    n = `$coerce_to(#{n}, #{Integer}, 'to_int')`
 
     if `n <= 0`
       raise ArgumentError, 'invalid slice size'
@@ -493,7 +493,7 @@ module Enumerable
       end
     else
       result = []
-      number = Opal.coerce_to number, Integer, :to_int
+      number = `$coerce_to(number, #{Integer}, 'to_int')`
 
       if `number < 0`
         raise ArgumentError, 'attempt to take negative size'
@@ -686,9 +686,9 @@ module Enumerable
           return result;
         }
       }
-    }
 
-    n = Opal.coerce_to(n, Integer, :to_int)
+      n = $coerce_to(n, #{Integer}, 'to_int');
+    }
 
     sort(&block).reverse.first(n)
   end

--- a/opal/corelib/enumerator.rb
+++ b/opal/corelib/enumerator.rb
@@ -1,4 +1,4 @@
-# helpers: breaker, slice, falsy, truthy
+# helpers: breaker, slice, falsy, truthy, coerce_to
 
 require 'corelib/enumerable'
 
@@ -28,7 +28,7 @@ class Enumerator
       @size   = `arguments[0] || nil`
 
       if @size && !@size.respond_to?(:call)
-        @size = Opal.coerce_to @size, Integer, :to_int
+        @size = `$coerce_to(#{@size}, #{Integer}, 'to_int')`
       end
     else
       @object = `arguments[0]`
@@ -54,7 +54,7 @@ class Enumerator
 
   def with_index(offset = 0, &block)
     offset = if offset
-               Opal.coerce_to offset, Integer, :to_int
+               `$coerce_to(offset, #{Integer}, 'to_int')`
              else
                0
              end
@@ -222,7 +222,7 @@ class Enumerator
     end
 
     def drop(n)
-      n = Opal.coerce_to n, Integer, :to_int
+      n = `$coerce_to(#{n}, #{Integer}, 'to_int')`
 
       if n < 0
         raise ArgumentError, 'attempt to drop negative size'
@@ -339,7 +339,7 @@ class Enumerator
     end
 
     def take(n)
-      n = Opal.coerce_to n, Integer, :to_int
+      n = `$coerce_to(#{n}, #{Integer}, 'to_int')`
 
       if n < 0
         raise ArgumentError, 'attempt to take negative size'

--- a/opal/corelib/helpers.rb
+++ b/opal/corelib/helpers.rb
@@ -1,22 +1,12 @@
-# helpers: type_error
+# helpers: type_error, coerce_to
 
 module Opal
   def self.bridge(constructor, klass)
     `Opal.bridge(constructor, klass)`
   end
 
-  def self.coerce_to(object, type, method, *args)
-    return object if type === object
-
-    unless object.respond_to? method
-      raise `$type_error(object, type)`
-    end
-
-    object.__send__ method, *args
-  end
-
   def self.coerce_to!(object, type, method, *args)
-    coerced = coerce_to(object, type, method, *args)
+    coerced = `$coerce_to(object, type, method, args)`
 
     unless type === coerced
       raise `$type_error(object, type, method, coerced)`
@@ -28,7 +18,7 @@ module Opal
   def self.coerce_to?(object, type, method, *args)
     return unless object.respond_to? method
 
-    coerced = coerce_to(object, type, method, *args)
+    coerced = `$coerce_to(object, type, method, args)`
 
     return if coerced.nil?
 

--- a/opal/corelib/helpers.rb
+++ b/opal/corelib/helpers.rb
@@ -90,10 +90,6 @@ module Opal
     obj.respond_to?(method, include_all)
   end
 
-  def self.inspect_obj(obj)
-    `Opal.inspect(obj)`
-  end
-
   def self.instance_variable_name!(name)
     name = Opal.coerce_to!(name, String, :to_str)
 

--- a/opal/corelib/helpers.rb
+++ b/opal/corelib/helpers.rb
@@ -1,21 +1,15 @@
+# helpers: type_error
+
 module Opal
   def self.bridge(constructor, klass)
     `Opal.bridge(constructor, klass)`
-  end
-
-  def self.type_error(object, type, method = nil, coerced = nil)
-    if method && coerced
-      TypeError.new "can't convert #{object.class} into #{type} (#{object.class}##{method} gives #{coerced.class})"
-    else
-      TypeError.new "no implicit conversion of #{object.class} into #{type}"
-    end
   end
 
   def self.coerce_to(object, type, method, *args)
     return object if type === object
 
     unless object.respond_to? method
-      raise type_error(object, type)
+      raise `$type_error(object, type)`
     end
 
     object.__send__ method, *args
@@ -25,7 +19,7 @@ module Opal
     coerced = coerce_to(object, type, method, *args)
 
     unless type === coerced
-      raise type_error(object, type, method, coerced)
+      raise `$type_error(object, type, method, coerced)`
     end
 
     coerced
@@ -39,7 +33,7 @@ module Opal
     return if coerced.nil?
 
     unless type === coerced
-      raise type_error(object, type, method, coerced)
+      raise `$type_error(object, type, method, coerced)`
     end
 
     coerced

--- a/opal/corelib/kernel.rb
+++ b/opal/corelib/kernel.rb
@@ -1,4 +1,4 @@
-# helpers: truthy
+# helpers: truthy, coerce_to
 
 module Kernel
   def method_missing(symbol, *args, &block)
@@ -202,7 +202,7 @@ module Kernel
       if (status.$$is_boolean) {
         status = status ? 0 : 1;
       } else {
-        status = #{Opal.coerce_to(status, Integer, :to_int)}
+        status = $coerce_to(status, #{Integer}, 'to_int')
       }
 
       Opal.exit(status);
@@ -341,7 +341,7 @@ module Kernel
       if (base === undefined) {
         base = 0;
       } else {
-        base = #{Opal.coerce_to(`base`, Integer, :to_int)};
+        base = $coerce_to(base, #{Integer}, 'to_int');
         if (base === 1 || base < 0 || base > 36) {
           #{raise ArgumentError, "invalid radix #{base}"}
         }

--- a/opal/corelib/kernel.rb
+++ b/opal/corelib/kernel.rb
@@ -1,4 +1,4 @@
-# helpers: truthy, coerce_to
+# helpers: truthy, coerce_to, respond_to
 
 module Kernel
   def method_missing(symbol, *args, &block)
@@ -577,22 +577,26 @@ module Kernel
   end
 
   def respond_to?(name, include_all = false)
-    return true if respond_to_missing?(name, include_all)
-
     %x{
       var body = self['$' + name];
 
       if (typeof(body) === "function" && !body.$$stub) {
         return true;
       }
-    }
 
-    false
+      if (self['$respond_to_missing?'].$$pristine === true) {
+        return false;
+      } else {
+        return #{respond_to_missing?(name, include_all)};
+      }
+    }
   end
 
   def respond_to_missing?(method_name, include_all = false)
     false
   end
+
+  Opal.pristine(self, :respond_to?, :respond_to_missing?)
 
   def require(file)
     file = Opal.coerce_to!(file, String, :to_str)

--- a/opal/corelib/kernel.rb
+++ b/opal/corelib/kernel.rb
@@ -698,6 +698,8 @@ module Kernel
     return enum_for(:yield_self) { 1 } unless block_given?
     yield self
   end
+
+  Opal.pristine(self, :method_missing)
 end
 
 class Object

--- a/opal/corelib/kernel/format.rb
+++ b/opal/corelib/kernel/format.rb
@@ -1,3 +1,5 @@
+# helpers: coerce_to
+
 module Kernel
   def format(format_string, *args)
     if args.length == 1 && args[0].respond_to?(:to_ary)
@@ -487,7 +489,7 @@ module Kernel
             if (#{`arg`.respond_to?(:to_str)}) {
               str = #{`arg`.to_str};
             } else {
-              str = String.fromCharCode(#{Opal.coerce_to(`arg`, Integer, :to_int)});
+              str = String.fromCharCode($coerce_to(arg, #{Integer}, 'to_int'));
             }
             if (str.length !== 1) {
               #{raise ArgumentError, '%c requires a character'}

--- a/opal/corelib/math.rb
+++ b/opal/corelib/math.rb
@@ -1,3 +1,5 @@
+# helpers: type_error
+
 module Math
   E  = `Math.E`
   PI = `Math.PI`
@@ -23,13 +25,13 @@ module Math
   def self.float!(value)
     Float(value)
   rescue ArgumentError
-    raise Opal.type_error(value, Float)
+    raise `$type_error(value, #{Float})`
   end
 
   def self.integer!(value)
     Integer(value)
   rescue ArgumentError
-    raise Opal.type_error(value, Integer)
+    raise `$type_error(value, #{Integer})`
   end
 
   module_function
@@ -368,14 +370,14 @@ module Math
 
   def log(x, base = undefined)
     if String === x
-      raise Opal.type_error(x, Float)
+      raise `$type_error(x, #{Float})`
     end
 
     if `base == null`
       Math.checked :log, Math.float!(x)
     else
       if String === base
-        raise Opal.type_error(base, Float)
+        raise `$type_error(base, #{Float})`
       end
 
       Math.checked(:log, Math.float!(x)) / Math.checked(:log, Math.float!(base))
@@ -392,7 +394,7 @@ module Math
 
   def log10(x)
     if String === x
-      raise Opal.type_error(x, Float)
+      raise `$type_error(x, #{Float})`
     end
 
     Math.checked :log10, Math.float!(x)
@@ -408,7 +410,7 @@ module Math
 
   def log2(x)
     if String === x
-      raise Opal.type_error(x, Float)
+      raise `$type_error(x, #{Float})`
     end
 
     Math.checked :log2, Math.float!(x)

--- a/opal/corelib/module.rb
+++ b/opal/corelib/module.rb
@@ -1,4 +1,4 @@
-# helpers: truthy
+# helpers: truthy, coerce_to
 
 class Module
   def self.allocate
@@ -84,8 +84,8 @@ class Module
   end
 
   def alias_method(newname, oldname)
-    newname = Opal.coerce_to newname, String, :to_str
-    oldname = Opal.coerce_to oldname, String, :to_str
+    newname = `$coerce_to(newname, #{String}, 'to_str')`
+    oldname = `$coerce_to(oldname, #{String}, 'to_str')`
     `Opal.alias(self, newname, oldname)`
 
     self

--- a/opal/corelib/regexp.rb
+++ b/opal/corelib/regexp.rb
@@ -1,3 +1,5 @@
+# helpers: coerce_to
+
 class RegexpError < StandardError; end
 
 class Regexp < `RegExp`
@@ -164,7 +166,7 @@ class Regexp < `RegExp`
 
       if (pos === undefined) {
         if (string === nil) return #{$~ = nil};
-        var m = self.exec(#{Opal.coerce_to(string, String, :to_str)});
+        var m = self.exec($coerce_to(string, #{String}, 'to_str'));
         if (m) {
           #{$~ = MatchData.new(`self`, `m`)};
           return block === nil ? #{$~} : #{yield $~};
@@ -173,13 +175,13 @@ class Regexp < `RegExp`
         }
       }
 
-      pos = #{Opal.coerce_to(pos, Integer, :to_int)};
+      pos = $coerce_to(pos, #{Integer}, 'to_int');
 
       if (string === nil) {
         return #{$~ = nil};
       }
 
-      string = #{Opal.coerce_to(string, String, :to_str)};
+      string = $coerce_to(string, #{String}, 'to_str');
 
       if (pos < 0) {
         pos += string.length;
@@ -212,16 +214,16 @@ class Regexp < `RegExp`
       }
 
       if (pos === undefined) {
-        return string === nil ? false : self.test(#{Opal.coerce_to(string, String, :to_str)});
+        return string === nil ? false : self.test($coerce_to(string, #{String}, 'to_str'));
       }
 
-      pos = #{Opal.coerce_to(pos, Integer, :to_int)};
+      pos = $coerce_to(pos, #{Integer}, 'to_int');
 
       if (string === nil) {
         return false;
       }
 
-      string = #{Opal.coerce_to(string, String, :to_str)};
+      string = $coerce_to(string, #{String}, 'to_str');
 
       if (pos < 0) {
         pos += string.length;

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -1709,16 +1709,28 @@
   // @param block [Function] ruby block
   // @return [Object] returning value of the method call
   Opal.send = function(recv, method, args, block) {
-    var body = (typeof(method) === 'string') ? recv['$'+method] : method;
+    var body;
 
-    if (body != null) {
-      if (typeof block === 'function') {
-        body.$$p = block;
+    if (typeof(method) === 'function') {
+      body = method;
+      method = null;
+    } else if (typeof(method) === 'string') {
+      body = recv['$'+method];
+    } else {
+      throw Opal.NameError.$new("Passed method should be a string or a function");
       }
-      return body.apply(recv, args);
+
+    return Opal.send2(recv, body, method, args, block);
+  };
+
+  Opal.send2 = function(recv, body, method, args, block) {
+    if (body == null && method != null && recv.$method_missing) {
+      body = recv.$method_missing;
+      args = [method].concat(args);
     }
 
-    return recv.$method_missing.apply(recv, [method].concat(args));
+    if (typeof block === 'function') body.$$p = block;
+    return body.apply(recv, args);
   };
 
   Opal.lambda = function(block) {

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -193,6 +193,22 @@
     return Opal.send(object, method, args);
   }
 
+  Opal.respond_to = function(obj, jsid, include_all) {
+    if (obj == null || !obj.$$class) return false;
+    include_all = !!include_all;
+    var body = obj[jsid];
+
+    if (obj['$respond_to?'].$$pristine) {
+      if (obj['$respond_to_missing?'].$$pristine) {
+        return typeof(body) === "function" && !body.$$stub;
+      } else {
+        return Opal.send(obj, obj['$respond_to_missing?'], [jsid.substr(1), include_all]);
+      }
+    } else {
+      return Opal.send(obj, obj['$respond_to?'], [jsid.substr(1), include_all]);
+    }
+  }
+
 
   // Constants
   // ---------
@@ -1632,7 +1648,7 @@
   //
   Opal.extract_kwargs = function(parameters) {
     var kwargs = parameters[parameters.length - 1];
-    if (kwargs != null && kwargs['$respond_to?']('to_hash', true)) {
+    if (kwargs != null && Opal.respond_to(kwargs, '$to_hash', true)) {
       $splice.call(parameters, parameters.length - 1, 1);
       return kwargs.$to_hash();
     }

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -155,7 +155,7 @@
   Opal.slice = $slice;
 
 
-  // Truth
+  // Helpers
   // -----
 
   Opal.truthy = function(val) {
@@ -164,6 +164,22 @@
 
   Opal.falsy = function(val) {
     return (val === nil || val == null || (val.$$is_boolean && val == false))
+  };
+
+  Opal.type_error = function(object, type, method, coerced) {
+    object = object.$$class;
+
+    if (coerced && method) {
+      coerced = coerced.$$class;
+      return Opal.TypeError.$new(
+        "can't convert " + object + " into " + type +
+        " (" + object + "#" + method + " gives " + coerced + ")"
+      )
+    } else {
+      return Opal.TypeError.$new(
+        "no implicit conversion of " + object + " into " + type
+      )
+    }
   };
 
 

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -182,6 +182,17 @@
     }
   };
 
+  Opal.coerce_to = function(object, type, method, args) {
+    if (type['$==='](object)) return object;
+
+    if (!object['$respond_to?'](method)) {
+      throw Opal.type_error(object, type);
+    }
+
+    if (args == null) args = [];
+    return Opal.send(object, method, args);
+  }
+
 
   // Constants
   // ---------

--- a/opal/corelib/string.rb
+++ b/opal/corelib/string.rb
@@ -1,4 +1,4 @@
-# helpers: coerce_to
+# helpers: coerce_to, respond_to
 
 require 'corelib/comparable'
 require 'corelib/regexp'
@@ -119,7 +119,7 @@ class String < `String`
       if (other.$$is_string) {
         return self.toString() === other.toString();
       }
-      if (#{Opal.respond_to? `other`, :to_str}) {
+      if ($respond_to(other, '$to_str')) {
         return #{other == self};
       }
       return false;

--- a/opal/corelib/string.rb
+++ b/opal/corelib/string.rb
@@ -1,3 +1,5 @@
+# helpers: coerce_to
+
 require 'corelib/comparable'
 require 'corelib/regexp'
 
@@ -28,7 +30,7 @@ class String < `String`
   end
 
   def self.new(str = '')
-    str = Opal.coerce_to(str, String, :to_str)
+    str = `$coerce_to(str, #{String}, 'to_str')`
     `new self.$$constructor(str)`
   end
 
@@ -51,7 +53,7 @@ class String < `String`
 
   def *(count)
     %x{
-      count = #{Opal.coerce_to(`count`, Integer, :to_int)};
+      count = $coerce_to(count, #{Integer}, 'to_int');
 
       if (count < 0) {
         #{raise ArgumentError, 'negative argument'}
@@ -88,7 +90,7 @@ class String < `String`
   end
 
   def +(other)
-    other = Opal.coerce_to other, String, :to_str
+    other = `$coerce_to(#{other}, #{String}, 'to_str')`
 
     `self + #{other.to_s}`
   end
@@ -143,8 +145,8 @@ class String < `String`
 
       if (index.$$is_range) {
         exclude = index.excl;
-        length  = #{Opal.coerce_to(`index.end`, Integer, :to_int)};
-        index   = #{Opal.coerce_to(`index.begin`, Integer, :to_int)};
+        length  = $coerce_to(index.end, #{Integer}, 'to_int');
+        index   = $coerce_to(index.begin, #{Integer}, 'to_int');
 
         if (Math.abs(index) > size) {
           return nil;
@@ -194,7 +196,7 @@ class String < `String`
           return self.$$cast(match[0]);
         }
 
-        length = #{Opal.coerce_to(`length`, Integer, :to_int)};
+        length = $coerce_to(length, #{Integer}, 'to_int');
 
         if (length < 0 && -length < match.length) {
           return self.$$cast(match[length += match.length]);
@@ -208,7 +210,7 @@ class String < `String`
       }
 
 
-      index = #{Opal.coerce_to(`index`, Integer, :to_int)};
+      index = $coerce_to(index, #{Integer}, 'to_int');
 
       if (index < 0) {
         index += size;
@@ -221,7 +223,7 @@ class String < `String`
         return self.$$cast(self.substr(index, 1));
       }
 
-      length = #{Opal.coerce_to(`length`, Integer, :to_int)};
+      length = $coerce_to(length, #{Integer}, 'to_int');
 
       if (length < 0) {
         return nil;
@@ -247,7 +249,7 @@ class String < `String`
 
   def casecmp(other)
     return nil unless other.respond_to?(:to_str)
-    other = Opal.coerce_to(other, String, :to_str).to_s
+    other = `$coerce_to(other, #{String}, 'to_str')`.to_s
     %x{
       var ascii_only = /^[\x00-\x7F]*$/;
       if (ascii_only.test(self) && ascii_only.test(other)) {
@@ -270,8 +272,8 @@ class String < `String`
   end
 
   def center(width, padstr = ' ')
-    width  = Opal.coerce_to(width, Integer, :to_int)
-    padstr = Opal.coerce_to(padstr, String, :to_str).to_s
+    width  = `$coerce_to(#{width}, #{Integer}, 'to_int')`
+    padstr = `$coerce_to(#{padstr}, #{String}, 'to_str')`.to_s
 
     if padstr.empty?
       raise ArgumentError, 'zero width padding'
@@ -385,7 +387,7 @@ class String < `String`
   def delete_prefix(prefix)
     %x{
       if (!prefix.$$is_string) {
-        #{prefix = Opal.coerce_to(prefix, String, :to_str)}
+        prefix = $coerce_to(prefix, #{String}, 'to_str');
       }
 
       if (self.slice(0, prefix.length) === prefix) {
@@ -399,7 +401,7 @@ class String < `String`
   def delete_suffix(suffix)
     %x{
       if (!suffix.$$is_string) {
-        #{suffix = Opal.coerce_to(suffix, String, :to_str)}
+        suffix = $coerce_to(suffix, #{String}, 'to_str');
       }
 
       if (self.slice(self.length - suffix.length) === suffix) {
@@ -436,7 +438,7 @@ class String < `String`
         return self;
       }
 
-      separator = #{Opal.coerce_to(`separator`, String, :to_str)}
+      separator = $coerce_to(separator, #{String}, 'to_str')
 
       var a, i, n, length, chomped, trailing, splitted;
 
@@ -475,7 +477,7 @@ class String < `String`
   def end_with?(*suffixes)
     %x{
       for (var i = 0, length = suffixes.length; i < length; i++) {
-        var suffix = #{Opal.coerce_to(`suffixes[i]`, String, :to_str).to_s};
+        var suffix = $coerce_to(suffixes[i], #{String}, 'to_str').$to_s();
 
         if (self.length >= suffix.length &&
             self.substr(self.length - suffix.length, suffix.length) == suffix) {
@@ -500,7 +502,7 @@ class String < `String`
       if (pattern.$$is_regexp) {
         pattern = Opal.global_multiline_regexp(pattern);
       } else {
-        pattern = #{Opal.coerce_to(`pattern`, String, :to_str)};
+        pattern = $coerce_to(pattern, #{String}, 'to_str');
         pattern = new RegExp(pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gm');
       }
 
@@ -526,7 +528,7 @@ class String < `String`
         }
         else {
           if (!replacement.$$is_string) {
-            replacement = #{Opal.coerce_to(`replacement`, String, :to_str)};
+            replacement = $coerce_to(replacement, #{String}, 'to_str');
           }
           _replacement = replacement.replace(/([\\]+)([0-9+&`'])/g, function (original, slashes, command) {
             if (slashes.length % 2 === 0) {
@@ -574,7 +576,7 @@ class String < `String`
   def include?(other)
     %x{
       if (!other.$$is_string) {
-        #{other = Opal.coerce_to(other, String, :to_str)}
+        other = $coerce_to(other, #{String}, 'to_str');
       }
       return self.indexOf(other) !== -1;
     }
@@ -589,7 +591,7 @@ class String < `String`
       if (offset === undefined) {
         offset = 0;
       } else {
-        offset = #{Opal.coerce_to(`offset`, Integer, :to_int)};
+        offset = $coerce_to(offset, #{Integer}, 'to_int');
         if (offset < 0) {
           offset += self.length;
           if (offset < 0) {
@@ -615,7 +617,7 @@ class String < `String`
           regex.lastIndex = match.index + 1;
         }
       } else {
-        search = #{Opal.coerce_to(`search`, String, :to_str)};
+        search = $coerce_to(search, #{String}, 'to_str');
         if (search.length === 0 && offset > self.length) {
           index = -1;
         } else {
@@ -663,8 +665,8 @@ class String < `String`
   end
 
   def ljust(width, padstr = ' ')
-    width  = Opal.coerce_to(width, Integer, :to_int)
-    padstr = Opal.coerce_to(padstr, String, :to_str).to_s
+    width  = `$coerce_to(#{width}, #{Integer}, 'to_int')`
+    padstr = `$coerce_to(#{padstr}, #{String}, 'to_str')`.to_s
 
     if padstr.empty?
       raise ArgumentError, 'zero width padding'
@@ -860,7 +862,7 @@ class String < `String`
           i = m.index;
         }
       } else {
-        sep = #{Opal.coerce_to(`sep`, String, :to_str)};
+        sep = $coerce_to(sep, #{String}, 'to_str');
         i = self.indexOf(sep);
       }
 
@@ -887,7 +889,7 @@ class String < `String`
       if (offset === undefined) {
         offset = self.length;
       } else {
-        offset = #{Opal.coerce_to(`offset`, Integer, :to_int)};
+        offset = $coerce_to(offset, #{Integer}, 'to_int');
         if (offset < 0) {
           offset += self.length;
           if (offset < 0) {
@@ -915,7 +917,7 @@ class String < `String`
           i = m.index;
         }
       } else {
-        search = #{Opal.coerce_to(`search`, String, :to_str)};
+        search = $coerce_to(search, #{String}, 'to_str');
         i = self.lastIndexOf(search, offset);
       }
 
@@ -924,8 +926,8 @@ class String < `String`
   end
 
   def rjust(width, padstr = ' ')
-    width  = Opal.coerce_to(width, Integer, :to_int)
-    padstr = Opal.coerce_to(padstr, String, :to_str).to_s
+    width  = `$coerce_to(#{width}, #{Integer}, 'to_int')`
+    padstr = `$coerce_to(#{padstr}, #{String}, 'to_str')`.to_s
 
     if padstr.empty?
       raise ArgumentError, 'zero width padding'
@@ -969,7 +971,7 @@ class String < `String`
         }
 
       } else {
-        sep = #{Opal.coerce_to(`sep`, String, :to_str)};
+        sep = $coerce_to(sep, #{String}, 'to_str');
         i = self.lastIndexOf(sep);
       }
 
@@ -998,7 +1000,7 @@ class String < `String`
       if (pattern.$$is_regexp) {
         pattern = Opal.global_multiline_regexp(pattern);
       } else {
-        pattern = #{Opal.coerce_to(`pattern`, String, :to_str)};
+        pattern = $coerce_to(pattern, #{String}, 'to_str');
         pattern = new RegExp(pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gm');
       }
 
@@ -1052,7 +1054,7 @@ class String < `String`
       if (pattern.$$is_regexp) {
         pattern = Opal.global_multiline_regexp(pattern);
       } else {
-        pattern = #{Opal.coerce_to(pattern, String, :to_str).to_s};
+        pattern = $coerce_to(pattern, #{String}, 'to_str').$to_s();
         if (pattern === ' ') {
           pattern = /\s+/gm;
           string = string.replace(/^\s+/, '');
@@ -1139,7 +1141,7 @@ class String < `String`
   def start_with?(*prefixes)
     %x{
       for (var i = 0, length = prefixes.length; i < length; i++) {
-        var prefix = #{Opal.coerce_to(`prefixes[i]`, String, :to_str).to_s};
+        var prefix = $coerce_to(prefixes[i], #{String}, 'to_str').$to_s();
 
         if (self.indexOf(prefix) === 0) {
           return true;
@@ -1157,7 +1159,7 @@ class String < `String`
   def sub(pattern, replacement = undefined, &block)
     %x{
       if (!pattern.$$is_regexp) {
-        pattern = #{Opal.coerce_to(`pattern`, String, :to_str)};
+        pattern = $coerce_to(pattern, #{String}, 'to_str');
         pattern = new RegExp(pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
       }
 
@@ -1182,7 +1184,7 @@ class String < `String`
 
         } else {
 
-          replacement = #{Opal.coerce_to(`replacement`, String, :to_str)};
+          replacement = $coerce_to(replacement, #{String}, 'to_str');
 
           replacement = replacement.replace(/([\\]+)([0-9+&`'])/g, function (original, slashes, command) {
             if (slashes.length % 2 === 0) {
@@ -1215,7 +1217,7 @@ class String < `String`
 
   def sum(n = 16)
     %x{
-      n = #{Opal.coerce_to(`n`, Integer, :to_int)};
+      n = $coerce_to(n, #{Integer}, 'to_int');
 
       var result = 0,
           length = self.length,
@@ -1268,7 +1270,7 @@ class String < `String`
     %x{
       var result,
           string = self.toLowerCase(),
-          radix = #{Opal.coerce_to(`base`, Integer, :to_int)};
+          radix = $coerce_to(base, #{Integer}, 'to_int');
 
       if (radix === 1 || radix < 0 || radix > 36) {
         #{raise ArgumentError, "invalid radix #{`radix`}"}
@@ -1364,9 +1366,10 @@ class String < `String`
   alias to_sym intern
 
   def tr(from, to)
-    from = Opal.coerce_to(from, String, :to_str).to_s
-    to = Opal.coerce_to(to, String, :to_str).to_s
     %x{
+      from = $coerce_to(from, #{String}, 'to_str').$to_s();
+      to = $coerce_to(to, #{String}, 'to_str').$to_s();
+
       if (from.length == 0 || from === to) {
         return self;
       }
@@ -1508,9 +1511,10 @@ class String < `String`
   end
 
   def tr_s(from, to)
-    from = Opal.coerce_to(from, String, :to_str).to_s
-    to = Opal.coerce_to(to, String, :to_str).to_s
     %x{
+      from = $coerce_to(from, #{String}, 'to_str').$to_s();
+      to = $coerce_to(to, #{String}, 'to_str').$to_s();
+
       if (from.length == 0) {
         return self;
       }
@@ -1675,9 +1679,10 @@ class String < `String`
 
   def upto(stop, excl = false, &block)
     return enum_for :upto, stop, excl unless block_given?
-    stop = Opal.coerce_to(stop, String, :to_str)
     %x{
       var a, b, s = self.toString();
+
+      stop = $coerce_to(stop, #{String}, 'to_str');
 
       if (s.length === 1 && stop.length === 1) {
 
@@ -1778,7 +1783,7 @@ class String < `String`
           neg_intersection = '';
 
       for (i = 0, len = sets.length; i < len; i++) {
-        set = #{Opal.coerce_to(`sets[i]`, String, :to_str)};
+        set = $coerce_to(sets[i], #{String}, 'to_str');
         neg = (set.charAt(0) === '^' && set.length > 1);
         set = explode_sequences_in_character_set(neg ? set.slice(1) : set);
         if (neg) {


### PR DESCRIPTION
Move the most used Opal helpers to the runtime for better performance and to treat them as core (there was some situations in which the helpers were loaded after they were needed).