### PR TITLE
Support return from lambda (fixes opal#260)

### DIFF
--- a/lib/opal/nodes/call.rb
+++ b/lib/opal/nodes/call.rb
@@ -344,6 +344,12 @@ module Opal
         push fragment "Opal.hash({ arity_check: #{compiler.arity_check?} })"
       end
 
+      add_special :lambda do |compile_default|
+        scope.defines_lambda do
+          compile_default.call
+        end
+      end
+
       add_special :nesting do |compile_default|
         push_nesting = push_nesting?
         push '(Opal.Module.$$nesting = $nesting, ' if push_nesting

--- a/lib/opal/nodes/lambda.rb
+++ b/lib/opal/nodes/lambda.rb
@@ -11,7 +11,9 @@ module Opal
       def compile
         helper :lambda
 
-        push '$lambda(', expr(iter), ')'
+        scope.defines_lambda do
+          push '$lambda(', expr(iter), ')'
+        end
       end
     end
   end

--- a/lib/opal/nodes/logic.rb
+++ b/lib/opal/nodes/logic.rb
@@ -126,13 +126,13 @@ module Opal
       end
 
       def return_in_iter?
-        if scope.iter? && parent_def = scope.find_parent_def
+        if (scope.iter? && !scope.lambda?) && parent_def = scope.find_parent_def
           parent_def
         end
       end
 
       def return_expr_in_def?
-        return scope if expr? && scope.def?
+        return scope if expr? && (scope.def? || scope.lambda?)
       end
 
       def scope_to_catch_return

--- a/lib/opal/nodes/scope.rb
+++ b/lib/opal/nodes/scope.rb
@@ -106,6 +106,24 @@ module Opal
         @type == :def || @type == :defs
       end
 
+      def lambda?
+        iter? && @is_lambda
+      end
+
+      def is_lambda! # rubocop:disable Naming/PredicateName
+        @is_lambda = true
+      end
+
+      def defines_lambda
+        @lambda_definition = true
+        yield
+        @lambda_definition = false
+      end
+
+      def lambda_definition?
+        @lambda_definition
+      end
+
       # Is this a normal def method directly inside a class? This is
       # used for optimizing ivars as we can set them to nil in the
       # class body
@@ -250,7 +268,7 @@ module Opal
       def find_parent_def
         scope = self
         while scope = scope.parent
-          if scope.def?
+          if scope.def? || scope.lambda?
             return scope
           end
         end

--- a/spec/filters/bugs/kernel.rb
+++ b/spec/filters/bugs/kernel.rb
@@ -404,4 +404,5 @@ opal_filter "Kernel" do
   fails "Kernel.sprintf returns a String in the same encoding as the format String if compatible" # NameError: uninitialized constant Encoding::KOI8_U
   fails "Kernel.sprintf width specifies the minimum number of characters that will be written to the result" # Expected "         1.095200e+02" to equal "        1.095200e+02"
   fails "Kernel.srand returns the previous seed value on the first call" # NoMethodError: undefined method `insert' for "rubyexe.rb"
+  fails "Kernel.lambda treats the block as a Proc when lambda is re-defined" # Expected 2 == 1 to be truthy but was false
 end


### PR DESCRIPTION
The lambdas are now behaving exactly as they do in Ruby, they work just
like the def in terms of the return logic.