### PR TITLE
Implement String#start_with with a regexp argument

### DIFF
--- a/opal/corelib/string.rb
+++ b/opal/corelib/string.rb
@@ -1142,11 +1142,11 @@ class String < `String`
     %x{
       for (var i = 0, length = prefixes.length; i < length; i++) {
         if (prefixes[i].$$is_regexp) {
-          var prefix = prefixes[i];
-          var match = prefix.exec(self);
+          var regexp = prefixes[i];
+          var match = regexp.exec(self);
 
           if (match != null && match.index === 0) {
-            #{$~ = MatchData.new(`prefix`, `match`)};
+            #{$~ = MatchData.new(`regexp`, `match`)};
             return true;
           } else {
             #{$~ = nil}

--- a/opal/corelib/string.rb
+++ b/opal/corelib/string.rb
@@ -1141,10 +1141,22 @@ class String < `String`
   def start_with?(*prefixes)
     %x{
       for (var i = 0, length = prefixes.length; i < length; i++) {
-        var prefix = $coerce_to(prefixes[i], #{String}, 'to_str').$to_s();
+        if (prefixes[i].$$is_regexp) {
+          var prefix = prefixes[i];
+          var match = prefix.exec(self);
 
-        if (self.indexOf(prefix) === 0) {
-          return true;
+          if (match != null && match.index === 0) {
+            #{$~ = MatchData.new(`prefix`, `match`)};
+            return true;
+          } else {
+            #{$~ = nil}
+          }
+        } else {
+          var prefix = $coerce_to(prefixes[i], #{String}, 'to_str').$to_s();
+
+          if (self.indexOf(prefix) === 0) {
+            return true;
+          }
         }
       }
 

--- a/spec/filters/bugs/string.rb
+++ b/spec/filters/bugs/string.rb
@@ -265,9 +265,6 @@ opal_filter "String" do
   fails "String#split with Regexp when a block is given yields the string when limit is 1" # Expected ["chunky bacon"] == "chunky bacon" to be truthy but was false
   fails "String#split with String returns String instances based on self" # Expected "x" (StringSpecs::MyString) to be an instance of String
   fails "String#squeeze returns String instances when called on a subclass" # Expected "oh no!" (StringSpecs::MyString) to be an instance of String
-  fails "String#start_with? sets Regexp.last_match if it returns true" # TypeError: no implicit conversion of Regexp into String
-  fails "String#start_with? supports regexps with ^ and $ modifiers" # TypeError: no implicit conversion of Regexp into String
-  fails "String#start_with? supports regexps" # TypeError: no implicit conversion of Regexp into String
   fails "String#sub with pattern, replacement returns String instances when called on a subclass" # Expected "" (StringSpecs::MyString) to be an instance of String
   fails "String#sub with pattern, replacement returns a copy of self when no modification is made" # Expected "hello" not to be identical to "hello"
   fails "String#succ returns String instances when called on a subclass" # Expected "" (StringSpecs::MyString) to be an instance of String


### PR DESCRIPTION
Fix #2197 and pass these test cases.

```
"String#start_with? sets Regexp.last_match if it returns true" # TypeError: no implicit conversion of Regexp into String
"String#start_with? supports regexps with ^ and $ modifiers" # TypeError: no implicit conversion of Regexp into String
"String#start_with? supports regexps" # TypeError: no implicit conversion of Regexp into String
```