### PR TITLE
Backport some methods from opal-rspec

### DIFF
--- a/opal/corelib/struct.rb
+++ b/opal/corelib/struct.rb
@@ -5,11 +5,18 @@ class Struct
 
   def self.new(const_name, *args, keyword_init: false, &block)
     if const_name
-      begin
-        const_name = Opal.const_name!(const_name)
-      rescue TypeError, NameError
+      if const_name.class == String && const_name[0].upcase != const_name[0]
+        # Fast track so that we skip needlessly going thru exceptions
+        # in most cases.
         args.unshift(const_name)
         const_name = nil
+      else
+        begin
+          const_name = Opal.const_name!(const_name)
+        rescue TypeError, NameError
+          args.unshift(const_name)
+          const_name = nil
+        end
       end
     end
 

--- a/stdlib/js.rb
+++ b/stdlib/js.rb
@@ -60,5 +60,9 @@ module JS
   end
   alias method_missing call
 
+  def [](name)
+    `Opal.global[#{name}]`
+  end
+
   extend self
 end

--- a/stdlib/nodejs/env.rb
+++ b/stdlib/nodejs/env.rb
@@ -34,6 +34,13 @@ class << ENV
     }
   end
 
+  def fetch(key, default_value = undefined, &block)
+    return self[key] if key?(key)
+    return yield key if block_given?
+    return default_value unless `typeof(#{default_value}) === 'undefined'`
+    raise KeyError, 'key not found'
+  end
+
   def to_s
     'ENV'
   end


### PR DESCRIPTION
In addition, modify the Struct initializer a little. In my experience,
I have never encountered using this to name a constant, yet this is
the default path. Let's try to create a shortpath.

The main reason for this, though, is that I really struggled with
the browser debugger trying to note all caught exceptions.

Co-authored-by: Elia Schito <elia@schito.me>