### PR TITLE
JavaScript engines are using UTF-16 internally but String are UTF-8 encoded by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,10 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.combo.ruby }}
+          # NOTE: Bundler 2.2.0 fails to install libv8
+          # https://github.com/rubyjs/libv8/issues/310
+          bundler: "2.1.4"
+          bundler-cache: true
       - run: ruby bin/git-submodule-fast-install
       - run: bundle lock
       - uses: actions/cache@v2

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -2452,7 +2452,10 @@
 
   // @returns a String object with the encoding set from a string literal
   Opal.enc = function(str, name) {
-    return Opal.set_encoding(new String(str), name);
+    var dup = new String(str);
+    Opal.set_encoding(dup, name);
+    dup.internal_encoding = dup.encoding;
+    return dup
   }
 
 

--- a/opal/corelib/string/encoding.rb
+++ b/opal/corelib/string/encoding.rb
@@ -162,20 +162,22 @@ end
 
 class String
   attr_reader :encoding
-  `Opal.defineProperty(String.prototype, 'encoding', #{Encoding::UTF_16LE})`
+  attr_reader :internal_encoding
+  `Opal.defineProperty(String.prototype, 'encoding', #{Encoding::UTF_8})`
+  `Opal.defineProperty(String.prototype, 'internal_encoding', #{Encoding::UTF_8})`
 
   def bytes
     each_byte.to_a
   end
 
   def bytesize
-    @encoding.bytesize(self)
+    @internal_encoding.bytesize(self)
   end
 
   def each_byte(&block)
     return enum_for :each_byte unless block_given?
 
-    @encoding.each_byte(self, &block)
+    @internal_encoding.each_byte(self, &block)
 
     self
   end
@@ -197,7 +199,7 @@ class String
   end
 
   def encode(encoding)
-    dup.force_encoding(encoding)
+    `Opal.enc(self, encoding)`
   end
 
   def force_encoding(encoding)
@@ -216,7 +218,7 @@ class String
   end
 
   def getbyte(idx)
-    @encoding.getbyte(self, idx)
+    @internal_encoding.getbyte(self, idx)
   end
 
   # stub

--- a/spec/filters/bugs/encoding.rb
+++ b/spec/filters/bugs/encoding.rb
@@ -1,11 +1,5 @@
 # NOTE: run bin/format-filters after changing this file
 opal_filter "Encoding" do
-  fails "#String#bytesize returns the length of self in bytes" # Expected 10 to equal 5
-  fails "#String#bytesize works with pseudo-ASCII strings containing UTF-8 characters" # Expected 6 to equal 5
-  fails "#String#bytesize works with pseudo-ASCII strings containing single UTF-8 characters" # Expected 2 to equal 3
-  fails "#String#bytesize works with strings containing UTF-8 characters" # Expected 6 to equal 5
-  fails "#String#bytesize works with strings containing single UTF-8 characters" # Expected 2 to equal 3
-  fails "Date#strftime passes the format string's encoding to the result string" # Expected #<Encoding:UTF-16LE> to equal #<Encoding:UTF-8>
   fails "File.basename returns basename windows forward slash" # Expected "C:" to equal "/"
   fails "File.basename returns basename windows unc" # Expected "\\\\foo\\bar\\baz.txt" to equal "baz.txt"
   fails "File.basename returns basename with windows suffix" # Expected "c:\\bar" to equal "bar"
@@ -33,7 +27,6 @@ opal_filter "Encoding" do
   fails "Integer#to_s fixnum when given a base raises an ArgumentError if the base is less than 2 or higher than 36" # NoMethodError: undefined method `default_internal' for Encoding
   fails "Integer#to_s fixnum when given a base returns self converted to a String in the given base" # NoMethodError: undefined method `default_internal' for Encoding
   fails "Integer#to_s fixnum when no base given returns self converted to a String using base 10" # NoMethodError: undefined method `default_internal' for Encoding
-  fails "Kernel#sprintf returns a String in the argument encoding if format encoding is more restrictive" # Expected #<Encoding:UTF-16LE> to be identical to #<Encoding:UTF-8>
   fails "Kernel#sprintf returns a String in the same encoding as the format String if compatible" # NameError: uninitialized constant Encoding::KOI8_U
   fails "Marshal.dump when passed an IO calls binmode when it's defined" # ArgumentError: [Marshal.dump] wrong number of arguments(2 for 1)
   fails "Marshal.dump with a String dumps a String in another encoding" # Expected "\u0004\b\"\u000Fm\u0000ö\u0000h\u0000r\u0000e\u0000" to equal "\u0004\bI\"\u000Fm\u0000ö\u0000h\u0000r\u0000e\u0000\u0006:\rencoding\"\rUTF-16LE"
@@ -76,7 +69,6 @@ opal_filter "Encoding" do
   fails "Source files encoded in UTF-8 without a BOM can be parsed" # NoMethodError: undefined method `tmp' for #<MSpecEnv:0x7a11e>
   fails "String#% output's encoding negotiates a compatible encoding if necessary" # Expected #<Encoding:UTF-16LE> to equal #<Encoding:ASCII-8BIT (dummy)>
   fails "String#* raises an ArgumentError if the length of the resulting string doesn't fit into a long" # RangeError: multiply count must not overflow maximum string size
-  fails "String#* returns a String in the same encoding as self" # Expected #<Encoding:UTF-16LE> to be identical to #<Encoding:UTF-8>
   fails "String#[]= with Fixnum index calls #to_int to convert the index" # Mock 'string element set' expected to receive 'to_int' exactly 1 times but received it 0 times
   fails "String#[]= with Fixnum index encodes the String in an encoding compatible with the replacement" # NoMethodError: undefined method `pack' for [160]:Array
   fails "String#[]= with Fixnum index raises a TypeError if #to_int does not return an Fixnum" # Mock 'string element set' expected to receive 'to_int' exactly 1 times but received it 0 times
@@ -209,8 +201,6 @@ opal_filter "Encoding" do
   fails "String#encoding for Strings with \\u escapes is not affected by the default external encoding" # NameError: uninitialized constant Encoding::SHIFT_JIS
   fails "String#encoding for Strings with \\u escapes is not affected by the default internal encoding" # NoMethodError: undefined method `default_internal' for Encoding
   fails "String#encoding for Strings with \\u escapes returns US-ASCII if self is US-ASCII only" # Expected false to be true
-  fails "String#encoding for Strings with \\u escapes returns UTF-8 if self isn't US-ASCII only" # Expected #<Encoding:UTF-16LE> to equal #<Encoding:UTF-8>
-  fails "String#encoding for Strings with \\u escapes returns UTF-8" # Expected #<Encoding:UTF-16LE> to equal #<Encoding:UTF-8>
   fails "String#encoding for Strings with \\u escapes returns the given encoding if #encode!has been called" # NameError: uninitialized constant Encoding::SHIFT_JIS
   fails "String#encoding for Strings with \\u escapes returns the given encoding if #force_encoding has been called" # NameError: uninitialized constant Encoding::SHIFT_JIS
   fails "String#encoding for Strings with \\x escapes is not affected by both the default internal and external encoding being set at the same time" # NoMethodError: undefined method `default_internal' for Encoding
@@ -226,7 +216,6 @@ opal_filter "Encoding" do
   fails "String#encoding for US-ASCII Strings returns US-ASCII if self is US-ASCII only, despite the default internal and external encodings being different" # NoMethodError: undefined method `default_internal' for Encoding
   fails "String#encoding for US-ASCII Strings returns US-ASCII if self is US-ASCII only, despite the default internal encoding being different" # NoMethodError: undefined method `default_internal' for Encoding
   fails "String#encoding for US-ASCII Strings returns US-ASCII if self is US-ASCII" # Expected #<Encoding:UTF-16LE> to equal #<Encoding:ASCII-8BIT (dummy)>
-  fails "String#encoding is equal to the source encoding by default" # Expected #<Encoding:UTF-16LE> to equal #<Encoding:UTF-8>
   fails "String#encoding returns an Encoding object" # Expected #<Encoding:UTF-16LE> (#<Class:0xc2>) to be an instance of Encoding
   fails "String#encoding returns the given encoding if #encode!has been called" # NameError: uninitialized constant Encoding::SHIFT_JIS
   fails "String#encoding returns the given encoding if #force_encoding has been called" # NameError: uninitialized constant Encoding::SHIFT_JIS
@@ -257,12 +246,6 @@ opal_filter "Encoding" do
   fails "String#size returns the length of a string in different encodings" # NameError: uninitialized constant Encoding::UTF_32BE
   fails "String#size returns the length of the new self after encoding is changed" # Expected 4 to equal 12
   fails "String#split with String throws an ArgumentError if the pattern is not a valid string" # NotImplementedError: String#chop! not supported. Mutable String methods are not supported in Opal.
-  fails "String#tr can replace a 7-bit ASCII character with a multibyte one" # Expected #<Encoding:UTF-16LE> to equal #<Encoding:UTF-8>
-  fails "String#tr can replace a multibyte character with a single byte one" # Expected #<Encoding:UTF-16LE> to equal #<Encoding:UTF-8>
-  fails "String#tr_s can replace a 7-bit ASCII character with a multibyte one" # Expected #<Encoding:UTF-16LE> to equal #<Encoding:UTF-8>
-  fails "String#tr_s can replace a multibyte character with a single byte one" # Expected #<Encoding:UTF-16LE> to equal #<Encoding:UTF-8>
-  fails "String#tr_s can replace multiple 7-bit ASCII characters with a multibyte one" # Expected #<Encoding:UTF-16LE> to equal #<Encoding:UTF-8>
-  fails "String#tr_s can replace multiple multibyte characters with a single byte one" # Expected #<Encoding:UTF-16LE> to equal #<Encoding:UTF-8>
   fails "String#valid_encoding? returns false if a valid String had an invalid character appended to it" # NoMethodError: undefined method `pack' for [221]:Array
   fails "String#valid_encoding? returns false if self contains a character invalid in the associated encoding" # NoMethodError: undefined method `pack' for [128]:Array
   fails "String#valid_encoding? returns false if self is valid in one encoding, but invalid in the one it's tagged with" # Expected true to be false

--- a/spec/filters/bugs/kernel.rb
+++ b/spec/filters/bugs/kernel.rb
@@ -213,7 +213,6 @@ opal_filter "Kernel" do
   fails "Kernel#sprintf precision float types does not affect G format" # Expected "12.12340000" to equal "12.1234"
   fails "Kernel#sprintf precision string formats determines the maximum number of characters to be copied from the string" # Expected "1" to equal "["
   fails "Kernel#sprintf raises Encoding::CompatibilityError if both encodings are ASCII compatible and there ano not ASCII characters" # ArgumentError: unknown encoding name - windows-1252
-  fails "Kernel#sprintf returns a String in the argument's encoding if format encoding is more restrictive" # Expected #<Encoding:UTF-16LE> to be identical to #<Encoding:UTF-8>
   fails "Kernel#sprintf width specifies the minimum number of characters that will be written to the result" # Expected "         1.095200e+02" to equal "        1.095200e+02"
   fails "Kernel#sprintf with format string that contains %<> sections raises ArgumentError if missing second named argument" # KeyError: key not found: "foo"
   fails "Kernel#warn :uplevel keyword argument converts value to Integer" # TypeError: no implicit conversion of Number into Integer
@@ -317,7 +316,6 @@ opal_filter "Kernel" do
   fails "Kernel.sprintf precision float types does not affect G format" # Expected "12.12340000" to equal "12.1234"
   fails "Kernel.sprintf precision string formats determines the maximum number of characters to be copied from the string" # Expected "1" to equal "["
   fails "Kernel.sprintf raises Encoding::CompatibilityError if both encodings are ASCII compatible and there ano not ASCII characters" # ArgumentError: unknown encoding name - windows-1252
-  fails "Kernel.sprintf returns a String in the argument's encoding if format encoding is more restrictive" # Expected #<Encoding:UTF-16LE> to be identical to #<Encoding:UTF-8>
   fails "Kernel.sprintf returns a String in the same encoding as the format String if compatible" # NameError: uninitialized constant Encoding::KOI8_U
   fails "Kernel.sprintf width specifies the minimum number of characters that will be written to the result" # Expected "         1.095200e+02" to equal "        1.095200e+02"
 end

--- a/spec/filters/bugs/string.rb
+++ b/spec/filters/bugs/string.rb
@@ -43,7 +43,6 @@ opal_filter "String" do
   fails "String#% precision string formats determines the maximum number of characters to be copied from the string" # Expected "1" to equal "["
   fails "String#% raises Encoding::CompatibilityError if both encodings are ASCII compatible and there ano not ASCII characters" # ArgumentError: unknown encoding name - windows-1252
   fails "String#% raises an error if single % appears at the end" # Expected ArgumentError but no exception was raised ("%" was returned)
-  fails "String#% returns a String in the argument's encoding if format encoding is more restrictive" # Expected #<Encoding:UTF-16LE> to be identical to #<Encoding:UTF-8>
   fails "String#% returns a String in the same encoding as the format String if compatible" # NameError: uninitialized constant Encoding::KOI8_U
   fails "String#% supports inspect formats using %p" # Expected "{\"capture\"=>1}" to equal "{:capture=>1}"
   fails "String#% width specifies the minimum number of characters that will be written to the result" # Expected "         1.095200e+02" to equal "        1.095200e+02"
@@ -161,10 +160,10 @@ opal_filter "String" do
   fails "String#grapheme_clusters works with multibyte characters" # NoMethodError: undefined method `grapheme_clusters' for "覇"
   fails "String#include? with String raises an Encoding::CompatibilityError if the encodings are incompatible" # NameError: uninitialized constant Encoding::EUC_JP
   fails "String#inspect when the string's encoding is different than the result's encoding and the string's encoding is ASCII-compatible but the characters are non-ASCII returns a string with the non-ASCII characters replaced by \\x notation" # ArgumentError: unknown encoding name - EUC-JP
+  fails "String#intern returns a UTF-16LE Symbol for a UTF-16LE String containing non US-ASCII characters" # Error
   fails "String#intern raises an EncodingError for UTF-8 String containing invalid bytes" # Expected true to equal false
   fails "String#intern returns a US-ASCII Symbol for a UTF-8 String containing only US-ASCII characters" # Expected #<Encoding:UTF-16LE> to equal #<Encoding:ASCII-8BIT (dummy)>
   fails "String#intern returns a US-ASCII Symbol for a binary String containing only US-ASCII characters" # Expected #<Encoding:UTF-16LE> to equal #<Encoding:ASCII-8BIT (dummy)>
-  fails "String#intern returns a UTF-8 Symbol for a UTF-8 String containing non US-ASCII characters" # Expected #<Encoding:UTF-16LE> to equal #<Encoding:UTF-8>
   fails "String#intern returns a binary Symbol for a binary String containing non US-ASCII characters" # Expected #<Encoding:UTF-16LE> to equal #<Encoding:ASCII-8BIT (dummy)>
   fails "String#lines when `chomp` keyword argument is passed ignores new line characters when separator is specified" # ArgumentError: [String#lines] wrong number of arguments(2 for -1)
   fails "String#lines when `chomp` keyword argument is passed removes new line characters when separator is not specified" # TypeError: no implicit conversion of Hash into String
@@ -188,10 +187,10 @@ opal_filter "String" do
   fails "String#swapcase full Unicode case mapping updates string metadata" # Expected "aßET" to equal "aSSET"
   fails "String#swapcase full Unicode case mapping works for all of Unicode with no option" # Expected "äÖü" to equal "ÄöÜ"
   fails "String#swapcase works for all of Unicode" # Expected "äÖü" to equal "ÄöÜ"
+  fails "String#to_sym returns a UTF-16LE Symbol for a UTF-16LE String containing non US-ASCII characters" # ERROR
   fails "String#to_sym raises an EncodingError for UTF-8 String containing invalid bytes" # Expected true to equal false
   fails "String#to_sym returns a US-ASCII Symbol for a UTF-8 String containing only US-ASCII characters" # Expected #<Encoding:UTF-16LE> to equal #<Encoding:ASCII-8BIT (dummy)>
   fails "String#to_sym returns a US-ASCII Symbol for a binary String containing only US-ASCII characters" # Expected #<Encoding:UTF-16LE> to equal #<Encoding:ASCII-8BIT (dummy)>
-  fails "String#to_sym returns a UTF-8 Symbol for a UTF-8 String containing non US-ASCII characters" # Expected #<Encoding:UTF-16LE> to equal #<Encoding:UTF-8>
   fails "String#to_sym returns a binary Symbol for a binary String containing non US-ASCII characters" # Expected #<Encoding:UTF-16LE> to equal #<Encoding:ASCII-8BIT (dummy)>
   fails "String#undump Limitations cannot undump non ASCII-compatible string" # NoMethodError: undefined method `undump' for "\"foo\""
   fails "String#undump always returns String instance" # NoMethodError: undefined method `undump' for "\"foo\""

--- a/spec/opal/core/string_spec.rb
+++ b/spec/opal/core/string_spec.rb
@@ -2,11 +2,7 @@ require 'spec_helper'
 
 describe 'Encoding' do
   it 'supports US-ASCII' do
-    # this wouldn't be allowed under MRI:
-    #   ruby -e "# encoding: utf-16le\np 'asdf'.force_encoding 'ascii'"                                                          ~/C/opal
-    #   -e:1: UTF-16LE is not ASCII compatible (ArgumentError)
-    # although for now seems to be the best way to handle it.
-    "è".encoding.name.should == 'UTF-16LE'
+    "è".encoding.name.should == 'UTF-8'
     "è".force_encoding('ASCII').should == "\xC3\xA8"
     "è".force_encoding('ascii').should == "\xC3\xA8"
     "è".force_encoding('US-ASCII').should == "\xC3\xA8"

--- a/test/nodejs/test_file.rb
+++ b/test/nodejs/test_file.rb
@@ -52,7 +52,7 @@ class TestNodejsFile < Test::Unit::TestCase
 
   def test_read_binary_utf8_file
     binary_text = ::File.open('./test/nodejs/fixtures/utf8.txt', 'rb') {|f| f.read}
-    assert_equal(binary_text.encoding, Encoding::UTF_16LE)
+    assert_equal(binary_text.encoding, Encoding::UTF_8)
     assert_match(/^\u00E7\u00E9\u00E0/, binary_text)
     utf8_text = binary_text.force_encoding('utf-8')
     assert_equal("çéà", utf8_text)
@@ -60,7 +60,7 @@ class TestNodejsFile < Test::Unit::TestCase
 
   def test_read_binary_iso88591_file
     binary_text = ::File.open('./test/nodejs/fixtures/iso88591.txt', 'rb') {|f| f.read}
-    assert_equal(binary_text.encoding, Encoding::UTF_16LE)
+    assert_equal(binary_text.encoding, Encoding::UTF_8)
     assert_match(/^\u00E7\u00E9\u00E0/, binary_text)
     utf8_text = binary_text.force_encoding('utf-8')
     assert_equal("çéà", utf8_text)
@@ -68,7 +68,7 @@ class TestNodejsFile < Test::Unit::TestCase
 
   def test_read_binary_win1258_file
     binary_text = ::File.open('./test/nodejs/fixtures/win1258.txt', 'rb') {|f| f.read}
-    assert_equal(binary_text.encoding, Encoding::UTF_16LE)
+    assert_equal(binary_text.encoding, Encoding::UTF_8)
     assert_match(/^\u00E7\u00E9\u00E0/, binary_text)
     utf8_text = binary_text.force_encoding('utf-8')
     assert_equal("çéà", utf8_text)

--- a/test/nodejs/test_file_encoding.rb
+++ b/test/nodejs/test_file_encoding.rb
@@ -6,14 +6,14 @@ class TestNodejsFileEncoding < Test::Unit::TestCase
 
   def test_force_encoding_raw_text_to_utf8
     raw_text = 'çéà'
-    assert_equal(raw_text.encoding, Encoding::UTF_16LE)
+    assert_equal(raw_text.encoding, Encoding::UTF_8)
     utf8_text = raw_text.force_encoding('utf-8')
     assert_equal("çéà", utf8_text)
   end
 
   def test_force_encoding_from_binary_to_utf8
     raw_text = "\xC3\xA7\xC3\xA9\xC3\xA0"
-    assert_equal(raw_text.encoding, Encoding::UTF_16LE)
+    assert_equal(raw_text.encoding, Encoding::UTF_8)
     utf8_text = raw_text.force_encoding('utf-8')
     assert_equal("çéà", utf8_text)
   end


### PR DESCRIPTION
#### Reasoning

```js
Buffer.byteLength('foo') // 3
Buffer.byteLength('écrire') // 7

'foo'.$bytesize() // should be 3 not 6
```

I've been able to enable 22 specs :tada: 
Most notably the `String#bytesize` method is now working as expected.

On the other hand, I had to disable 2 specs, one on `String#intern` and another one on `String#to_sym`.
But if you take a closer look, they were working by luck because the value of the `encoding` attribute on String primitive was UTF-16LE.
In fact, the method `String#to_sym` was always returning a UTF-16LE Symbol even when the String was not a UTF-16LE encoded String.

#### Implementation

The method `force_encoding` should only update the `encoding` attribute but it should not modify how the string is encoded. As a result, the methods `bytesize` and `each_byte` should not rely on the `encoding` attribute.

I've introduced an "internal encoding" that will be updated when `encode` is called (but not when `force_encoding` is called). The `bytesize` and `each_byte` now rely on the "internal encoding" instead of the "encoding" attribute.


/cc @mojavelinux