### PR TITLE
Kernel#sleep should return an integer

### DIFF
--- a/opal/corelib/kernel.rb
+++ b/opal/corelib/kernel.rb
@@ -648,7 +648,7 @@ module Kernel
 
       var t = get_time();
       while (get_time() - t <= seconds * 1000);
-      return seconds;
+      return Math.round(seconds);
     }
   end
 


### PR DESCRIPTION
There's a spec for this [here](https://github.com/ruby/spec/blob/875a09e47a6efdd45c94ddea8227fd0df72f65b0/core/kernel/sleep_spec.rb#L10), but given the confusion between Integer and Float due to JavaScript numbers it didn't catch the error.