### PR TITLE
Fast Complex fix

### DIFF
--- a/opal/corelib/complex.rb
+++ b/opal/corelib/complex.rb
@@ -245,7 +245,7 @@ class Complex < Numeric
 
   alias rectangular rect
 
-  undef step
+  begin; undef step; rescue; nil; end
 
   def to_f
     unless @imag == 0


### PR DESCRIPTION
With opal-optimizer, the undef step caused a regression.