### PR TITLE
Add --rbrequire (-q) option to opal cmdline tool

### DIFF
--- a/lib/opal/cli.rb
+++ b/lib/opal/cli.rb
@@ -7,7 +7,7 @@ require 'opal/cli_runners'
 module Opal
   class CLI
     attr_reader :options, :file, :compiler_options, :evals, :load_paths, :argv,
-      :output, :requires, :gems, :stubs, :verbose, :runner_options,
+      :output, :requires, :rbrequires, :gems, :stubs, :verbose, :runner_options,
       :preload, :filename, :debug, :no_exit, :lib_only, :missing_require_severity
 
     class << self
@@ -37,6 +37,7 @@ module Opal
       @debug       = options.delete(:debug)      { false }
       @filename    = options.delete(:filename)   { @file && @file.path }
       @requires    = options.delete(:requires)   { [] }
+      @rbrequires  = options.delete(:rbrequires) { [] }
 
       @missing_require_severity = options.delete(:missing_require_severity) { Opal::Config.missing_require_severity }
 
@@ -79,6 +80,8 @@ module Opal
     end
 
     def create_builder
+      rbrequires.each(&Kernel.method(:require))
+
       builder = Opal::Builder.new(
         stubs: stubs,
         compiler_options: compiler_options,

--- a/lib/opal/cli_options.rb
+++ b/lib/opal/cli_options.rb
@@ -58,6 +58,13 @@ module Opal
         options[:requires] << library
       end
 
+      on('-q', '--rbrequire LIBRARY', String,
+        'Require the library in Ruby context before compiling'
+      ) do |library|
+        options[:rbrequires] ||= []
+        options[:rbrequires] << library
+      end
+
       on('-s', '--stub FILE', String, 'Stubbed files will be compiled as empty files') do |stub|
         options[:stubs] ||= []
         options[:stubs] << stub

--- a/spec/lib/cli_spec.rb
+++ b/spec/lib/cli_spec.rb
@@ -121,6 +121,15 @@ RSpec.describe Opal::CLI do
     end
   end
 
+  describe ':rbrequires options' do
+    context 'when set' do
+      let(:options) { {:rbrequires => ["some_nonexisting_require"], :evals => [''] } }
+      it 'requires the file before compiling' do
+        expect{ subject.run }.to raise_error(LoadError)
+      end
+    end
+  end
+
   describe ':gems options' do
     context 'with a Gem name' do
       let(:dir)      { File.dirname(file) }


### PR DESCRIPTION
The short rationale behind it is that for now it's impossible to
require opal libraries like opal-browser (close to impossible - it
needs Gem paths) or opal-erubi (impossible, because it needs to
modify the compiler context to support .erubi files).

The longer rationale is that opal-rspec depends on Opal::CLI. We
can't test opal-webassembly due to that.