### PR TITLE
Parser 3.0: numblocks support

### DIFF
--- a/lib/opal/rewriter.rb
+++ b/lib/opal/rewriter.rb
@@ -12,6 +12,7 @@ require 'opal/rewriters/hashes/key_duplicates_rewriter'
 require 'opal/rewriters/dump_args'
 require 'opal/rewriters/mlhs_args'
 require 'opal/rewriters/inline_args'
+require 'opal/rewriters/numblocks'
 
 module Opal
   class Rewriter
@@ -42,6 +43,7 @@ module Opal
 
     use Rewriters::OpalEngineCheck
     use Rewriters::ForRewriter
+    use Rewriters::Numblocks
     use Rewriters::BlockToIter
     use Rewriters::DotJsSyntax
     use Rewriters::JsReservedWords

--- a/lib/opal/rewriters/numblocks.rb
+++ b/lib/opal/rewriters/numblocks.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'opal/rewriters/base'
+
+module Opal
+  module Rewriters
+    # This rewriter transforms the Ruby 2.7 numblocks to regular blocks:
+    #
+    # proc { _1 }
+    #      v
+    # proc { |_1| _1 }
+    class Numblocks < Base
+      def on_numblock(node)
+        left, arg_count, right = node.children
+
+        s(
+          :block,
+          left,
+          s(:args, *gen_args(arg_count)),
+          right
+        )
+      end
+
+      def gen_args(arg_count)
+        (1..arg_count).map do |i|
+          s(:arg, :"_#{i}")
+        end
+      end
+    end
+  end
+end

--- a/spec/opal/core/language/numblocks_spec.rb
+++ b/spec/opal/core/language/numblocks_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe "numblocks" do
+  it "supports numblocks" do
+    [1,2,3].map { _1 * 2 }.should == [2,4,6]
+    [[1,2],[3,4]].map { _1 * _2 }.should == [2,12]
+  end
+
+  it "reports correct arity" do
+    proc { [_1, _2] + [_3] }.arity.should == 3
+  end
+
+  it "reports correct parameters" do
+    proc { [_1, _2] }.parameters.should == [[:opt, :_1], [:opt, :_2]]
+  end
+end


### PR DESCRIPTION
This pull request depends on #2148.

This pull request implements a Ruby 2.7 syntax feature of numblocks by transforming an expression of this kind:

```
proc { _1 + _2 }
```

Into an expression of this kind:

```
proc { |_1, _2| _1 + _2 }
```