### PR TITLE
Fix a zero-length regexp match bug

### DIFF
--- a/opal/corelib/string.rb
+++ b/opal/corelib/string.rb
@@ -551,7 +551,7 @@ class String < `String`
         }
 
         if (pattern.lastIndex === match.index) {
-          result += (_replacement + self.slice(index, match.index + 1))
+          result += (self.slice(index, match.index) + _replacement + (self[match.index] || ""));
           pattern.lastIndex += 1;
         }
         else {

--- a/spec/opal/core/string/gsub_spec.rb
+++ b/spec/opal/core/string/gsub_spec.rb
@@ -1,19 +1,35 @@
 require 'spec_helper'
 
-describe 'String#gsub' do
-  it 'handles recursive gsub' do
-    pass_slot_rx = /{(\d+)}/
-    recurse_gsub = -> text {
-      text.gsub(pass_slot_rx) {
-        index = $1.to_i
-        if index == 0
-          recurse_gsub.call '{1}'
-        else
-          'value'
-        end
+describe 'String' do
+  describe '#gsub' do
+    it 'handles recursive gsub' do
+      pass_slot_rx = /{(\d+)}/
+      recurse_gsub = -> text {
+        text.gsub(pass_slot_rx) {
+          index = $1.to_i
+          if index == 0
+            recurse_gsub.call '{1}'
+          else
+            'value'
+          end
+        }
       }
-    }
-    result = recurse_gsub.call '<code>{0}</code>'
-    result.should == '<code>value</code>'
+      result = recurse_gsub.call '<code>{0}</code>'
+      result.should == '<code>value</code>'
+    end
+
+    it 'works well with zero-length matches' do
+      expect("test".gsub(/^/, '2')).to eq "2test"
+      expect("test".gsub(/$/, '2')).to eq "test2"
+      expect("test".gsub(/\b/, '2')).to eq "2test2"
+    end
+  end
+
+  describe '#sub' do
+    it 'works well with zero-length matches' do
+      expect("test".sub(/^/, '2')).to eq "2test"
+      expect("test".sub(/$/, '2')).to eq "test2"
+      expect("test".sub(/\b/, '2')).to eq "2test"
+    end
   end
 end


### PR DESCRIPTION
 ```
     expect("test".gsub(/$/, '2')).to eq "test2"
```

Before this commit it was "2test".