### PR TITLE
Parser 3.0: Forward arguments support: def a(...); puts(...); end

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,6 +1,7 @@
 ### Added
 
 - Support for multiple arguments in Hash#{merge, merge!, update} (#2187)
+- Support for Ruby 3.0 forward arguments: `def a(...) puts(...) end` (#2153)
 
 ### Fixed
 

--- a/lib/opal/nodes/args/parameters.rb
+++ b/lib/opal/nodes/args/parameters.rb
@@ -30,6 +30,7 @@ module Opal
 
         def on_restarg(arg_name = nil)
           if arg_name
+            arg_name = :* if arg_name == :fwd_rest_arg
             %{['rest', '#{arg_name}']}
           else
             %{['rest']}
@@ -53,6 +54,7 @@ module Opal
         end
 
         def on_blockarg(arg_name)
+          arg_name = :& if arg_name == :fwd_block_arg
           %{['block', '#{arg_name}']}
         end
 

--- a/lib/opal/rewriter.rb
+++ b/lib/opal/rewriter.rb
@@ -14,6 +14,7 @@ require 'opal/rewriters/mlhs_args'
 require 'opal/rewriters/inline_args'
 require 'opal/rewriters/numblocks'
 require 'opal/rewriters/returnable_logic'
+require 'opal/rewriters/forward_args'
 
 module Opal
   class Rewriter
@@ -45,6 +46,7 @@ module Opal
     use Rewriters::OpalEngineCheck
     use Rewriters::ForRewriter
     use Rewriters::Numblocks
+    use Rewriters::ForwardArgs
     use Rewriters::BlockToIter
     use Rewriters::DotJsSyntax
     use Rewriters::JsReservedWords

--- a/lib/opal/rewriters/forward_args.rb
+++ b/lib/opal/rewriters/forward_args.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'opal/rewriters/base'
+
+module Opal
+  module Rewriters
+    class ForwardArgs < Base
+      def on_forward_args(_node)
+        process(
+          s(:args, s(:forward_arg, :"$"))
+        )
+      end
+
+      def on_args(node)
+        if node.children.last && node.children.last.type == :forward_arg
+          prev_children = node.children[0..-2]
+
+          node.updated(nil,
+            [
+              *prev_children,
+              s(:restarg, '$fwd_rest'),
+              s(:blockarg, '$fwd_block')
+            ]
+          )
+        else
+          super
+        end
+      end
+
+      def on_send(node)
+        if node.children.last &&
+           node.children.last.class != Symbol &&
+           node.children.last.type == :forwarded_args
+
+          prev_children = node.children[0..-2]
+
+          node.updated(nil,
+            [
+              *prev_children,
+              s(:splat,
+                s(:lvar, '$fwd_rest')
+              ),
+              s(:block_pass,
+                s(:lvar, '$fwd_block')
+              )
+            ]
+          )
+        else
+          super
+        end
+      end
+    end
+  end
+end

--- a/spec/filters/bugs/language.rb
+++ b/spec/filters/bugs/language.rb
@@ -436,8 +436,6 @@ opal_filter "language" do
   fails "The yield call taking no arguments ignores assignment to the explicit block argument and calls the passed block"
   fails "a method definition that sets more than one default parameter all to the same value only allows overriding the default value of the first such parameter in each set" # ArgumentError: [MSpecEnv#foo] wrong number of arguments(2 for -1)
   fails "a method definition that sets more than one default parameter all to the same value treats the argument after the multi-parameter normally" # ArgumentError: [MSpecEnv#bar] wrong number of arguments(3 for -1)
-  fails "delegation with def(...) delegates block" # Opal::SyntaxError: Unsupported sexp: forward_args
-  fails "delegation with def(...) delegates rest and kwargs" # Opal::SyntaxError: Unsupported sexp: forward_args
   fails "delegation with def(...) parses as open endless Range when brackets are omitted" # Opal::SyntaxError: Unsupported sexp: forward_args
   fails "self in a metaclass body (class << obj) raises a TypeError for numbers"
   fails "self in a metaclass body (class << obj) raises a TypeError for symbols"

--- a/spec/opal/core/language/forward_args_spec.rb
+++ b/spec/opal/core/language/forward_args_spec.rb
@@ -1,0 +1,53 @@
+describe "Forward arguments" do
+  it "forwards args, kwargs and blocks" do
+    def fwd_t1_pass1(...)
+      fwd_t1_pass2(...)
+    end
+
+    def fwd_t1_pass2(*args, **kwargs, &block)
+      [args.count, kwargs.count, block_given?]
+    end
+
+    fwd_t1_pass1(1, 2, 3, a: 1, b: 2).should == [3, 2, false]
+    fwd_t1_pass1(1, 2, &:itself).should == [2, 0, true]
+    fwd_t1_pass1(a: 1, b: 2).should == [0, 2, false]
+  end
+
+  it "supports forwarding with initial arguments (3.0 behavior)" do
+    def fwd_t2_pass1(initial, ...)
+      fwd_t2_pass2(0, initial + 1, ...)
+    end
+
+    def fwd_t2_pass2(a, b, c)
+      a + b + c
+    end
+
+    fwd_t2_pass1(2, 3).should == 6
+    error = nil
+    begin
+      fwd_t2_pass1(2, 3, 4) # Too many arguments passwd to fwd_t2_pass2
+    rescue ArgumentError
+      error = :ArgumentError
+    end
+    error.should == :ArgumentError
+  end
+
+  it "supports forwarding to multiple methods at once" do
+    def fwd_t3_pass1(...)
+      fwd_t3_pass2a(...) + fwd_t3_pass2b(...) + fwd_t3_pass2c(...)
+    end
+
+    def fwd_t3_pass2a(*args)
+      -2 * args.count
+    end
+    def fwd_t3_pass2b(*args)
+      1 * args.count
+    end
+    def fwd_t3_pass2c(*args)
+      0 * args.count
+    end
+
+    fwd_t3_pass1(0, 0, 0).should == -3
+    fwd_t3_pass1(0, 0).should == -2
+  end
+end


### PR DESCRIPTION
Support 2.7 + 3.0 argument forwarding.

Now instead of:

```
def method_missing(meth, *args, **kwargs, &block)
  send(:"do_#{ meth }", *args, **kwargs, &block)
end
```

We will be able to write:

```
def method_missing(meth, ...)
  send(:"do_#{ meth }", ...)
end
```

WIP again due to tests not present yet.