### PR TITLE
Opal::Builder::Prefork for blazingly fast multicore compilation times

### DIFF
--- a/lib/opal/builder_scheduler.rb
+++ b/lib/opal/builder_scheduler.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Opal
+  class BuilderScheduler
+    def initialize(builder)
+      @builder = builder
+    end
+
+    attr_reader :builder
+  end
+
+  singleton_class.attr_accessor :builder_scheduler
+
+  if RUBY_ENGINE != 'opal'
+    # Windows has a faulty `fork`.
+    if Gem.win_platform? || ENV['OPAL_PREFORK_DISABLE']
+      require 'opal/builder_scheduler/sequential'
+      Opal.builder_scheduler = BuilderScheduler::Sequential
+    else
+      require 'opal/builder_scheduler/prefork'
+      Opal.builder_scheduler = BuilderScheduler::Prefork
+    end
+  else
+    require 'opal/builder_scheduler/sequential'
+    Opal.builder_scheduler = BuilderScheduler::Sequential
+  end
+end

--- a/lib/opal/builder_scheduler/prefork.rb
+++ b/lib/opal/builder_scheduler/prefork.rb
@@ -1,0 +1,257 @@
+# frozen_string_literal: true
+
+require 'etc'
+
+module Opal
+  class BuilderScheduler
+    class Prefork < BuilderScheduler
+      # We hook into the process_requires method
+      def process_requires(rel_path, requires, autoloads, options)
+        return if requires.empty?
+
+        if @in_fork
+          io = @in_fork
+          io.send(:new_requires, rel_path, requires, autoloads, options)
+        else
+          prefork_reactor(rel_path, requires, autoloads, options)
+        end
+      end
+
+      private
+
+      class ForkSet < Array
+        def initialize(count, &block)
+          super([])
+
+          @count, @block = count, block
+
+          create_fork
+        end
+
+        def get_events(queue_length)
+          # Wait for anything to happen:
+          # - Either any of our workers return some data
+          # - Or any workers become ready to receive data
+          #   - But only if we have enough work for them
+          ios = IO.select(
+            map(&:read_io),
+            sample(queue_length).map(&:write_io),
+            []
+          )
+          return [[], []] unless ios
+
+          events = ios[0].map do |io|
+            io = from_io(io, :read_io)
+            [io, *io.recv]
+          end
+
+          idles = ios[1].map do |io|
+            from_io(io, :write_io)
+          end
+
+          # Progressively create forks, because we may not need all
+          # the workers at the time. The number 6 was picked due to
+          # some trial and error on a Ryzen machine.
+          #
+          # Do note that prefork may happen more than once.
+          create_fork if length < @count && rand(6) == 1
+
+          [events, idles]
+        end
+
+        def create_fork
+          self << Fork.new(self, &@block)
+        end
+
+        def from_io(io, type)
+          find { |i| i.__send__(type) == io }
+        end
+
+        def close
+          each(&:close)
+        end
+
+        def wait
+          each(&:wait)
+        end
+      end
+
+      class Fork
+        def initialize(forkset)
+          @parent_read, @child_write = IO.pipe
+          @child_read, @parent_write = IO.pipe
+          @forkset = forkset
+          @in_fork = false
+
+          @pid = fork do
+            @in_fork = true
+
+            begin
+              @parent_read.close
+              @parent_write.close
+
+              yield(self)
+            rescue => error
+              send(:exception, error)
+            ensure
+              send(:close) unless write_io.closed?
+              @child_write.close
+            end
+          end
+
+          @child_read.close
+          @child_write.close
+        end
+
+        def close
+          send(:close)
+          @parent_write.close
+        end
+
+        def goodbye
+          read_io.close unless read_io.closed?
+        end
+
+        def send_message(io, msg)
+          msg = Marshal.dump(msg)
+          io.write([msg.length].pack('Q') + msg)
+        end
+
+        def recv_message(io)
+          length, = *io.read(8).unpack('Q')
+          Marshal.load(io.read(length)) # rubocop:disable Security/MarshalLoad
+        end
+
+        def fork?
+          @in_fork
+        end
+
+        def read_io
+          fork? ? @child_read : @parent_read
+        end
+
+        def write_io
+          fork? ? @child_write : @parent_write
+        end
+
+        def eof?
+          write_io.closed?
+        end
+
+        def send(*msg)
+          send_message(write_io, msg)
+        end
+
+        def recv
+          recv_message(read_io)
+        end
+
+        def wait
+          Process.waitpid(@pid, Process::WNOHANG)
+        end
+      end
+
+      # By default we use 3/4 of CPU threads detected.
+      def fork_count
+        ENV['OPAL_PREFORK_THREADS']&.to_i || (Etc.nprocessors * 3 / 4.0).ceil
+      end
+
+      def prefork
+        @forks = ForkSet.new(fork_count, &method(:fork_entrypoint))
+      end
+
+      def fork_entrypoint(io)
+        @in_fork = io
+
+        until io.eof?
+          $0 = 'opal/builder: idle'
+
+          type, *args = *io.recv
+          case type
+          when :compile
+            rel_path, req, autoloads, options = *args
+            $0 = "opal/builder: #{req}"
+            begin
+              asset = builder.process_require_threadsafely(req, autoloads, options)
+              io.send(:new_asset, asset)
+            rescue Builder::MissingRequire => error
+              io.send(:missing_require_exception, rel_path, error)
+            end
+          when :close
+            io.goodbye
+            break
+          end
+        end
+      end
+
+      def prefork_reactor(rel_path, requires, autoloads, options)
+        prefork
+
+        first = rel_path
+        queue = requires.map { |i| [rel_path, i, autoloads, options] }
+
+        awaiting = 0
+        built = 0
+
+        $stderr.print "\r\e[K" if $stderr.tty?
+
+        loop do
+          events, idles = @forks.get_events(queue.length)
+
+          idles.each do |io|
+            break if queue.empty?
+
+            rel_path, req, autoloads, options = *queue.pop
+
+            next if builder.already_processed.include?(req)
+            awaiting += 1
+            builder.already_processed << req
+            io.send(:compile, rel_path, req, autoloads, options)
+          end
+
+          events.each do |io, type, *args|
+            case type
+            when :new_requires
+              rel_path, requires, autoloads, options = *args
+              requires.each do |i|
+                queue << [rel_path, i, autoloads, options]
+              end
+            when :new_asset
+              asset, = *args
+              if !asset
+                # Do nothing, we received a nil which is expected.
+              elsif asset.filename == 'corelib/runtime.js'
+                # Opal runtime should go first... the rest can go their way.
+                builder.processed.unshift(asset)
+              else
+                builder.processed << asset
+              end
+              built += 1
+              awaiting -= 1
+            when :missing_require_exception
+              rel_path, error = *args
+              raise error, "A file required by #{rel_path.inspect} wasn't found.\n#{error.message}", error.backtrace
+            when :exception
+              error, = *args
+              raise error
+            when :close
+              io.goodbye
+            end
+          end
+
+          if $stderr.tty?
+            percent = (100.0 * built / (awaiting + built)).round(1)
+            str = format("[opal/builder] Building %<first>s... (%<percent>4.3g%%)\r", first: first, percent: percent)
+            $stderr.print str
+          end
+
+          break if awaiting == 0 && queue.empty?
+        end
+      ensure
+        $stderr.print "\r\e[K\r" if $stderr.tty?
+        @forks.close
+        @forks.wait
+      end
+    end
+  end
+end

--- a/lib/opal/builder_scheduler/sequential.rb
+++ b/lib/opal/builder_scheduler/sequential.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Opal
+  class BuilderScheduler
+    class Sequential < BuilderScheduler
+      def process_requires(rel_path, requires, autoloads, options)
+        requires.map { |r| builder.process_require(r, autoloads, options) }
+      rescue Builder::MissingRequire => error
+        raise error, "A file required by #{rel_path.inspect} wasn't found.\n#{error.message}", error.backtrace
+      end
+    end
+  end
+end

--- a/lib/opal/cli_runners/mini_racer.rb
+++ b/lib/opal/cli_runners/mini_racer.rb
@@ -14,6 +14,10 @@ module Opal
         # TODO: pass it
         argv = data.fetch(:argv)
 
+        # MiniRacer doesn't like to fork. Let's build Opal first
+        # in a forked environment.
+        code = builder.to_s + "\n" + builder.source_map.to_data_uri_comment
+
         v8 = ::MiniRacer::Context.new
         v8.attach('prompt', ->(_msg = '') { $stdin.gets&.chomp })
         v8.attach('console.log', ->(i) { output.print(i); output.flush })
@@ -21,8 +25,6 @@ module Opal
         v8.attach('crypto.randomBytes', method(:random_bytes).to_proc)
         v8.attach('opalminiracer.exit', ->(status) { Kernel.exit(status) })
         v8.attach('opalminiracer.argv', argv)
-
-        code = builder.to_s + "\n" + builder.source_map.to_data_uri_comment
 
         v8.eval(code)
       end

--- a/lib/opal/source_map/map.rb
+++ b/lib/opal/source_map/map.rb
@@ -9,7 +9,15 @@ module Opal::SourceMap::Map
   end
 
   def to_json
-    to_h.to_json
+    map = to_h
+    map.to_json
+  rescue Encoding::UndefinedConversionError
+    map[:sections].each do |i|
+      i.to_json
+    rescue Encoding::UndefinedConversionError
+      map[:sections].delete(i)
+    end
+    map.to_json
   end
 
   def as_json(*)


### PR DESCRIPTION
Well, yes, unfortunately this uses fork, but the architecture is provided so that we can also provide other kinds of multicore builders, like for instance this attempt to use Ractor, or a win32 specific builder (using some win32 equivalent of fork or process spawning - at this time unfortunately I don't have enough win32 experience to say something intelligent).

https://github.com/opal/opal/commit/611a2af66c4ac341e249028bda16021c99d950cc

(Both use a similar approach).

Unfortunately, Ractor is not really suitable for now. In short, I gave up when I found out I would need to patch Ragel:

https://github.com/adrian-thurston/ragel/blob/ragel-6/ragel/rubycodegen.cpp#L100-L104

Such a patch, while possible, (and while it should be done) would require a lot of logistics. Thing is, Ractors are really hard to do right. The illegal operation here is that when the main Ractor defines a class, other Ractors can't access its instance properties.

This patch is done on top of #2242 so that we may use the compiler Marshaling, also we touch similar targets (the thing below is applicable to both PRs). This pull request in general implements multithreading for the following pipelines (anything that uses Opal::Builder, not Opal::Compiler)
- Opal::SimpleServer
- opal command line utilities (opal, opal-repl)
- opal builder via rake
- opal via Tilt (eg for Roda)
- opal specs (rspec, mspec, minitest)

It doesn't touch the following:
- Opal compiled with Opal
- Opal::Sprockets, anything Sprockets (Sprockets unfortunately is single threaded)
- anything Webpack (but in my opinion it may be used for that purpose as well)