### PR TITLE
Define properties as Symbol

### DIFF
--- a/opal/corelib/basic_object.rb
+++ b/opal/corelib/basic_object.rb
@@ -14,11 +14,11 @@ class BasicObject
 
   def __id__
     %x{
-      if (self.$$id != null) {
-        return self.$$id;
+      if (self[Opal.$$id_s] != null) {
+        return self[Opal.$$id_s];
       }
-      Opal.defineProperty(self, '$$id', Opal.uid());
-      return self.$$id;
+      Opal.defineProperty(self, Opal.$$id_s, Opal.uid());
+      return self[Opal.$$id_s];
     }
   end
 

--- a/opal/corelib/class.rb
+++ b/opal/corelib/class.rb
@@ -17,7 +17,7 @@ class Class
   def allocate
     %x{
       var obj = new self.$$constructor();
-      obj.$$id = Opal.uid();
+      obj[Opal.$$id_s] = Opal.uid();
       return obj;
     }
   end

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -68,6 +68,12 @@
     enable_stack_trace: true                  // true, false
   };
 
+  var $$id_s = Symbol('$$id')
+  Opal.$$id_s = $$id_s
+  Opal.propertySymbols = {
+    '$$id': $$id_s
+  }
+
   // Minify common function calls
   var $has_own   = Object.hasOwnProperty;
   var $bind      = Function.prototype.bind;
@@ -91,11 +97,11 @@
   // Retrieve or assign the id of an object
   Opal.id = function(obj) {
     if (obj.$$is_number) return (obj * 2)+1;
-    if (obj.$$id != null) {
-      return obj.$$id;
+    if (obj[$$id_s] != null) {
+      return obj[$$id_s];
     }
-    $defineProperty(obj, '$$id', Opal.uid());
-    return obj.$$id;
+    $defineProperty(obj, $$id_s, Opal.uid());
+    return obj[$$id_s];
   };
 
   // Globals table
@@ -2525,7 +2531,7 @@
   Opal.NilClass = Opal.allocate_class('NilClass', Opal.Object, $NilClass);
   Opal.const_set(_Object, 'NilClass', Opal.NilClass);
   nil = Opal.nil = new Opal.NilClass();
-  nil.$$id = nil_id;
+  nil[Opal.$$id_s] = nil_id;
   nil.call = nil.apply = function() { throw Opal.LocalJumpError.$new('no block given'); };
 
   // Errors


### PR DESCRIPTION
Since this fix will require a lot of changes I want to make sure that we are on the same page.

For well-known attributes, we can declare symbols in `runtime.js`. For instance:

```js
var $$id_s = Symbol('$$id')
```

Then, we can use this symbol to access a property on an object.
I think we also need to 'export' the symbol:

```js
Opal.$$id_s = $$id_s
```

Note: the `_s` suffix is not necessarily needed. 

For user-defined attributes, we should probably use a Map to store the symbols:

```js
function getPropertySymbol(propertyName) {
  if (Opal.propertySymbols.has(propertyName)) {
    return Opal.propertySymbols.get(propertyName)
  }
  const symbol = Symbol(propertyName)
  Opal.propertySymbols.set(propertyName, symbol)
  return symbol
}
```

This is "mandatory" if we want to call (Ruby) methods in JavaScript:

```js
// proposed
const doc = Opal.Asciidoctor.Document[Opal.$$new_s]('foo')
console.log(doc[Opal.propertySymbols.get('$title')]())
```

For reference, here's how we can (Ruby) methods in JavaScript today:
```js
// current
const doc = Opal.Asciidoctor.Document.$new('foo')
console.log(doc.$title()) 
```

Again the naming is not definitive.

Alternatively, we could assign the symbols on the Opal object, and use `Object.getOwnPropertySymbols()` to retrieve them.

```js
Opal[Symbol('$name')] = '' // we need to set a value but we won't use it
console.log(Object.getOwnPropertySymbols(Opal)) // [Symbol('$name')]
```

ref #2144