### PR TITLE
Fix Object#pretty_inspect.

### DIFF
--- a/spec/opal/stdlib/pp_spec.rb
+++ b/spec/opal/stdlib/pp_spec.rb
@@ -1,0 +1,5 @@
+describe 'Object#pretty_inspect' do
+  it "doesn't throw due to the use of #<<" do
+    expect("test".pretty_inspect).to eq %{"test"\n}
+  end
+end

--- a/stdlib/pp.rb
+++ b/stdlib/pp.rb
@@ -72,11 +72,15 @@ class PP < PrettyPrint
   #
   # PP.pp returns +out+.
   def PP.pp(obj, out=$stdout, width=79)  # Opal: replace $> with $stdout
+    out = [] if out == '' # Opal: "" is immutable. We will use an array.
     q = PP.new(out, width)
     q.guard_inspect_key {q.pp obj}
     q.flush
     #$pp = q
     out << "\n"
+    # Opal: Make a string of an array
+    out = out.join if out.respond_to? :join
+    out
   end
 
   # Outputs +obj+ to +out+ like PP.pp but with no indent and
@@ -84,9 +88,12 @@ class PP < PrettyPrint
   #
   # PP.singleline_pp returns +out+.
   def PP.singleline_pp(obj, out=$stdout)  # Opal: replace $> with $stdout
+    out = [] if out == '' # Opal: "" is immutable. We will use an array.
     q = SingleLine.new(out)
     q.guard_inspect_key {q.pp obj}
     q.flush
+    # Opal: Make a string of an array
+    out = out.join if out.respond_to? :join
     out
   end
 

--- a/stdlib/prettyprint.rb
+++ b/stdlib/prettyprint.rb
@@ -42,10 +42,13 @@ class PrettyPrint
   #     output
   #   end
   #
-  def PrettyPrint.format(output=''.dup, maxwidth=79, newline="\n", genspace=lambda {|n| ' ' * n})
+  def PrettyPrint.format(output="".dup, maxwidth=79, newline="\n", genspace=lambda {|n| ' ' * n})
+    output = [] if output == "" # Opal: Strings are immutable in Opal, so we use an array
     q = PrettyPrint.new(output, maxwidth, newline, &genspace)
     yield q
     q.flush
+    # Opal: Make a string off an array
+    output = output.join if output.respond_to? :join
     output
   end
 
@@ -56,9 +59,12 @@ class PrettyPrint
   # The invocation of +breakable+ in the block doesn't break a line and is
   # treated as just an invocation of +text+.
   #
-  def PrettyPrint.singleline_format(output=''.dup, maxwidth=nil, newline=nil, genspace=nil)
+  def PrettyPrint.singleline_format(output="".dup, maxwidth=nil, newline=nil, genspace=nil)
+    output = [] if output == "" # Opal: Strings are immutable in Opal, so we use an array
     q = SingleLine.new(output)
     yield q
+    # Opal: Make a string off an array
+    output = output.join if output.respond_to? :join
     output
   end
 
@@ -79,7 +85,8 @@ class PrettyPrint
   # The block is used to generate spaces. {|width| ' ' * width} is used if it
   # is not given.
   #
-  def initialize(output=''.dup, maxwidth=79, newline="\n", &genspace)
+  def initialize(output="".dup, maxwidth=79, newline="\n", &genspace)
+    output = [] if output == "" # Opal: Strings are immutable in Opal, so we use an array
     @output = output
     @maxwidth = maxwidth
     @newline = newline


### PR DESCRIPTION
Before this commit it threw an error, because it tried to use String#<<.

It caused the mspec_opal_nodejs tests to fail with a wrong error, like:

```
  1. String #gsub works well with zero-length matches

    NotImplementedError: String#<< not supported. Mutable String methods are not supported in Opal.
    NotImplementedError: String#<< not supported. Mutable String methods are not supported in Opal.
  from corelib/runtime.js:1729:5:in `Opal.send2'
  from corelib/runtime.js:1719:5:in `Opal.send'
  from corelib/error.rb:28:5:in `new'
  from corelib/kernel.rb:535:23:in `exception'
  from corelib/unsupported.rb:31:5:in `raise'
  from prettyprint.rb:182:7:in `<<'
  from prettyprint.rb:250:5:in `text'
  from corelib/runtime.js:1729:5:in `Opal.send2'
  from corelib/runtime.js:1719:5:in `Opal.send'
  from pp.rb:166:9:in `group'
```