### PR TITLE
CI: Permissively check for introduced V8 deoptimizations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,11 @@ jobs:
             ruby: 3.0
           - name: timezone
             ruby: 3.0
+          - name: optstatus
+            ruby: 3.0
+            permissive: true
+            fetchdepth: '0'
+            command: bin/rake optstatus_compare
 
           # Currently failing:
           # - ruby: truffleruby
@@ -56,8 +61,11 @@ jobs:
           # - ruby: ruby-head
 
     runs-on: ${{ matrix.combo.os || 'ubuntu-latest' }}
+    continue-on-error: ${{ matrix.combo.permissive || false }}
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: ${{ fromJSON(matrix.combo.fetchdepth || '1') }}
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.combo.ruby }}

--- a/tasks/testing.rake
+++ b/tasks/testing.rake
@@ -467,3 +467,32 @@ task :test_all => [:rspec, :mspec, :minitest]
 task(:cruby_tests) { warn "The task 'cruby_tests' has been renamed to 'minitest_cruby_nodejs'."; exit 1 }
 task(:test_cruby)  { warn "The task 'test_cruby' has been renamed to 'minitest_cruby_nodejs'."; exit 1 }
 task(:test_nodejs) { warn "The task 'test_nodejs' has been renamed to 'minitest_node_nodejs'."; exit 1 }
+
+desc "Generate V8 function optimization status report for corelib methods"
+task :optstatus do
+  system("NODE_OPTS=--allow-natives-syntax bin/opal tasks/testing/optimization_status.rb")
+end
+
+task :optstatus_compare do
+  this_ref = `git describe`.chomp
+  ref = "HEAD^"
+  ref = ENV['GITHUB_BASE_REF'] if ENV['GITHUB_BASE_REF'] && !ENV['GITHUB_BASE_REF'].empty?
+  ref = `git describe #{ref}`.chomp
+
+  system("bundle exec rake optstatus > /tmp/optstatus_current")
+  system("git checkout --recurse-submodules #{ref}")
+  system("bundle install >/dev/null 2>&1")
+  system("bundle exec rake optstatus > /tmp/optstatus_previous")
+  system("git checkout --recurse-submodules #{this_ref}")
+  system("bundle install >/dev/null 2>&1")
+
+  diff = `diff -F '^Class' -Naur /tmp/optstatus_previous /tmp/optstatus_current`
+  diff_lines = diff.split("\n")
+
+  puts
+  puts "Comparison of V8 function optimization status between #{ref} and #{this_ref}:"
+  puts diff
+  puts
+
+  fail if diff_lines.grep(/^-\s+\[COMPILED\]/).count > 0
+end

--- a/tasks/testing/optimization_status.rb
+++ b/tasks/testing/optimization_status.rb
@@ -1,0 +1,77 @@
+klasses = [
+  Array,
+  Class,
+  # Complex,
+  # Dir,
+  Enumerable,
+  Enumerator,
+  Exception,
+  Hash,
+  # Kernel,
+  Math,
+  Method,
+  Module,
+  Object,
+  Proc,
+  Range,
+  Rational,
+  Regexp,
+  Struct,
+  String,
+  Time
+]
+
+%x{
+  function getOptimizationStatus(fn) {
+    var optstatus = %GetOptimizationStatus(fn);
+
+    return (optstatus & (1 << 6)) ? "[INTERPRETED]" : "[COMPILED]";
+  }
+  
+  function triggerOptAndGetStatus(fn) {
+    // using try/catch to avoid having to call functions properly
+    try {
+      // Fill type-info
+      fn();
+      // 2 calls are needed to go from uninitialized -> pre-monomorphic -> monomorphic
+      fn();
+    }
+    catch (e) {}
+    %OptimizeFunctionOnNextCall(fn);
+    try {
+      fn();
+    }
+    catch (e) {}
+    return getOptimizationStatus(fn);
+  }
+}
+
+optimization_status = Hash[klasses.map do |klass|
+  methods = klass.instance_methods
+  methods -= Object.instance_methods unless klass == Object
+  methods -= [:product, :exit, :exit!, :at_exit]
+  opt_status = Hash[methods.map do |method|
+    method_func = `#{klass.instance_method(method)}.method`
+    [method, `triggerOptAndGetStatus(#{method_func})`]
+  end]
+  by_status_grouped = opt_status.group_by {|method, status| status }
+  as_hash = Hash[by_status_grouped.map do |status, stuff|
+    list = stuff.map {|val| val[0]}
+    [status, list]
+  end]
+  [klass, as_hash]
+end]
+
+puts '----Report----'
+optimization_status.sort_by {|klass,_| klass.name}.each do |klass, statuses|
+  puts "---------------"
+  puts "Class #{klass}:"
+  puts "---------------"
+  statuses.sort_by {|stat,_| stat }.each do |status, methods|
+    methods.sort.each do |m|
+      puts "  #{status} #{m}"
+    end
+  end
+end
+
+puts 'done!'


### PR DESCRIPTION
Co-authored-by: Brady Wied <wied03@users.noreply.github.com>

This fixes #1255

What happens on deoptimization:
- https://github.com/opal/opal/runs/3328310772?check_suite_focus=true

With pull request we check against the branch we apply the pull request for (master most probably).

Otherwise, we check against the previous commit.

Deoptimization failures are not fatal. But they can serve us some idea what went wrong.