### PR TITLE
Fix `class Class < superclass` for invalid superclass

### DIFF
--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -542,9 +542,20 @@
     }
 
     // If the superclass is not an Opal-generated class then we're bridging a native JS class
-    if (superclass != null && !superclass.hasOwnProperty('$$is_class')) {
-      bridged = superclass;
-      superclass = _Object;
+    if (
+      superclass != null && (!superclass.hasOwnProperty || (
+        superclass.hasOwnProperty && !superclass.hasOwnProperty('$$is_class')
+      ))
+    ) {
+      if (superclass.constructor && superclass.constructor.name == "Function") {
+        bridged = superclass;
+        superclass = _Object;
+      } else {
+        throw Opal.TypeError.$new("superclass must be a Class (" + (
+          (superclass.constructor && (superclass.constructor.name || superclass.constructor.$$name)) ||
+          typeof(superclass)
+        ) + " given)");
+      }
     }
 
     var klass = find_existing_class(scope, name);

--- a/spec/opal/core/runtime/bridged_classes_spec.rb
+++ b/spec/opal/core/runtime/bridged_classes_spec.rb
@@ -121,3 +121,19 @@ describe 'Bridged classes in different modules' do
     @bridged.new.some_bridged_method.should == [4, 5, 6]
   end
 end
+
+
+describe "Invalid bridged classes" do
+  it "raises a TypeError when trying to extend with non-Class" do
+    error_msg = /superclass must be a Class/
+    -> { class TestClass < `""`;                  end }.should raise_error(TypeError, error_msg)
+    -> { class TestClass < `3`;                   end }.should raise_error(TypeError, error_msg)
+    -> { class TestClass < `true`;                end }.should raise_error(TypeError, error_msg)
+    -> { class TestClass < `Math`;                end }.should raise_error(TypeError, error_msg)
+    -> { class TestClass < `Object.create({})`;   end }.should raise_error(TypeError, error_msg)
+    -> { class TestClass < `Object.create(null)`; end }.should raise_error(TypeError, error_msg)
+    -> { class TestClass < Module.new;            end }.should raise_error(TypeError, error_msg)
+    -> { class TestClass < BasicObject.new;       end }.should raise_error(TypeError, error_msg)
+  end
+end
+


### PR DESCRIPTION
While trying to do #2114 I found this bug that
```ruby
class TestClass < BasicObject.new
end
```

This fails with `Uncaught TypeError: can't convert undefined to object` but it should raise error `TypeError: superclass must be a Class (BasicObject given)` like Ruby does.

Note that `Class.new(BasicObject.new)` works correctly.
In Ruby specs there is test for `Class.new` but not for `class Class < superclass` so they were passing, but I added such test aswell ruby/spec#792
