### PR TITLE
Remove BasicObject#class

### DIFF
--- a/opal/corelib/basic_object.rb
+++ b/opal/corelib/basic_object.rb
@@ -134,10 +134,6 @@ class BasicObject
   def singleton_method_undefined(*)
   end
 
-  def class
-    `self.$$class`
-  end
-
   def method_missing(symbol, *args, &block)
     message = if `self.$inspect && !self.$inspect.$$stub`
                 "undefined method `#{symbol}' for #{inspect}:#{`self.$$class`}"


### PR DESCRIPTION
MRI defines it on Kernel (as we also do) and not on basic object.

Fixes #2164 