### PR TITLE
Fix BuilderProcessors::Processor.handles for rbenv

### DIFF
--- a/lib/opal/builder_processors.rb
+++ b/lib/opal/builder_processors.rb
@@ -24,7 +24,7 @@ module Opal
         def handles(*extensions)
           @extensions = extensions
           matches = extensions.join('|')
-          matches = "(#{matches})" if extensions.size == 1
+          matches = "(#{matches})" unless extensions.size == 1
           @match_regexp = Regexp.new "\\.#{matches}#{REGEXP_END}"
 
           ::Opal::Builder.register_processor(self, extensions)


### PR DESCRIPTION
Ensure to probably match multiple extensions so that it doesn't match `.rbenv`

This is a contribution from the [Interscript project](https://github.com/interscript) of [Ribose](https://github.com/riboseinc).