### PR TITLE
Parse the NODE_OPTS environment variable in the Node runner

### DIFF
--- a/lib/opal/cli_runners/nodejs.rb
+++ b/lib/opal/cli_runners/nodejs.rb
@@ -15,7 +15,7 @@ module Opal
         argv = data[:argv].dup.to_a
         argv.unshift('--') if argv.any?
 
-        opts = Shellwords.shellwords(ENV['NODE_OPTS'] || "")
+        opts = Shellwords.shellwords(ENV['NODE_OPTS'] || '')
 
         SystemRunner.call(data) do |tempfile|
           [

--- a/lib/opal/cli_runners/nodejs.rb
+++ b/lib/opal/cli_runners/nodejs.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'shellwords'
 require 'opal/paths'
 require 'opal/cli_runners/system_runner'
 
@@ -14,10 +15,13 @@ module Opal
         argv = data[:argv].dup.to_a
         argv.unshift('--') if argv.any?
 
+        opts = Shellwords.shellwords(ENV['NODE_OPTS'] || "")
+
         SystemRunner.call(data) do |tempfile|
           [
             'node',
             '--require', "#{__dir__}/source-map-support-node",
+            *opts,
             tempfile.path,
             *argv
           ]


### PR DESCRIPTION
Add the content of the `NODE_OPTS` environment variable to the NodeJS' arguments in the node runner. This is notably useful to enable remote debugging while testing:

 ```
NODE_OPTS=--inspect-brk=0.0.0.0:9993 opal -Itest -Ilib -Ivendored-minitest \
                                           -soptparse -sio/console -stimeout -srubygems -stempfile -smonitor \
                                           -Rnodejs tmp/minitest_node_nodejs.rb
```

The string in `NODE_OPTS` is parsed using `Shellwords` (available in Ruby ≥ 1.8 according to [this SO answer](https://stackoverflow.com/a/6068282/2363712))