### PR TITLE
Implement Native to behave like a Class

### DIFF
--- a/opal/corelib/kernel.rb
+++ b/opal/corelib/kernel.rb
@@ -35,11 +35,9 @@ module Kernel
   def method(name)
     %x{
       var meth = self['$' + name];
-
       if (!meth || meth.$$stub) {
-        #{raise NameError.new("undefined method `#{name}' for class `#{self.class}'", name)};
+        #{::Kernel.raise NameError.new("undefined method `#{name}' for class `#{self.class}'", name)};
       }
-
       return #{Method.new(self, `meth.$$owner || #{self.class}`, `meth`, name)};
     }
   end

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -159,11 +159,11 @@
   // -----
 
   Opal.truthy = function(val) {
-    return (val !== nil && val != null && (!val.$$is_boolean || val == true));
+    return (val !== nil && val != null && (!val.$$is_boolean || val == true) && (!val["$nil?"] || !val["$nil?"]()));
   };
 
   Opal.falsy = function(val) {
-    return (val === nil || val == null || (val.$$is_boolean && val == false))
+    return (val === nil || val == null || (val.$$is_boolean && val == false) || (val["$nil?"] && val["$nil?"]()));
   };
 
   Opal.type_error = function(object, type, method, coerced) {

--- a/spec/opal/stdlib/native/class_spec.rb
+++ b/spec/opal/stdlib/native/class_spec.rb
@@ -1,0 +1,110 @@
+require 'native'
+
+describe "Native" do
+  it "can be used to extend Math" do
+    class ExtendedMath < Native(`Math`)
+      def self.toRadians(degrees)
+        degrees * (self.PI / 180)
+      end
+
+      def initialize(precision)
+        @Precision = precision
+      end
+
+      def sinDegrees(degrees)
+        sin(self.class.toRadians(degrees)).round(@Precision)
+      end
+    end
+
+    ExtendedMath.toRadians(90).should == `Math.PI / 2`
+    ExtendedMath.new(2).sinDegrees(30).should == 0.50
+  end
+
+  it "works with #respond_to?" do
+    class ExtendedMath2 < Native(`Math`)
+      def self.sin2x(radians)
+        self.sin(radians * 2)
+      end
+
+      def sin4x(radians)
+        self.sin(radians * 4)
+      end
+    end
+
+    ExtendedMath2.respond_to?(:sin).should be_true
+    ExtendedMath2.respond_to?(:sin2x).should be_true
+
+    ExtendedMath2.new.respond_to?(:cos).should be_true
+    ExtendedMath2.new.respond_to?(:sin4x).should be_true
+  end
+
+  it "works with #send" do
+    class ExtendedMath3 < Native(`Math`)
+      def self.cos2x(radians)
+        self.cos(radians * 2)
+      end
+
+      def cos4x(radians)
+        self.cos(radians * 4)
+      end
+    end
+
+    ExtendedMath3.send(:cos, 0).should == 1
+    ExtendedMath3.new.send(:cos, Math::PI / 3).round(2).should == 0.50
+
+    ExtendedMath3.send(:cos2x, 0).should == 1
+    ExtendedMath3.new.send(:cos4x, Math::PI / 3).round(2).should == -0.50
+  end
+
+  it "works with #method" do
+    class ExtendedMath4 < Native(`Math`)
+      def self.tan2x(radians)
+        self.tan(radians * 2)
+      end
+
+      def tan4x(radians)
+        self.tan(radians * 4)
+      end
+    end
+    ExtendedMath4.method(:tan).class.should == Method
+    ExtendedMath4.method(:tan).call(Math::PI / 4).round(2).should == 1.00
+    ExtendedMath4.method(:tan2x).call(Math::PI / 4).should == `Math.tan(Math.PI / 2)`
+
+    ExtendedMath4.new.method(:tan).class.should == Method
+    ExtendedMath4.new.method(:tan).call(Math::PI / 4).round(2).should == 1.00
+    ExtendedMath4.new.method(:tan4x).call(Math::PI / 4).should == `Math.tan(Math.PI)`
+  end
+
+  it "doesn't fail when trying to extend null" do
+    class ExtendNull < Native(`null`); end
+
+    ExtendNull.nil?.should be_true
+    ExtendNull.new.nil?.should be_true
+    (ExtendNull == nil).should be_true
+    (ExtendNull.new == nil).should be_true
+
+    lambda { ExtendNull.new.missing }.should raise_error(NoMethodError)
+  end
+
+  it "doesn't fail when trying to extend undefined" do
+    class ExtendUndefined < Native(`undefined`); end
+
+    ExtendUndefined.nil?.should be_true
+    ExtendUndefined.new.nil?.should be_true
+    (ExtendUndefined == nil).should be_true
+    (ExtendUndefined.new == nil).should be_true
+
+    lambda { ExtendUndefined.new.missing }.should raise_error(NoMethodError)
+  end
+
+  it "is falsy when null or undefined" do
+    class ExtendNull2 < Native(`null`); end
+    class ExtendUndefined2 < Native(`undefined`); end
+
+    [ExtendNull2, ExtendUndefined2, ExtendNull2.new, ExtendUndefined2.new].each do |target|
+      (target ? true : false).should be_false
+      (!target).should be_true
+    end
+  end
+end
+

--- a/spec/opal/stdlib/native/each_spec.rb
+++ b/spec/opal/stdlib/native/each_spec.rb
@@ -10,4 +10,13 @@ describe "Native::Object#each" do
   it "accesses the native when no block is given" do
     Native(`{ a: 2, b: 3, each: function() { return 42; } }`).each.should == 42
   end
+
+  it "raises NoMethodError for null" do
+    lambda { Native(`null`).each { } }.should raise_error(NoMethodError)
+  end
+
+  it "works for undefined" do
+    lambda { Native(`undefined`).each { } }.should raise_error(NoMethodError)
+  end
+
 end

--- a/spec/opal/stdlib/native/element_reference_spec.rb
+++ b/spec/opal/stdlib/native/element_reference_spec.rb
@@ -6,6 +6,11 @@ describe "Native::Object#[]" do
     Native(`"lol"`).should === "lol"
   end
 
+  it "should raise for nil" do
+    lambda { Native(`null`)[:a] }.should raise_error(NoMethodError)
+    lambda { Native(`undefined`)[:a] }.should raise_error(NoMethodError)
+  end
+
   it "should return functions as is" do
     Native(`{ a: function(){} }`)[:a].should be_kind_of Proc
   end

--- a/spec/opal/stdlib/native/method_missing_spec.rb
+++ b/spec/opal/stdlib/native/method_missing_spec.rb
@@ -4,6 +4,12 @@ describe "Native::Object#method_missing" do
   it "should return values" do
     Native(`{ a: 23 }`).a.should == 23
     Native(`{ a: { b: 42 } }`).a.b.should == 42
+    Native(`{ a: 2 }`).b.should be_nil
+  end
+
+  it "should raise when accessing nil" do
+    lambda { Native(`null`).a }.should raise_error(NoMethodError)
+    lambda { Native(`undefined`).a }.should raise_error(NoMethodError)
   end
 
   it "should call functions" do
@@ -33,6 +39,11 @@ describe "Native::Object#method_missing" do
     Native(var).a = 42
     `#{var}.a`.should == 42
     Native(var).a.should == 42
+  end
+
+  it "should raise when assigning to nil" do
+    lambda { Native(`null`).a = 42 }.should raise_error(NoMethodError)
+    lambda { Native(`undefined`).a = 42 }.should raise_error(NoMethodError)
   end
 
   it "should pass the block as function" do

--- a/spec/opal/stdlib/native/new_spec.rb
+++ b/spec/opal/stdlib/native/new_spec.rb
@@ -4,6 +4,8 @@ describe "Native()" do
   it "should return nil for null or undefined" do
     Native(`null`).should be_nil
     Native(`undefined`).should be_nil
+    Native(`null`).nil?.should be_true
+    Native(`undefined`).nil?.should be_true
   end
 
   it "should return String" do


### PR DESCRIPTION
This PR implements `Native` to behave both like a Module (as was before) and also like a Class which allows native objects to be extended as Ruby objects.

Consider this example
```ruby
class RubyWindow < Native(`window`)
    def self.url
        location.href
    end
end

puts RubyWindow.url
# https://github.com/opal/opal/
```

In this way this PR also resolves #2113 and makes that `#send` and `#method` works.

