### PR TITLE
Comment out the "Failed to load WithCLexer, using pure Ruby lexer" warning

### DIFF
--- a/lib/opal/parser/with_c_lexer.rb
+++ b/lib/opal/parser/with_c_lexer.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
+# There's no compatible c_lexer for parser 3.0.0.0 at this point...
 begin
   require 'c_lexer'
 rescue LoadError
-  $stderr.puts 'Failed to load WithCLexer, using pure Ruby lexer'
+  $stderr.puts 'Failed to load WithCLexer, using pure Ruby lexer' if $DEBUG
 end
 
 if defined? Parser::Ruby25WithWithCLexer


### PR DESCRIPTION
The rationale behind this is that we don't have a matching c_lexer for
parser 3.0.0.0 and this warning can be misleading. It isn't code removal,
as we may want to reenable this warning once c_lexer becomes compatible.