### PR TITLE
Opal::Cache, an optional compiler cache

### DIFF
--- a/lib/opal/builder_processors.rb
+++ b/lib/opal/builder_processors.rb
@@ -80,11 +80,15 @@ module Opal
       end
 
       def compiled
-        @compiled ||= Cache.find_key_or_exec(self.class, @filename, @source, @options) do
+        @compiled ||= Opal.cache.fetch(cache_key) do
           compiler = compiler_for(@source, file: @filename)
           compiler.compile
           compiler
         end
+      end
+
+      def cache_key
+        [self.class, @filename, @source, @options]
       end
 
       def compiler_for(source, options = {})

--- a/lib/opal/builder_processors.rb
+++ b/lib/opal/builder_processors.rb
@@ -2,6 +2,7 @@
 
 require 'opal/compiler'
 require 'opal/erb'
+require 'opal/cache'
 
 module Opal
   module BuilderProcessors
@@ -79,7 +80,7 @@ module Opal
       end
 
       def compiled
-        @compiled ||= begin
+        @compiled ||= Cache.find_key_or_exec(self.class, @filename, @source, @options) do
           compiler = compiler_for(@source, file: @filename)
           compiler.compile
           compiler

--- a/lib/opal/cache.rb
+++ b/lib/opal/cache.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+if RUBY_ENGINE != 'opal'
+  require 'fileutils'
+  require 'digest/sha2'
+end
+
+module Opal
+  module Cache
+    module_function
+
+    class CacheError < StandardError; end
+
+    if RUBY_ENGINE == 'opal'
+      def find_key_or_exec(*, &block)
+        yield
+      end
+    else
+      def disabled?
+        # In the future we may think about some kind of a compiler switch.
+        !%w[1 true TRUE].include? ENV['OPAL_CACHE']
+      end
+
+      def find_key_or_exec(klass, *key, &block)
+        if klass != Opal::BuilderProcessors::RubyProcessor || disabled?
+          yield
+        elsif File.exist?(file = cache_file_name(key))
+          Marshal.load(File.binread(file))
+        else
+          compiler = yield
+          File.binwrite(file, Marshal.dump(compiler))
+          compiler
+        end
+      end
+
+      private def cache_directory_name
+        @cache_directory_name ||= begin
+          # Is our Opal directory writable?
+          if File.writable?(dir = __dir__ + '/../..')
+            FileUtils.mkdir_p(dir += '/tmp/cache')
+          elsif File.writable?(dir = '/tmp') && File.sticky?(dir)
+            FileUtils.mkdir_p(dir += "/opal-cache-#{ENV['USER']}")
+            FileUtils.chmod(0o700, dir)
+          else
+            raise CacheError, "Can't find a reliable cache directory"
+          end
+
+          dir
+        end
+      end
+
+      private def cache_file_name(key)
+        "#{cache_directory_name}/#{runtime_hash}-#{hash key}.rbm"
+      end
+
+      private def hash(object)
+        digest object.inspect
+      end
+
+      private def digest(string)
+        Digest::SHA256.hexdigest(string)[-32..-1].to_i(16).to_s(36)
+      end
+
+      private def runtime_hash
+        @runtime_hash ||= begin
+          # We want to ensure the compiler stays untouched
+          files = Dir[__dir__ + '/../../lib/**/*']
+          # Along with our Gemfiles
+          files += Dir[__dir__ + '/../../Gemfile*']
+          files += Dir[__dir__ + '/../../*.gemspec']
+
+          str = files.map { |i| File.mtime(i).to_f.to_s }.join(',')
+
+          # Add Opal::Config
+          str << hash(Opal::Config.compiler_options)
+
+          # Compute our hash
+          digest str
+        end
+      end
+    end
+  end
+end

--- a/lib/opal/compiler.rb
+++ b/lib/opal/compiler.rb
@@ -223,7 +223,8 @@ module Opal
     # @param source_file [String] optional source_file to reference ruby source
     # @return [Opal::SourceMap]
     def source_map
-      ::Opal::SourceMap::File.new(@fragments, file, @source)
+      # We only use @source_map if compiler is cached.
+      @source_map || ::Opal::SourceMap::File.new(@fragments, file, @source, @result)
     end
 
     # Any helpers required by this file. Used by {Opal::Nodes::Top} to reference
@@ -491,6 +492,19 @@ module Opal
       else
         fragment('false', scope, sexp)
       end
+    end
+
+    # Marshalling for cache shortpath
+    def marshal_dump
+      [@options, @option_values, @source_map ||= source_map.cache,
+       @magic_comments, @result,
+       @required_trees, @requires]
+    end
+
+    def marshal_load(src)
+      @options, @option_values, @source_map,
+      @magic_comments, @result,
+      @required_trees, @requires = src
     end
   end
 end

--- a/lib/opal/source_map/file.rb
+++ b/lib/opal/source_map/file.rb
@@ -7,11 +7,12 @@ class Opal::SourceMap::File
   attr_reader :file
   attr_reader :source
 
-  def initialize(fragments, file, source)
+  def initialize(fragments, file, source, generated_code = nil)
     @fragments = fragments
     @file = file
     @source = source
     @names_map = Hash.new { |hash, name| hash[name] = hash.size }
+    @generated_code = generated_code
     @absolute_mappings = nil
   end
 

--- a/lib/opal/source_map/map.rb
+++ b/lib/opal/source_map/map.rb
@@ -5,11 +5,11 @@ require 'json'
 
 module Opal::SourceMap::Map
   def to_h
-    map
+    @to_h || map
   end
 
   def to_json
-    map.to_json
+    to_h.to_json
   end
 
   def as_json(*)
@@ -17,10 +17,24 @@ module Opal::SourceMap::Map
   end
 
   def to_s
-    map.to_s
+    to_h.to_s
   end
 
   def to_data_uri_comment
     "//# sourceMappingURL=data:application/json;base64,#{Base64.encode64(to_json).delete("\n")}"
+  end
+
+  # Marshaling for cache shortpath
+  def cache
+    @to_h ||= map
+    self
+  end
+
+  def marshal_dump
+    [to_h, generated_code]
+  end
+
+  def marshal_load(value)
+    @to_h, @generated_code = value
   end
 end


### PR DESCRIPTION
First, maybe how to use it:

```ruby
OPAL_CACHE=1 bundle exec rake mspec_opal_nodejs
```

I made it an ENV variable for now, not Opal::Config, mainly because there's a plethora of ways to call Opal and almost none of them support those options. This thing only works with Opal::Builder, so it doesn't work with opal-sprockets (but it would be trivial to add if it would be wanted, after all, Sprockets has its own cache - working better or worse).

As we all know, Opal compiles things slowly. So let's take probably the biggest Opal application out there, that is, `bundle exec rake mspec_ruby_nodejs`. So on my computer it takes 1 minute and 20 second (both with cache disabled and with cache full miss). But after cache is populated, it takes 23 seconds, almost a minute less.

Now, HOW does it work, well, this thing is a bit hacky I must say, but maybe someone will help me improve it. We cache Opal::Compiler instances (and Opal::SourceMap::File) with hand-crafted marshal_(dump,load) methods. We assume that some methods of Compiler/SourceMap won't be called, so we simply skip their instance variables if possible. Such a compiler would be useful for extracting what you usually want to extract from it, but no more.

But how and where it's stored? On disk, by 2 cache keys.

One cache key is an environment key, which is dependent on compiler options and... mtime of Opal compiler (ie. everything in lib/). The second is file key, which basically means a tuple of (filename, source, options). So you can work on Opal and have things run fast (unless you modify the compiler part, of course).

After running `mspec_opal_nodejs` the cache is 40MB. Deflating it is certainly a good idea.

The cache also isn't pruning itself automatically. It's up to user to do that at this point. At a later time we can think about some LRU, or other method so that it may be seamlessly included as a default option.