### PR TITLE
Make overcommit avaliable without globally installed one

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -15,6 +15,8 @@
 #
 # Uncomment the following lines to make the configuration take effect.
 
+gemfile: Gemfile
+
 PreCommit:
  RuboCop:
    enabled: true

--- a/bin/setup
+++ b/bin/setup
@@ -11,4 +11,4 @@ git submodule update --init
 
 npm install
 
-overcommit --install
+bundle exec overcommit --install


### PR DESCRIPTION
Fixed `bin/setup` which fails when overcommit gem is not installed globally.