### PR TITLE
Fix compatibility for including plain JS files with opal-sprockets

### DIFF
--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -2396,6 +2396,10 @@
     if (module) {
       module(Opal);
     }
+    else if (typeof OpalLoaded !== "undefined" && OpalLoaded.indexOf(path) !== -1) {
+      // Compatibility for loading plain JS files via opal-sprockets
+      return false;
+    }
     else {
       var severity = Opal.config.missing_require_severity;
       var message  = 'cannot load such file -- ' + path;


### PR DESCRIPTION
opal-sprockets adds some OpalLoaded variable to keep track of plain JS files loaded. It may be a good idea to make use of this variable. Loading those files threw an error before this commit, because those were loaded but Opal expected an Opal module.

@janbiedermann This place may also be a good way to handle JS includes for Webpack. Seeing commit 0791b81 of your ES6 modules branch for 1.1, it looks like you came upon this problem as well.