### PR TITLE
Rework the String constructor; fixes #2185

### DIFF
--- a/spec/filters/bugs/kernel.rb
+++ b/spec/filters/bugs/kernel.rb
@@ -112,9 +112,7 @@ opal_filter "Kernel" do
   fails "Kernel#inspect returns a String for an object without #class method" # Exception: Maximum call stack size exceeded
   fails "Kernel#instance_variables immediate values returns the correct array if an instance variable is added"
   fails "Kernel#is_a? does not take into account `class` method overriding" # TypeError: can't define singleton
-  fails "Kernel#is_a? returns true if given a Module that object has been extended with" # Requires string mutability
   fails "Kernel#kind_of? does not take into account `class` method overriding" # TypeError: can't define singleton
-  fails "Kernel#kind_of? returns true if given a Module that object has been extended with" # Requires string mutability
   fails "Kernel#local_variables contains locals as they are added"
   fails "Kernel#local_variables includes only unique variable names" # NoMethodError: undefined method `local_variables' for #<MSpecEnv:0x476>
   fails "Kernel#local_variables is accessible from bindings"

--- a/spec/filters/bugs/marshal.rb
+++ b/spec/filters/bugs/marshal.rb
@@ -21,6 +21,7 @@ opal_filter "Marshal" do
   fails "Marshal.load for a Regexp loads a extended_user_regexp having ivar"
   fails "Marshal.load for a Regexp loads an extended Regexp" # Expected /[a-z]/ == /(?:)/ to be truthy but was false
   fails "Marshal.load for a String loads a String as BINARY if no encoding is specified at the end" # Expected #<Encoding:UTF-16LE> to equal #<Encoding:ASCII-8BIT (dummy)>
+  fails "Marshal.load for a String loads a String subclass with custom constructor" # ArgumentError: [UserCustomConstructorString#initialize] wrong number of arguments(1 for 2)
   fails "Marshal.load for a Struct does not call initialize on the unmarshaled struct"
   fails "Marshal.load for a Symbol loads a Symbol" # Expected #<Encoding:UTF-16LE> to equal #<Encoding:ASCII-8BIT (dummy)>
   fails "Marshal.load for a Symbol loads a binary encoded Symbol" # Expected "â\u0086\u0092" to equal "→"

--- a/spec/filters/bugs/string.rb
+++ b/spec/filters/bugs/string.rb
@@ -339,7 +339,6 @@ opal_filter "String" do
   fails "String#upcase! modifies self in place for ASCII-only case mapping works for non-ascii-compatible encodings" # NotImplementedError: String#upcase! not supported. Mutable String methods are not supported in Opal.
   fails "String#upcase! modifies self in place for non-ascii-compatible encodings" # NotImplementedError: String#upcase! not supported. Mutable String methods are not supported in Opal.
   fails "String#valid_encoding? returns true for IBM720 encoding self is valid in" # ArgumentError: unknown encoding name - IBM720
-  fails "String.new accepts a capacity argument" # ArgumentError: [String.new] wrong number of arguments(2 for -1)
   fails "String.new accepts an encoding argument" # ArgumentError: [String.new] wrong number of arguments(2 for -1)
   fails "String.new is called on subclasses" # Expected nil to equal "subclass"
 end

--- a/spec/opal/core/string/subclassing_spec.rb
+++ b/spec/opal/core/string/subclassing_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+class MyStringSubclass < String
+  attr_reader :v
+  def initialize(s, v)
+    super(s)
+    @v = v
+  end
+end
+
+describe "String subclassing" do
+  it "should call initialize for subclasses" do
+    c = MyStringSubclass.new('s', 5)
+    [c, c.v].should == ['s', 5]
+  end
+end


### PR DESCRIPTION
Allow :encoding option to String costructor
Make sure subclasses call a constructor, with a certain limitation:
```
  # Our initialize method does nothing, the string value setup is being
  # done by String.new. Therefore not all kinds of subclassing will work.
  # As a rule of thumb, when subclassing String, either make sure to override
  # .new or make sure that the first argument given to a constructor is
  # a string we want our subclass-string to hold.
```