### PR TITLE
Fix Number#to_i with huge number

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,6 +2,7 @@
 ### Fixed
 
 - Encoding lookup was working only with uppercase names, not giving any errors for wrong ones (#2181, #2183, #2190)
+- Fix `Number#to_i` with huge number (#2191)
 
 ### Changed
 ### Deprecated

--- a/opal/corelib/number.rb
+++ b/opal/corelib/number.rb
@@ -865,7 +865,7 @@ class Number < Numeric
   end
 
   def to_i
-    `parseInt(self, 10)`
+    `self < 0 ? Math.ceil(self) : Math.floor(self)`
   end
 
   alias to_int to_i

--- a/spec/filters/unsupported/float.rb
+++ b/spec/filters/unsupported/float.rb
@@ -33,6 +33,9 @@ opal_unsupported_filter "Float" do
   fails "Float#to_s emits a trailing '.0' for a whole number"
   fails "Float#to_s emits a trailing '.0' for the mantissa in e format"
   fails "Float#to_s returns '0.0' for 0.0"
+  fails "Float#<=> returns 1 when self is negative and other is -Infinity" # Expected 0 == 1
+  fails "Float#<=> returns 1 when self is Infinity and other is an Integer" # Expected 0 == 1
+  fails "Float#<=> returns -1 when self is -Infinity and other is negative" # Expected 0 == -1
   fails "Math.gamma returns approximately (n-1)! given n for n between 24 and 30" # precision error
   fails "Numeric#step with keyword arguments when no block is given returned Enumerator size when self, stop or step is a Float and step is positive returns the difference between self and stop divided by the number of steps"
   fails "Numeric#step with mixed arguments when no block is given returned Enumerator size when self, stop or step is a Float and step is positive returns the difference between self and stop divided by the number of steps"

--- a/spec/filters/unsupported/integer.rb
+++ b/spec/filters/unsupported/integer.rb
@@ -24,6 +24,9 @@ opal_unsupported_filter "Integer" do
   fails "Integer#<< (with n << m) fixnum returns an Bignum == fixnum_max * 2 when fixnum_max << 1 and n > 0" # Expected 2147483646 (Number) to be an instance of Bignum
   fails "Integer#<< (with n << m) fixnum returns an Bignum == fixnum_min * 2 when fixnum_min << 1 and n < 0" # Expected -2147483648 (Number) to be an instance of Bignum
   fails "Integer#<= bignum returns false if compares with near float" # Expected true to equal false
+  fails "Integer#<=> bignum returns -1 when self is -Infinity and other is negative" # Expected 0 == -1
+  fails "Integer#<=> bignum returns 1 when self is Infinity and other is a Bignum" # Expected 0 == 1
+  fails "Integer#<=> bignum returns 1 when self is negative and other is -Infinity" # Expected 0 == 1
   fails "Integer#<=> bignum with a Bignum when other is negative returns -1 when self is negative and other is larger" # Expected 0 to equal -1
   fails "Integer#<=> bignum with a Bignum when other is negative returns 1 when self is negative and other is smaller" # Expected 0 to equal 1
   fails "Integer#<=> bignum with a Bignum when other is positive returns -1 when self is positive and other is larger" # Expected 0 to equal -1

--- a/spec/filters/unsupported/time.rb
+++ b/spec/filters/unsupported/time.rb
@@ -123,6 +123,7 @@ opal_unsupported_filter "Time" do
   fails "Time#utc_offset returns the correct offset for US Eastern time zone around daylight savings time change"
   fails "Time#utc_offset returns the offset in seconds between the timezone of time and UTC"
   fails "Time#wday returns an integer representing the day of the week, 0..6, with Sunday being 0"
+  fails "Time#yday returns an integer representing the day of the year, 1..366" # Expected 117 == 116
   fails "Time#year returns the four digit year for a Time with a fixed offset"
   fails "Time#year returns the four digit year for a local Time as an Integer"
   fails "Time#zone Encoding.default_internal is set doesn't raise errors for a Time with a fixed offset"

--- a/spec/opal/core/number/to_i_spec.rb
+++ b/spec/opal/core/number/to_i_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe 'Number#to_i' do
+  it "should not change huge number" do
+    1504642339053716000000.to_i.should == 1504642339053716000000
+  end
+
+  it "should not change negative huge number" do
+    -1504642339053716000000.to_i.should == -1504642339053716000000
+  end
+
+  it "equals Number#truncate(0) with huge number" do
+    1504642339053716000000.to_i.should == 1504642339053716000000.truncate(0)
+  end
+
+  it "should not change Infinity" do
+    `Infinity`.to_i.should == `Infinity`
+  end
+
+  it "should not change -Infinity" do
+    `-Infinity`.to_i.should == `-Infinity`
+  end
+
+  it "should not change NaN" do
+    x = `NaN`.to_i
+    `Number.isNaN(x)`.should be_true
+  end
+end


### PR DESCRIPTION
This pull request fixes the behavior of `Number#to_i` to that of `Math.trunc()` of JavaScript.

Before the fix, `Number#to_i` with a huge number in exponential notation returns a small number due to `parseInt()` specification of JavaScript. `parseInt()` converts numbers to strings and then parses it. `parseInt()` doesn't support exponential notation.

If `parseInt()` encounters a character that is not a numeral in the specified radix, it ignores it and all succeeding characters and returns the integer value parsed up to that point.

## e.g.
```ruby
# In Opal (before the fix)
1504642339053716000000.to_s #=> "1.504642339053716e+21"
1504642339053716000000.to_i #=> 1
```

## Reasons for adding unsupported filter

- `Float#<=>`, `Integer#<=>`
  -  It compare `Infinity` and `Float::MAX.to_i*2`. `Float::MAX.to_i*2` will be Infinity in Opal
- `Time#yday`
  - `with_timezone` helper is not working in Opal. It uses `ENV['TZ']`

## Ref.
- parseInt()
  - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt
- Math.trunc()
  - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/trunc