### PR TITLE
Output less code for opal_engine_check

### DIFF
--- a/lib/opal/rewriters/opal_engine_check.rb
+++ b/lib/opal/rewriters/opal_engine_check.rb
@@ -9,14 +9,12 @@ module Opal
         test, true_body, false_body = *node.children
 
         if skip_check_present?(test)
-          false_body = s(:nil)
+          process(true_body || s(:nil))
+        elsif skip_check_present_not?(test)
+          process(false_body || s(:nil))
+        else
+          super
         end
-
-        if skip_check_present_not?(test)
-          true_body = s(:nil)
-        end
-
-        node.updated(nil, process_all([test, true_body, false_body]))
       end
 
       def skip_check_present?(test)


### PR DESCRIPTION
The rationale for that is that if/else blocks already share the closure in JS (we don't output `let` variables at this time yet), so nothing is expected to break. Another rationale is that old code produced more code than needed, for example it created an empty
else block even if no else block was present, now the worst case scenario is adding an empty `nil`.

This commit fixes #1965.