### PR TITLE
Parser 3.0: Add missing tests for forward_args and numblocks rewriters

### DIFF
--- a/spec/lib/rewriters/forward_args_spec.rb
+++ b/spec/lib/rewriters/forward_args_spec.rb
@@ -1,0 +1,61 @@
+require 'lib/spec_helper'
+require 'support/rewriters_helper'
+require 'opal/rewriters/forward_args'
+
+RSpec.describe Opal::Rewriters::ForwardArgs do
+  include RewritersHelper
+  extend  RewritersHelper
+
+  before(:each) { Opal::Rewriters::ForRewriter.reset_tmp_counter! }
+
+  correct_names = proc do |ast|
+    case ast
+    when Opal::AST::Node
+      ast.children.map do |i|
+        correct_names.(i)
+      end.yield_self { |children| s(ast.type, *children) }
+    when :fwd_rest
+      "$fwd_rest"
+    when :fwd_block
+      "$fwd_block"
+    else
+      ast
+    end
+  end
+
+  include_examples 'it rewrites source-to-AST', <<~ENDSOURCE, correct_names.(parse(<<~ENDDEST))
+    def forward(...)
+      other(...)
+    end
+  ENDSOURCE
+    def forward(*fwd_rest, &fwd_block)
+      other(*fwd_rest, &fwd_block)
+    end
+  ENDDEST
+
+  include_examples 'it rewrites source-to-AST', <<~ENDSOURCE, correct_names.(parse(<<~ENDDEST))
+    def forward(first_arg, ...)
+      other(first_arg, second_arg, ...)
+      other(other_arg, ...)
+      other(...)
+    end
+  ENDSOURCE
+    def forward(first_arg, *fwd_rest, &fwd_block)
+      other(first_arg, second_arg, *fwd_rest, &fwd_block)
+      other(other_arg, *fwd_rest, &fwd_block)
+      other(*fwd_rest, &fwd_block)
+    end
+  ENDDEST
+
+  # Not supported by the parser (nor by the rewriter which would have to rearrange the arguments)
+
+  # include_examples 'it rewrites source-to-AST', <<~ENDSOURCE, correct_names.(parse(<<~ENDDEST))
+  #   def forward(a:, ...)
+  #     other(...)
+  #   end
+  # ENDSOURCE
+  #   def forward(*fwd_rest, a:, &fwd_block)
+  #     other(*fwd_rest, &fwd_block)
+  #   end
+  # ENDDEST
+end

--- a/spec/lib/rewriters/numblocks_spec.rb
+++ b/spec/lib/rewriters/numblocks_spec.rb
@@ -1,0 +1,44 @@
+require 'lib/spec_helper'
+require 'support/rewriters_helper'
+require 'opal/rewriters/numblocks'
+
+RSpec.describe Opal::Rewriters::Numblocks do
+  include RewritersHelper
+  extend  RewritersHelper
+
+  before(:each) { Opal::Rewriters::ForRewriter.reset_tmp_counter! }
+
+  correct_names = proc do |ast|
+    case ast
+    when Opal::AST::Node
+      ast.children.map do |i|
+        correct_names.(i)
+      end.yield_self { |children| s(ast.type, *children) }
+    when :arg1 then :_1
+    when :arg2 then :_2
+    when :arg3 then :_3
+    else
+      ast
+    end
+  end
+
+  include_examples 'it rewrites source-to-AST', <<~ENDSOURCE, correct_names.(parse(<<~ENDDEST))
+    proc do
+      _1
+    end
+  ENDSOURCE
+    proc do |arg1|
+      arg1
+    end
+  ENDDEST
+
+  include_examples 'it rewrites source-to-AST', <<~ENDSOURCE, correct_names.(parse(<<~ENDDEST))
+    proc do
+      _3
+    end
+  ENDSOURCE
+    proc do |arg1, arg2, arg3|
+      arg3
+    end
+  ENDDEST
+end


### PR DESCRIPTION
I couldn't find time to add those before... I will also now amend the remaining Parser 3.0 series issues to also include some rewriter tests.