### PR TITLE
Fix Regexp.new, replace \A to ^ and \z to $

### DIFF
--- a/opal/corelib/regexp.rb
+++ b/opal/corelib/regexp.rb
@@ -83,6 +83,8 @@ class ::Regexp < `RegExp`
           #{::Kernel.raise ::RegexpError, "too short escape sequence: /#{regexp}/"}
         }
 
+        regexp = regexp.replace('\\A', '^').replace('\\z', '$')
+
         if (options === undefined || #{!options}) {
           return new RegExp(regexp);
         }

--- a/spec/opal/core/regexp/assertions_spec.rb
+++ b/spec/opal/core/regexp/assertions_spec.rb
@@ -1,0 +1,19 @@
+describe 'Regexp assertions' do
+  it 'matches the beginning of input' do
+    /\Atext/.should =~ 'text'
+    /\Atext/.should_not =~ 'the text'
+
+    regexp = Regexp.new('\Atext')
+    regexp.should =~ 'text'
+    regexp.should_not =~ 'the text'
+  end
+
+  it 'matches the end of input' do
+    /text\z/.should =~ 'the text'
+    /text\z/.should_not =~ 'text of'
+
+    regexp = Regexp.new('text\z')
+    regexp.should =~ 'the text'
+    regexp.should_not =~ 'text of'
+  end
+end


### PR DESCRIPTION
Opal replaces `\A` and `\z` in regexp literal but it doesn't replace in `Regexp.new`.
https://github.com/opal/opal/blob/178d9cd117444dfd4db6d4f6700b36838a8097d4/lib/opal/nodes/literal.rb#L191

This PR changes to replace `\A` to `^` and `\z` to `$` by `Regexp.new`