### PR TITLE
Fix `class ::String`.

### DIFF
--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -533,7 +533,7 @@
   Opal.klass = function(scope, superclass, name) {
     var bridged;
 
-    if (scope == null) {
+    if (scope == null || scope == '::') {
       // Global scope
       scope = _Object;
     } else if (!scope.$$is_class && !scope.$$is_module) {
@@ -643,7 +643,7 @@
   Opal.module = function(scope, name) {
     var module;
 
-    if (scope == null) {
+    if (scope == null || scope == '::') {
       // Global scope
       scope = _Object;
     } else if (!scope.$$is_class && !scope.$$is_module) {

--- a/spec/filters/bugs/language.rb
+++ b/spec/filters/bugs/language.rb
@@ -94,8 +94,6 @@ opal_filter "language" do
   fails "An instance method with a default argument shadows an existing method with the same name as the local"
   fails "An instance method with a default argument warns and uses a nil value when there is an existing local method with same name" # Expected warning to match: /circular argument reference/ but got: ""
   fails "Assigning an anonymous module to a constant sets the name of a module scoped by an anonymous module" # NoMethodError: undefined method `end_with?' for nil
-  fails "Constant resolution within methods with dynamically assigned constants searches Object as a lexical scope only if Object is explicitly opened"
-  fails "Constant resolution within methods with statically assigned constants searches Object as a lexical scope only if Object is explicitly opened"
   fails "Executing break from within a block raises LocalJumpError when converted into a proc during a a super call" # Expected LocalJumpError but no exception was raised (1 was returned)
   fails "Executing break from within a block returns from the original invoking method even in case of chained calls"
   fails "Executing break from within a block works when passing through a super call" # Expected to not get Exception

--- a/spec/filters/bugs/module.rb
+++ b/spec/filters/bugs/module.rb
@@ -293,5 +293,4 @@ opal_filter "Module" do
   fails "Module#using scope of refinement is not active for code defined outside the current scope" # NoMethodError: undefined method `refine' for #<Module:0x2a072>
   fails "Module#using scope of refinement is not active when class/module reopens" # NoMethodError: undefined method `refine' for #<Module:0x2a056>
   fails "Module#using works in classes too" # NoMethodError: undefined method `refine' for #<Module:0x2a01c>
-  fails "Module::Nesting returns the list of Modules nested at the point of call"
 end


### PR DESCRIPTION
The former behavior was to create a subclass of String (as
`"::".$$class` is a String), which was incorrect. The same is also
related to modules.

This should fix #1475.