### PR TITLE
Make sure that ignoreCase is either true or false (not undefined)

### DIFF
--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -2319,7 +2319,7 @@
   // Combine multiple regexp parts together
   Opal.regexp = function(parts, flags) {
     var part;
-    var ignoreCase = flags && flags.indexOf('i') >= 0;
+    var ignoreCase = typeof flags !== 'undefined' && flags && flags.indexOf('i') >= 0;
 
     for (var i = 0, ii = parts.length; i < ii; i++) {
       part = parts[i];


### PR DESCRIPTION
Otherwise I get the following warning message:

```
warning: ignore case doesn't match for "\\/"
```

From line: https://github.com/opal/opal/blob/3c8d93ea8b3ed12b4c49c51cc96d092570c9f64c/stdlib/pathname.rb#L113