### PR TITLE
Better integer recognition

### DIFF
--- a/opal/corelib/kernel.rb
+++ b/opal/corelib/kernel.rb
@@ -648,7 +648,7 @@ module Kernel
 
       var t = get_time();
       while (get_time() - t <= seconds * 1000);
-      return seconds;
+      return Math.round(seconds);
     }
   end
 

--- a/opal/corelib/number.rb
+++ b/opal/corelib/number.rb
@@ -1010,6 +1010,7 @@ Fixnum = Number
 
 class Integer < Numeric
   `self.$$is_number_class = true`
+  `self.$$is_integer_class = true`
 
   class << self
     def allocate
@@ -1017,16 +1018,6 @@ class Integer < Numeric
     end
 
     undef :new
-
-    def ===(other)
-      %x{
-        if (!other.$$is_number) {
-          return false;
-        }
-
-        return (other % 1) === 0;
-      }
-    end
 
     def sqrt(n)
       n = Opal.coerce_to!(n, Integer, :to_int)

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -1509,7 +1509,7 @@
     }
 
     if (object.$$is_number && klass.$$is_number_class) {
-      return true;
+      return (klass.$$is_integer_class) ? (object % 1) === 0 : true;
     }
 
     var i, length, ancestors = Opal.ancestors(object.$$is_class ? Opal.get_singleton_class(object) : (object.$$meta || object.$$class));

--- a/spec/opal/core/runtime/is_a_spec.rb
+++ b/spec/opal/core/runtime/is_a_spec.rb
@@ -10,7 +10,7 @@ describe 'Opal.is_a' do
       [1.2, :Numeric, true],
       [1.2, :Number, true],
       [1.2, :Fixnum, true],
-      [1.2, :Integer, true],
+      [1.2, :Integer, false],
       [1.2, :Float, true],
 
       [Numeric.new, :Numeric, true],
@@ -31,6 +31,14 @@ describe 'Opal.is_a' do
       `!!#{Fixnum}.$$is_number_class`.should == true
       `!!#{Integer}.$$is_number_class`.should == true
       `!!#{Float}.$$is_number_class`.should == true
+    end
+
+    it 'can rely on Number subclasses having $$is_integer_class on their prototype' do
+      `!!#{Numeric}.$$is_integer_class`.should == false
+      `!!#{Number}.$$is_integer_class`.should == false
+      `!!#{Fixnum}.$$is_integer_class`.should == false
+      `!!#{Integer}.$$is_integer_class`.should == true
+      `!!#{Float}.$$is_integer_class`.should == false
     end
 
     it 'works for non-Opal objects' do

--- a/spec/opal/core/runtime/is_a_spec.rb
+++ b/spec/opal/core/runtime/is_a_spec.rb
@@ -1,25 +1,26 @@
 describe 'Opal.is_a' do
   describe 'Numeric/Number special cases' do
     [
-      [1, Numeric, true],
-      [1, Number, true],
-      [1, Fixnum, true],
-      [1, Integer, true],
-      [1, Float, true],
+      [1, :Numeric, true],
+      [1, :Number, true],
+      [1, :Fixnum, true],
+      [1, :Integer, true],
+      [1, :Float, true],
 
-      [1.2, Numeric, true],
-      [1.2, Number, true],
-      [1.2, Fixnum, true],
-      [1.2, Integer, true],
-      [1.2, Float, true],
+      [1.2, :Numeric, true],
+      [1.2, :Number, true],
+      [1.2, :Fixnum, true],
+      [1.2, :Integer, true],
+      [1.2, :Float, true],
 
-      [Numeric.new, Numeric, true],
-      [Numeric.new, Number, false],
-      [Numeric.new, Fixnum, false],
-      [Numeric.new, Integer, false],
-      [Numeric.new, Float, false],
-    ].each do |(value, klass, result)|
-      it "returns #{result} for Opal.is_a(#{value}, #{klass})" do
+      [Numeric.new, :Numeric, true],
+      [Numeric.new, :Number, false],
+      [Numeric.new, :Fixnum, false],
+      [Numeric.new, :Integer, false],
+      [Numeric.new, :Float, false],
+    ].each do |(value, klass_name, result)|
+      klass = Object.const_get(klass_name)
+      it "returns #{result} for Opal.is_a(#{value}, #{klass_name})" do
         `Opal.is_a(#{value}, #{klass})`.should == result
       end
     end


### PR DESCRIPTION
After this PR numbers with a decimal part won't be recognized by either `Integer.===` nor `Opal.is_a()`.