### PR TITLE
Parser 3.0: Support beginless and endless ranges

### DIFF
--- a/lib/opal/nodes/literal.rb
+++ b/lib/opal/nodes/literal.rb
@@ -253,9 +253,11 @@ module Opal
       end
 
       def compile_inline?
-        start.type == finish.type &&
-          SIMPLE_CHILDREN_TYPES.include?(start.type) &&
-          SIMPLE_CHILDREN_TYPES.include?(finish.type)
+        (
+          !start || (start.type && SIMPLE_CHILDREN_TYPES.include?(start.type))
+        ) && (
+          !finish || (finish.type && SIMPLE_CHILDREN_TYPES.include?(finish.type))
+        )
       end
 
       def compile_inline
@@ -271,11 +273,11 @@ module Opal
       handle :irange
 
       def compile_inline
-        push '$range(', expr(start), ', ', expr(finish), ', false)'
+        push '$range(', expr_or_nil(start), ', ', expr_or_nil(finish), ', false)'
       end
 
       def compile_range_initialize
-        push 'Opal.Range.$new(', expr(start), ', ', expr(finish), ', false)'
+        push 'Opal.Range.$new(', expr_or_nil(start), ', ', expr_or_nil(finish), ', false)'
       end
     end
 
@@ -283,11 +285,11 @@ module Opal
       handle :erange
 
       def compile_inline
-        push '$range(', expr(start), ', ', expr(finish), ', true)'
+        push '$range(', expr_or_nil(start), ', ', expr_or_nil(finish), ', true)'
       end
 
       def compile_range_initialize
-        push 'Opal.Range.$new(', expr(start), ',', expr(finish), ', true)'
+        push 'Opal.Range.$new(', expr_or_nil(start), ',', expr_or_nil(finish), ', true)'
       end
     end
 

--- a/opal/corelib/array.rb
+++ b/opal/corelib/array.rb
@@ -2332,12 +2332,8 @@ class Array < `Array`
         if (o.$$is_array) {
           continue;
         }
-        if (o.$$is_enumerator) {
-          if (o.$size() === Infinity) {
-            others[j] = o.$take(size);
-          } else {
-            others[j] = o.$to_a();
-          }
+        if (o.$$is_range || o.$$is_enumerator) {
+          others[j] = o.$take(size);
           continue;
         }
         others[j] = #{(

--- a/opal/corelib/range.rb
+++ b/opal/corelib/range.rb
@@ -153,6 +153,7 @@ class Range
   def size
     infinity = Float::INFINITY
 
+    return 0 if (@begin == infinity && !@end.nil?) || (@end == -infinity && !@begin.nil?)
     return infinity if `infinite(self)`
     return nil unless Numeric === @begin && Numeric === @end
 

--- a/opal/corelib/range.rb
+++ b/opal/corelib/range.rb
@@ -21,7 +21,7 @@ class Range
   end
 
   %x{
-    function infinite(self) {
+    function is_infinite(self) {
       if (self.begin === nil || self.end === nil ||
           self.begin === -Infinity || self.end === Infinity ||
           self.begin === Infinity || self.end === -Infinity) return true;
@@ -30,14 +30,14 @@ class Range
   }
 
   def count(&block)
-    if !block_given? && `infinite(self)`
+    if !block_given? && `is_infinite(self)`
       return Float::INFINITY
     end
     super
   end
 
   def to_a
-    raise TypeError, 'cannot convert endless range to an array' if `infinite(self)`
+    raise TypeError, 'cannot convert endless range to an array' if `is_infinite(self)`
     super
   end
 
@@ -154,7 +154,7 @@ class Range
     infinity = Float::INFINITY
 
     return 0 if (@begin == infinity && !@end.nil?) || (@end == -infinity && !@begin.nil?)
-    return infinity if `infinite(self)`
+    return infinity if `is_infinite(self)`
     return nil unless Numeric === @begin && Numeric === @end
 
     range_begin = @begin
@@ -255,7 +255,7 @@ class Range
   def bsearch(&block)
     return enum_for(:bsearch) unless block_given?
 
-    if `infinite(self) && (self.begin.$$is_number || self.end.$$is_number)`
+    if `is_infinite(self) && (self.begin.$$is_number || self.end.$$is_number)`
       raise NotImplementedError, "Can't #bsearch an infinite range"
     end
 

--- a/opal/corelib/range.rb
+++ b/opal/corelib/range.rb
@@ -9,7 +9,7 @@ class Range
 
   def initialize(first, last, exclude = false)
     raise NameError, "'initialize' called twice" if @begin
-    raise ArgumentError, 'bad value for range' unless first <=> last
+    raise ArgumentError, 'bad value for range' unless first <=> last || first.nil? || last.nil?
 
     @begin = first
     @end   = last
@@ -20,15 +20,35 @@ class Range
     include? value
   end
 
+  %x{
+    function infinite(self) {
+      if (self.begin === nil || self.end === nil ||
+          self.begin === -Infinity || self.end === Infinity ||
+          self.begin === Infinity || self.end === -Infinity) return true;
+      return false;
+    }
+  }
+
+  def count(&block)
+    if !block_given? && `infinite(self)`
+      return Float::INFINITY
+    end
+    super
+  end
+
+  def to_a
+    raise TypeError, 'cannot convert endless range to an array' if `infinite(self)`
+    super
+  end
+
   def cover?(value)
-    beg_cmp = (@begin <=> value)
-    return false unless beg_cmp && beg_cmp <= 0
-    end_cmp = (value <=> @end)
+    beg_cmp = (@begin.nil? && -1) || (@begin <=> value) || false
+    end_cmp = (@end.nil? && -1) || (value <=> @end) || false
     if @excl
       end_cmp && end_cmp < 0
     else
       end_cmp && end_cmp <= 0
-    end
+    end && beg_cmp && beg_cmp <= 0
   end
 
   def each(&block)
@@ -62,7 +82,7 @@ class Range
       raise TypeError, "can't iterate from #{current.class}"
     end
 
-    while (current <=> last) < 0
+    while @end.nil? || (current <=> last) < 0
       yield current
 
       current = current.succ
@@ -88,6 +108,7 @@ class Range
   end
 
   def first(n = undefined)
+    raise RangeError, 'cannot get the minimum of beginless range' if @begin.nil?
     return @begin if `n == null`
     super
   end
@@ -95,17 +116,19 @@ class Range
   alias include? cover?
 
   def last(n = undefined)
+    raise RangeError, 'cannot get the maximum of endless range' if @end.nil?
     return @end if `n == null`
     to_a.last(n)
   end
 
   # FIXME: currently hardcoded to assume range holds numerics
   def max
-    if block_given?
+    if @end.nil?
+      raise RangeError, 'cannot get the maximum of endless range'
+    elsif block_given?
       super
-    elsif @begin > @end
-      nil
-    elsif @excl && @begin == @end
+    elsif !@begin.nil? && (@begin > @end ||
+                           @excl && @begin == @end)
       nil
     else
       `#{@excl} ? #{@end} - 1 : #{@end}`
@@ -115,11 +138,12 @@ class Range
   alias member? cover?
 
   def min
-    if block_given?
+    if @begin.nil?
+      raise RangeError, 'cannot get the minimum of beginless range'
+    elsif block_given?
       super
-    elsif @begin > @end
-      nil
-    elsif @excl && @begin == @end
+    elsif !@end.nil? && (@begin > @end ||
+                         @excl && @begin == @end)
       nil
     else
       @begin
@@ -127,14 +151,16 @@ class Range
   end
 
   def size
+    infinity = Float::INFINITY
+
+    return infinity if `infinite(self)`
+    return nil unless Numeric === @begin && Numeric === @end
+
     range_begin = @begin
     range_end   = @end
     range_end  -= 1 if @excl
 
-    return nil unless Numeric === range_begin && Numeric === range_end
     return 0 if range_end < range_begin
-    infinity = Float::INFINITY
-    return infinity if [range_begin.abs, range_end.abs].include?(infinity)
 
     `Math.abs(range_end - range_begin) + 1`.to_i
   end
@@ -228,6 +254,10 @@ class Range
   def bsearch(&block)
     return enum_for(:bsearch) unless block_given?
 
+    if `infinite(self) && (self.begin.$$is_number || self.end.$$is_number)`
+      raise NotImplementedError, "Can't #bsearch an infinite range"
+    end
+
     unless `self.begin.$$is_number && self.end.$$is_number`
       raise TypeError, "can't do binary search for #{@begin.class}"
     end
@@ -236,11 +266,11 @@ class Range
   end
 
   def to_s
-    "#{@begin}#{@excl ? '...' : '..'}#{@end}"
+    "#{@begin.nil? ? '' : @begin}#{@excl ? '...' : '..'}#{@end.nil? ? '' : @end}"
   end
 
   def inspect
-    "#{@begin.inspect}#{@excl ? '...' : '..'}#{@end.inspect}"
+    "#{@begin.nil? ? '' : @begin.inspect}#{@excl ? '...' : '..'}#{@end.nil? ? '' : @end.inspect}"
   end
 
   def marshal_load(args)

--- a/opal/corelib/range.rb
+++ b/opal/corelib/range.rb
@@ -267,11 +267,11 @@ class Range
   end
 
   def to_s
-    "#{@begin.nil? ? '' : @begin}#{@excl ? '...' : '..'}#{@end.nil? ? '' : @end}"
+    "#{@begin || ''}#{@excl ? '...' : '..'}#{@end || ''}"
   end
 
   def inspect
-    "#{@begin.nil? ? '' : @begin.inspect}#{@excl ? '...' : '..'}#{@end.nil? ? '' : @end.inspect}"
+    "#{@begin && @begin.inspect}#{@excl ? '...' : '..'}#{@end && @end.inspect}"
   end
 
   def marshal_load(args)

--- a/spec/filters/bugs/language.rb
+++ b/spec/filters/bugs/language.rb
@@ -128,8 +128,6 @@ opal_filter "language" do
   fails "Literal (A::X) constant resolution uses the module or class #inspect to craft the error message if they are anonymous" # Expected NameError (/uninitialized constant <unusable info>::DOES_NOT_EXIST/) but got: NameError (uninitialized constant #<Module:0x50c0>::DOES_NOT_EXIST)
   fails "Literal (A::X) constant resolution uses the module or class #name to craft the error message" # Expected NameError (/uninitialized constant ModuleName::DOES_NOT_EXIST/) but got: NameError (uninitialized constant #<Module:0x50ba>::DOES_NOT_EXIST)
   fails "Literal (A::X) constant resolution with dynamically assigned constants evaluates the right hand side before evaluating a constant path"
-  fails "Literal Ranges creates beginless ranges" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Literal Ranges creates endless ranges" # Opal::SyntaxError: undefined method `type' for nil
   fails "Literal Regexps caches the Regexp object"
   fails "Literal Regexps raises a RegexpError for lookbehind with specific characters" # Expected RegexpError but no exception was raised (0 was returned)
   fails "Literal Regexps support handling unicode 9.0 characters with POSIX bracket expressions" # Expected "" to equal "𐓘"

--- a/spec/filters/bugs/language.rb
+++ b/spec/filters/bugs/language.rb
@@ -434,7 +434,6 @@ opal_filter "language" do
   fails "The yield call taking no arguments ignores assignment to the explicit block argument and calls the passed block"
   fails "a method definition that sets more than one default parameter all to the same value only allows overriding the default value of the first such parameter in each set" # ArgumentError: [MSpecEnv#foo] wrong number of arguments(2 for -1)
   fails "a method definition that sets more than one default parameter all to the same value treats the argument after the multi-parameter normally" # ArgumentError: [MSpecEnv#bar] wrong number of arguments(3 for -1)
-  fails "delegation with def(...) parses as open endless Range when brackets are omitted" # Opal::SyntaxError: Unsupported sexp: forward_args
   fails "self in a metaclass body (class << obj) raises a TypeError for numbers"
   fails "self in a metaclass body (class << obj) raises a TypeError for symbols"
   fails "self.send(:block_given?) returns false when a method defined by define_method is called with a block"

--- a/spec/filters/bugs/range.rb
+++ b/spec/filters/bugs/range.rb
@@ -2,138 +2,103 @@
 opal_filter "Range" do
   fails "Range#% produces an arithmetic sequence with a percent sign in #inspect" # NoMethodError: undefined method `%' for 1..10
   fails "Range#% works as a Range#step" # NoMethodError: undefined method `%' for 1..10
-  fails "Range#== returns true if the endpoints are == for beginless ranges" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#== returns true if the endpoints are == for endless ranges" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#== works for endless Ranges" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#=== requires #succ method to be implemented" # Expected TypeError (/can't iterate from/) but no exception was raised (true was returned)
-  fails "Range#=== returns true if other is an element of self for endless ranges" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#bsearch with Float values with a block returning negative, zero, positive numbers accepts (+/-)Float::INFINITY from the block"
+  fails "Range#bsearch with Float values with a block returning negative, zero, positive numbers accepts (+/-)Float::INFINITY from the block" # TypeError: can't iterate from Float
   fails "Range#bsearch with Float values with a block returning negative, zero, positive numbers returns a boundary element if appropriate" # NoMethodError: undefined method `prev_float' for 3
   fails "Range#bsearch with Float values with a block returning negative, zero, positive numbers returns an element at an index for which block returns 0 (small numbers)" # TypeError: can't iterate from Float
-  fails "Range#bsearch with Float values with a block returning negative, zero, positive numbers returns an element at an index for which block returns 0"
-  fails "Range#bsearch with Float values with a block returning negative, zero, positive numbers returns nil if the block never returns zero"
-  fails "Range#bsearch with Float values with a block returning negative, zero, positive numbers returns nil if the block returns greater than zero for every element"
-  fails "Range#bsearch with Float values with a block returning negative, zero, positive numbers returns nil if the block returns less than zero for every element"
-  fails "Range#bsearch with Float values with a block returning negative, zero, positive numbers works with infinity bounds" # TypeError: can't iterate from Float
+  fails "Range#bsearch with Float values with a block returning negative, zero, positive numbers returns an element at an index for which block returns 0" # TypeError: can't iterate from Float
+  fails "Range#bsearch with Float values with a block returning negative, zero, positive numbers returns nil if the block never returns zero" # TypeError: can't iterate from Float
+  fails "Range#bsearch with Float values with a block returning negative, zero, positive numbers returns nil if the block returns greater than zero for every element" # TypeError: can't iterate from Float
+  fails "Range#bsearch with Float values with a block returning negative, zero, positive numbers returns nil if the block returns less than zero for every element" # TypeError: can't iterate from Float
+  fails "Range#bsearch with Float values with a block returning negative, zero, positive numbers works with infinity bounds" # NotImplementedError: Can't #bsearch an infinite range
   fails "Range#bsearch with Float values with a block returning true or false returns a boundary element if appropriate" # NoMethodError: undefined method `prev_float' for 3
-  fails "Range#bsearch with Float values with a block returning true or false returns minimum element if the block returns true for every element"
-  fails "Range#bsearch with Float values with a block returning true or false returns nil if the block returns false for every element"
-  fails "Range#bsearch with Float values with a block returning true or false returns nil if the block returns nil for every element"
-  fails "Range#bsearch with Float values with a block returning true or false returns the smallest element for which block returns true"
-  fails "Range#bsearch with Float values with a block returning true or false works with infinity bounds" # TypeError: can't iterate from Float
-  fails "Range#bsearch with beginless ranges and Float values with a block returning negative, zero, positive numbers accepts (+/-)Float::INFINITY from the block" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#bsearch with beginless ranges and Float values with a block returning negative, zero, positive numbers returns an element at an index for which block returns 0" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#bsearch with beginless ranges and Float values with a block returning negative, zero, positive numbers returns an element at an index for which block returns 0.0" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#bsearch with beginless ranges and Float values with a block returning negative, zero, positive numbers returns nil if the block never returns zero" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#bsearch with beginless ranges and Float values with a block returning negative, zero, positive numbers returns nil if the block returns greater than zero for every element" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#bsearch with beginless ranges and Float values with a block returning negative, zero, positive numbers returns nil if the block returns less than zero for every element" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#bsearch with beginless ranges and Float values with a block returning negative, zero, positive numbers works with infinity bounds" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#bsearch with beginless ranges and Float values with a block returning true or false returns nil if the block returns nil for every element" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#bsearch with beginless ranges and Float values with a block returning true or false returns nil if the block returns true for every element" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#bsearch with beginless ranges and Float values with a block returning true or false returns the smallest element for which block returns true" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#bsearch with beginless ranges and Float values with a block returning true or false works with infinity bounds" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#bsearch with beginless ranges and Integer values with a block returning negative, zero, positive numbers accepts Float::INFINITY from the block" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#bsearch with beginless ranges and Integer values with a block returning negative, zero, positive numbers returns an element at an index for which block returns 0" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#bsearch with beginless ranges and Integer values with a block returning negative, zero, positive numbers returns an element at an index for which block returns 0.0" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#bsearch with beginless ranges and Integer values with a block returning negative, zero, positive numbers returns nil if the block never returns zero" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#bsearch with beginless ranges and Integer values with a block returning negative, zero, positive numbers returns nil if the block returns greater than zero for every element" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#bsearch with beginless ranges and Integer values with a block returning true or false returns the smallest element for which block returns true" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#bsearch with endless ranges and Float values with a block returning negative, zero, positive numbers accepts (+/-)Float::INFINITY from the block" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#bsearch with endless ranges and Float values with a block returning negative, zero, positive numbers returns an element at an index for which block returns 0" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#bsearch with endless ranges and Float values with a block returning negative, zero, positive numbers returns an element at an index for which block returns 0.0" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#bsearch with endless ranges and Float values with a block returning negative, zero, positive numbers returns nil if the block never returns zero" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#bsearch with endless ranges and Float values with a block returning negative, zero, positive numbers returns nil if the block returns greater than zero for every element" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#bsearch with endless ranges and Float values with a block returning negative, zero, positive numbers returns nil if the block returns less than zero for every element" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#bsearch with endless ranges and Float values with a block returning negative, zero, positive numbers works with infinity bounds" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#bsearch with endless ranges and Float values with a block returning true or false returns minimum element if the block returns true for every element" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#bsearch with endless ranges and Float values with a block returning true or false returns nil if the block returns false for every element" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#bsearch with endless ranges and Float values with a block returning true or false returns nil if the block returns nil for every element" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#bsearch with endless ranges and Float values with a block returning true or false returns the smallest element for which block returns true" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#bsearch with endless ranges and Float values with a block returning true or false works with infinity bounds" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#bsearch with endless ranges and Integer values with a block returning negative, zero, positive numbers accepts -Float::INFINITY from the block" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#bsearch with endless ranges and Integer values with a block returning negative, zero, positive numbers returns an element at an index for which block returns 0" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#bsearch with endless ranges and Integer values with a block returning negative, zero, positive numbers returns an element at an index for which block returns 0.0" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#bsearch with endless ranges and Integer values with a block returning negative, zero, positive numbers returns nil if the block never returns zero" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#bsearch with endless ranges and Integer values with a block returning negative, zero, positive numbers returns nil if the block returns less than zero for every element" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#bsearch with endless ranges and Integer values with a block returning true or false returns minimum element if the block returns true for every element" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#bsearch with endless ranges and Integer values with a block returning true or false returns the smallest element for which block returns true" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#count returns Infinity for beginless ranges without arguments or blocks" # Opal::SyntaxError: undefined method `type' for nil
+  fails "Range#bsearch with Float values with a block returning true or false returns minimum element if the block returns true for every element" # TypeError: can't iterate from Float
+  fails "Range#bsearch with Float values with a block returning true or false returns nil if the block returns false for every element" # TypeError: can't iterate from Float
+  fails "Range#bsearch with Float values with a block returning true or false returns nil if the block returns nil for every element" # TypeError: can't iterate from Float
+  fails "Range#bsearch with Float values with a block returning true or false returns the smallest element for which block returns true" # TypeError: can't iterate from Float
+  fails "Range#bsearch with Float values with a block returning true or false works with infinity bounds" # NotImplementedError: Can't #bsearch an infinite range
+  fails "Range#bsearch with beginless ranges and Float values with a block returning negative, zero, positive numbers accepts (+/-)Float::INFINITY from the block" # NotImplementedError: Can't #bsearch an infinite range
+  fails "Range#bsearch with beginless ranges and Float values with a block returning negative, zero, positive numbers returns an element at an index for which block returns 0" # NotImplementedError: Can't #bsearch an infinite range
+  fails "Range#bsearch with beginless ranges and Float values with a block returning negative, zero, positive numbers returns an element at an index for which block returns 0.0" # NotImplementedError: Can't #bsearch an infinite range
+  fails "Range#bsearch with beginless ranges and Float values with a block returning negative, zero, positive numbers returns nil if the block never returns zero" # NotImplementedError: Can't #bsearch an infinite range
+  fails "Range#bsearch with beginless ranges and Float values with a block returning negative, zero, positive numbers returns nil if the block returns greater than zero for every element" # NotImplementedError: Can't #bsearch an infinite range
+  fails "Range#bsearch with beginless ranges and Float values with a block returning negative, zero, positive numbers returns nil if the block returns less than zero for every element" # NotImplementedError: Can't #bsearch an infinite range
+  fails "Range#bsearch with beginless ranges and Float values with a block returning negative, zero, positive numbers works with infinity bounds" # NoMethodError: undefined method `inf' for #<MSpecEnv:0x1b536>
+  fails "Range#bsearch with beginless ranges and Float values with a block returning true or false returns nil if the block returns nil for every element" # NotImplementedError: Can't #bsearch an infinite range
+  fails "Range#bsearch with beginless ranges and Float values with a block returning true or false returns nil if the block returns true for every element" # NotImplementedError: Can't #bsearch an infinite range
+  fails "Range#bsearch with beginless ranges and Float values with a block returning true or false returns the smallest element for which block returns true" # NotImplementedError: Can't #bsearch an infinite range
+  fails "Range#bsearch with beginless ranges and Float values with a block returning true or false works with infinity bounds" # NoMethodError: undefined method `inf' for #<MSpecEnv:0x1b536>
+  fails "Range#bsearch with beginless ranges and Integer values with a block returning negative, zero, positive numbers accepts Float::INFINITY from the block" # NotImplementedError: Can't #bsearch an infinite range
+  fails "Range#bsearch with beginless ranges and Integer values with a block returning negative, zero, positive numbers returns an element at an index for which block returns 0" # NotImplementedError: Can't #bsearch an infinite range
+  fails "Range#bsearch with beginless ranges and Integer values with a block returning negative, zero, positive numbers returns an element at an index for which block returns 0.0" # NotImplementedError: Can't #bsearch an infinite range
+  fails "Range#bsearch with beginless ranges and Integer values with a block returning negative, zero, positive numbers returns nil if the block never returns zero" # NotImplementedError: Can't #bsearch an infinite range
+  fails "Range#bsearch with beginless ranges and Integer values with a block returning negative, zero, positive numbers returns nil if the block returns greater than zero for every element" # NotImplementedError: Can't #bsearch an infinite range
+  fails "Range#bsearch with beginless ranges and Integer values with a block returning true or false returns the smallest element for which block returns true" # NotImplementedError: Can't #bsearch an infinite range
+  fails "Range#bsearch with endless ranges and Float values with a block returning negative, zero, positive numbers accepts (+/-)Float::INFINITY from the block" # NotImplementedError: Can't #bsearch an infinite range
+  fails "Range#bsearch with endless ranges and Float values with a block returning negative, zero, positive numbers returns an element at an index for which block returns 0" # NotImplementedError: Can't #bsearch an infinite range
+  fails "Range#bsearch with endless ranges and Float values with a block returning negative, zero, positive numbers returns an element at an index for which block returns 0.0" # NotImplementedError: Can't #bsearch an infinite range
+  fails "Range#bsearch with endless ranges and Float values with a block returning negative, zero, positive numbers returns nil if the block never returns zero" # NotImplementedError: Can't #bsearch an infinite range
+  fails "Range#bsearch with endless ranges and Float values with a block returning negative, zero, positive numbers returns nil if the block returns greater than zero for every element" # NotImplementedError: Can't #bsearch an infinite range
+  fails "Range#bsearch with endless ranges and Float values with a block returning negative, zero, positive numbers returns nil if the block returns less than zero for every element" # NotImplementedError: Can't #bsearch an infinite range
+  fails "Range#bsearch with endless ranges and Float values with a block returning negative, zero, positive numbers works with infinity bounds" # NoMethodError: undefined method `inf' for #<MSpecEnv:0x1b536>
+  fails "Range#bsearch with endless ranges and Float values with a block returning true or false returns minimum element if the block returns true for every element" # NotImplementedError: Can't #bsearch an infinite range
+  fails "Range#bsearch with endless ranges and Float values with a block returning true or false returns nil if the block returns false for every element" # NotImplementedError: Can't #bsearch an infinite range
+  fails "Range#bsearch with endless ranges and Float values with a block returning true or false returns nil if the block returns nil for every element" # NotImplementedError: Can't #bsearch an infinite range
+  fails "Range#bsearch with endless ranges and Float values with a block returning true or false returns the smallest element for which block returns true" # NotImplementedError: Can't #bsearch an infinite range
+  fails "Range#bsearch with endless ranges and Float values with a block returning true or false works with infinity bounds" # NoMethodError: undefined method `inf' for #<MSpecEnv:0x1b536>
+  fails "Range#bsearch with endless ranges and Integer values with a block returning negative, zero, positive numbers accepts -Float::INFINITY from the block" # NotImplementedError: Can't #bsearch an infinite range
+  fails "Range#bsearch with endless ranges and Integer values with a block returning negative, zero, positive numbers returns an element at an index for which block returns 0" # NotImplementedError: Can't #bsearch an infinite range
+  fails "Range#bsearch with endless ranges and Integer values with a block returning negative, zero, positive numbers returns an element at an index for which block returns 0.0" # NotImplementedError: Can't #bsearch an infinite range
+  fails "Range#bsearch with endless ranges and Integer values with a block returning negative, zero, positive numbers returns nil if the block never returns zero" # NotImplementedError: Can't #bsearch an infinite range
+  fails "Range#bsearch with endless ranges and Integer values with a block returning negative, zero, positive numbers returns nil if the block returns less than zero for every element" # NotImplementedError: Can't #bsearch an infinite range
+  fails "Range#bsearch with endless ranges and Integer values with a block returning true or false returns minimum element if the block returns true for every element" # NotImplementedError: Can't #bsearch an infinite range
+  fails "Range#bsearch with endless ranges and Integer values with a block returning true or false returns the smallest element for which block returns true" # NotImplementedError: Can't #bsearch an infinite range
   fails "Range#cover? range argument accepts range argument" # Expected false to be true
   fails "Range#cover? range argument honors exclusion of right boundary (:exclude_end option)" # Expected false to be true
   fails "Range#cover? range argument supports boundaries of different comparable types" # Expected false to be true
-  fails "Range#cover? returns true if other is an element of self for endless ranges" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#each raises a TypeError beginless ranges" # Expected TypeError but got: Opal::SyntaxError (undefined method `type' for nil)
-  fails "Range#each raises a TypeError if the first element is a Time object"
-  fails "Range#each works with String endless ranges" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#each works with endless ranges" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#eql? returns false if the endpoints are not eql?"
-  fails "Range#eql? works for endless Ranges" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#first raises a RangeError when called on an beginless range" # Expected RangeError but got: Opal::SyntaxError (undefined method `type' for nil)
-  fails "Range#first raises a TypeError if #to_int does not return an Integer"
-  fails "Range#hash generates a Fixnum for the hash value"
+  fails "Range#each raises a TypeError if the first element is a Time object" # Expected TypeError but no exception was raised (2021-01-02 22:49:45 +0100..2021-01-02 22:49:46 +0100 was returned)
+  fails "Range#eql? returns false if the endpoints are not eql?" # Expected 0..1 not to have same value or type as 0..1
+  fails "Range#first raises a TypeError if #to_int does not return an Integer" # Expected TypeError but no exception was raised ([2] was returned)
   fails "Range#hash generates an Integer for the hash value" # Expected "A,1,1,0" (String) to be an instance of Integer
   fails "Range#include? on string elements returns false if other is not matched by element.succ" # Expected true to be false
-  fails "Range#include? returns true if other is an element of self for endless ranges" # Opal::SyntaxError: undefined method `type' for nil
   fails "Range#include? with weird succ when excluded end value returns false if other is not matched by element.succ" # Expected true to be false
   fails "Range#include? with weird succ when included end value returns false if other is equal as last element but not matched by element.succ" # Expected true to be false
   fails "Range#include? with weird succ when included end value returns false if other is not matched by element.succ" # Expected true to be false
   fails "Range#initialize raises a FrozenError if called on an already initialized Range" # Expected FrozenError but got: NameError ('initialize' called twice)
-  fails "Range#inspect works for beginless ranges" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#inspect works for endless ranges" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#inspect works for nil ... nil ranges" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#last raises a RangeError when called on an endless range" # Expected RangeError but got: Opal::SyntaxError (undefined method `type' for nil)
-  fails "Range#last raises a TypeError if #to_int does not return an Integer"
-  fails "Range#max given a block calls #> and #< on the return value of the block"
-  fails "Range#max given a block raises RangeError when called with custom comparison method on an beginless range" # Expected RangeError but got: Opal::SyntaxError (undefined method `type' for nil)
-  fails "Range#max raises RangeError when called on an endless range" # Expected RangeError but got: Opal::SyntaxError (undefined method `type' for nil)
-  fails "Range#max raises TypeError when called on a Time...Time(excluded end point)"
-  fails "Range#max raises TypeError when called on an exclusive range and a non Integer value"
-  fails "Range#max raises for an exclusive beginless range" # Expected TypeError (cannot exclude end value with non Integer begin value) but got: Opal::SyntaxError (undefined method `type' for nil)
-  fails "Range#max returns the end point for beginless ranges" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#max returns the maximum value in the range when called with no arguments"
-  fails "Range#member? on string elements returns false if other is not matched by element.succ"
-  fails "Range#member? returns true if other is an element of self for endless ranges" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#member? with weird succ when excluded end value returns false if other is not matched by element.succ"
-  fails "Range#member? with weird succ when included end value returns false if other is equal as last element but not matched by element.succ"
-  fails "Range#member? with weird succ when included end value returns false if other is not matched by element.succ"
-  fails "Range#min given a block calls #> and #< on the return value of the block"
-  fails "Range#min given a block raises RangeError when called with custom comparison method on an endless range" # Expected RangeError but got: Opal::SyntaxError (undefined method `type' for nil)
-  fails "Range#min raises RangeError when called on an beginless range" # Expected RangeError but got: Opal::SyntaxError (undefined method `type' for nil)
-  fails "Range#min returns the start point for endless ranges" # Opal::SyntaxError: undefined method `type' for nil
+  fails "Range#inspect works for nil ... nil ranges" # Expected ".." == "nil..nil" to be truthy but was false
+  fails "Range#last raises a TypeError if #to_int does not return an Integer" # Expected TypeError but no exception was raised ([3] was returned)
+  fails "Range#max given a block calls #> and #< on the return value of the block" # Mock 'obj' expected to receive >("any_args") exactly 2 times but received it 0 times
+  fails "Range#max given a block raises RangeError when called with custom comparison method on an beginless range" # Expected RangeError but got: TypeError (can't iterate from NilClass)
+  fails "Range#max raises TypeError when called on a Time...Time(excluded end point)" # Expected TypeError but no exception was raised (1609624185562 was returned)
+  fails "Range#max raises TypeError when called on an exclusive range and a non Integer value" # Expected TypeError but no exception was raised (907.1111 was returned)
+  fails "Range#max raises for an exclusive beginless range" # Expected TypeError (cannot exclude end value with non Integer begin value) but no exception was raised (0 was returned)
+  fails "Range#max returns the maximum value in the range when called with no arguments" # Expected NaN == "e" to be truthy but was false
+  fails "Range#member? on string elements returns false if other is not matched by element.succ" # Expected true to be false
+  fails "Range#member? with weird succ when excluded end value returns false if other is not matched by element.succ" # Expected true to be false
+  fails "Range#member? with weird succ when included end value returns false if other is equal as last element but not matched by element.succ" # Expected true to be false
+  fails "Range#member? with weird succ when included end value returns false if other is not matched by element.succ" # Expected true to be false
+  fails "Range#min given a block calls #> and #< on the return value of the block" # Mock 'obj' expected to receive >("any_args") exactly 2 times but received it 0 times
   fails "Range#minmax on an exclusive range raises TypeError if the end value is not an integer" # Expected TypeError (cannot exclude non Integer end value) but got: TypeError (can't iterate from Float)
-  fails "Range#minmax on an exclusive range should raise RangeError on a beginless range" # ArgumentError: bad value for range
+  fails "Range#minmax on an exclusive range should raise RangeError on a beginless range" # Expected RangeError (/cannot get the maximum of beginless range with custom comparison method|cannot get the minimum of beginless range/) but got: TypeError (can't iterate from NilClass)
   fails "Range#minmax on an exclusive range should raise RangeError on an endless range" # Mock 'x': method <=>  called with unexpected arguments (nil)
-  fails "Range#minmax on an inclusive range raises RangeError or ArgumentError on a beginless range" # ArgumentError: bad value for range
+  fails "Range#minmax on an inclusive range raises RangeError or ArgumentError on a beginless range" # Expected ArgumentError (comparison of NilClass with MockObject failed) but got: TypeError (can't iterate from NilClass)
   fails "Range#minmax on an inclusive range should raise RangeError on an endless range without iterating the range" # Mock 'x': method <=>  called with unexpected arguments (nil)
   fails "Range#minmax on an inclusive range should return the minimum and maximum values for a non-numeric range without iterating the range" # Mock 'x' expected to receive succ("any_args") exactly 0 times but received it 1 times
   fails "Range#minmax on an inclusive range should return the minimum and maximum values for a numeric range without iterating the range" # TypeError: can't iterate from Float
-  fails "Range#size returns Float::INFINITY for all beginless ranges" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#size returns Float::INFINITY for endless ranges if the start is numeric" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#size returns nil for endless ranges if the start is not numeric" # Opal::SyntaxError: undefined method `type' for nil
+  fails "Range#size returns nil for endless ranges if the start is not numeric" # Expected Infinity == nil to be truthy but was false
   fails "Range#step when no block is given raises an ArgumentError if step is 0" # Expected ArgumentError but no exception was raised (#<Enumerator: -1..1:step(0)> was returned)
-  fails "Range#step when no block is given returned Enumerator size raises a TypeError if #to_int does not return an Integer" # Expected TypeError but no exception was raised (#<Enumerator: 1..2:step(#<MockObject:0x13494>)> was returned)
-  fails "Range#step when no block is given returned Enumerator size raises a TypeError if step does not respond to #to_int" # Expected TypeError but no exception was raised (#<Enumerator: 1..2:step(#<MockObject:0x13478>)> was returned)
+  fails "Range#step when no block is given returned Enumerator size raises a TypeError if #to_int does not return an Integer" # Expected TypeError but no exception was raised (#<Enumerator: 1..2:step(#<MockObject:0x2d238>)> was returned)
+  fails "Range#step when no block is given returned Enumerator size raises a TypeError if step does not respond to #to_int" # Expected TypeError but no exception was raised (#<Enumerator: 1..2:step(#<MockObject:0x2d214>)> was returned)
   fails "Range#step when no block is given returned Enumerator size returns the ceil of range size divided by the number of steps even if step is negative" # ArgumentError: step can't be negative
   fails "Range#step when no block is given returned Enumerator type when both begin and end are numerics returns an instance of Enumerator::ArithmeticSequence" # Expected Enumerator == Enumerator::ArithmeticSequence to be truthy but was false
-  fails "Range#step with an endless range and Float values handles infinite values at the start" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#step with an endless range and Float values yields Float values incremented by 1 and less than end when not passed a step" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#step with an endless range and Float values yields Float values incremented by a Float step" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#step with an endless range and Float values yields Float values incremented by an Integer step" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#step with an endless range and Integer values yield Integer values incremented by 1 when not passed a step" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#step with an endless range and Integer values yields Float values incremented by a Float step" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#step with an endless range and Integer values yields Integer values incremented by an Integer step" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#step with an endless range and String values raises a TypeError when passed a Float step" # Expected TypeError but got: Opal::SyntaxError (undefined method `type' for nil)
-  fails "Range#step with an endless range and String values yields String values incremented by #succ and less than or equal to end when not passed a step" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#step with an endless range and String values yields String values incremented by #succ called Integer step times" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range#step with exclusive end and Float values returns Float values of 'step * n + begin < end'" # precision errors
-  fails "Range#step with exclusive end and String values raises a TypeError when passed a Float step" # requires Fixnum != Float
-  fails "Range#step with inclusive end and Float values returns Float values of 'step * n + begin <= end'" # precision errors
-  fails "Range#step with inclusive end and String values raises a TypeError when passed a Float step" # requires Fixnum != Float
-  fails "Range#to_a throws an exception for beginless ranges" # Expected TypeError but got: Opal::SyntaxError (undefined method `type' for nil)
-  fails "Range#to_a throws an exception for endless ranges" # Expected RangeError but got: Opal::SyntaxError (undefined method `type' for nil)
-  fails "Range#to_s can show endless ranges" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Range.new beginless/endless range allows beginless left boundary" # ArgumentError: bad value for range
-  fails "Range.new beginless/endless range allows endless right boundary" # ArgumentError: bad value for range
-  fails "Range.new beginless/endless range distinguishes ranges with included and excluded right boundary" # ArgumentError: bad value for range
+  fails "Range#step with an endless range and Float values yields Float values incremented by a Float step" # Expected [-1, 0] to have same value and type as [-1, -0.5, 0, 0.5]
+  fails "Range#step with an endless range and Integer values yields Float values incremented by a Float step" # Expected [-2, 1] to have same value and type as [-2, -0.5, 1]
+  fails "Range#step with exclusive end and Float values returns Float values of 'step * n + begin < end'" # Expected [1, 2.8, 4.6, 1, 19.2, 37.4, 55.599999999999994] to have same value and type as [1, 2.8, 4.6, 1, 19.2, 37.4]
+  fails "Range#step with exclusive end and String values raises a TypeError when passed a Float step" # Expected TypeError but no exception was raised ("A"..."G" was returned)
+  fails "Range#step with inclusive end and Float values returns Float values of 'step * n + begin <= end'" # Expected [1, 2.8, 4.6, 6.4, 1, 2.3, 3.6, 4.9, 6.2, 7.5, 8.8, 10.1, 11.4] to have same value and type as [1, 2.8, 4.6, 6.4, 1, 2.3, 3.6, 4.9, 6.2, 7.5, 8.8, 10.1, 11.4, 12.7]
+  fails "Range#step with inclusive end and String values raises a TypeError when passed a Float step" # Expected TypeError but no exception was raised ("A".."G" was returned)
+  fails "Range#to_a throws an exception for endless ranges" # Expected RangeError but got: TypeError (cannot convert endless range to an array)
+  fails "Range#to_s can show endless ranges" # Expected "1..." == "1.0..." to be truthy but was false
+  fails_badly "Range#min given a block raises RangeError when called with custom comparison method on an endless range" # Expected RangeError but got: Opal::SyntaxError (undefined method `type' for nil)
   fails_badly "Range#minmax on an exclusive range should return the minimum and maximum values for a numeric range without iterating the range"
+  fails_badly "Range#step with an endless range and String values raises a TypeError when passed a Float step" # Expected TypeError but got: Opal::SyntaxError (undefined method `type' for nil)
 end

--- a/spec/lib/compiler_spec.rb
+++ b/spec/lib/compiler_spec.rb
@@ -42,6 +42,22 @@ RSpec.describe Opal::Compiler do
     expect_compiled('"hello #{100}"').to include('"hello "', '100')
   end
 
+  it "should compile ruby ranges" do
+    expect_compiled('1..1').to include('$range(1, 1, false)')
+    expect_compiled('1...1').to include('$range(1, 1, true)')
+    expect_compiled('..1').to include('$range(nil, 1, false)')
+    expect_compiled('...1').to include('$range(nil, 1, true)')
+    expect_compiled('1..').to include('$range(1, nil, false)')
+    expect_compiled('1...').to include('$range(1, nil, true)')
+    # Following return Opal.range.$new instead of $range. Some also miss a space.
+    expect_compiled('nil..1').to include('(nil, 1, false)')
+    expect_compiled('nil...1').to include('(nil,1, true)')
+    expect_compiled('"a"..nil').to include('("a", nil, false)')
+    expect_compiled('"a"...nil').to include('("a",nil, true)')
+    expect_compiled('..nil').to include('(nil, nil, false)')
+    expect_compiled('...nil').to include('(nil,nil, true)')
+  end
+
   it "should compile method calls" do
     expect_compiled("self.inspect").to include("$inspect()")
     expect_compiled("self.map { |a| a + 10 }").to include("$map")

--- a/spec/opal/core/language/infinite_range_spec.rb
+++ b/spec/opal/core/language/infinite_range_spec.rb
@@ -1,0 +1,13 @@
+describe "Infinite ranges" do
+  it "supports endless ranges" do
+    range = (10..)
+    range.begin.should == 10
+    range.end.should == nil
+  end
+
+  it "supports beginless ranges" do
+    range = (..10)
+    range.begin.should == nil
+    range.end.should == 10
+  end
+end


### PR DESCRIPTION
This commit adds support for beginless and endless ranges as in `(..1)` and `(1..)`.

I tried to test it to the best of my abilities, but Ruby specs are quite outdated as of now. So I mark it as a work in progress until those tests are updated.