### PR TITLE
Output Exception#full_message on uncaught exceptions

### DIFF
--- a/lib/opal/cli_runners/source-map-support-browser.js
+++ b/lib/opal/cli_runners/source-map-support-browser.js
@@ -6464,12 +6464,17 @@ function printErrorAndExit (error) {
     process.stderr._handle.setBlocking(true);
   }
 
-  if (source) {
-    console.error();
-    console.error(source);
+  if (typeof error.$full_message === 'function') {
+    console.error(error.$full_message().$chomp());
   }
+  else {
+    if (source) {
+      console.error();
+      console.error(source);
+    }
 
-  console.error(error.stack);
+    console.error(error.stack);
+  }
   process.exit(1);
 }
 

--- a/lib/opal/cli_runners/source-map-support-node.js
+++ b/lib/opal/cli_runners/source-map-support-node.js
@@ -3720,12 +3720,17 @@ function printErrorAndExit (error) {
     process.stderr._handle.setBlocking(true);
   }
 
-  if (source) {
-    console.error();
-    console.error(source);
+  if (typeof error.$full_message === 'function') {
+    console.error(error.$full_message().$chomp());
   }
+  else {
+    if (source) {
+      console.error();
+      console.error(source);
+    }
 
-  console.error(error.stack);
+    console.error(error.stack);
+  }
   process.exit(1);
 }
 

--- a/lib/opal/cli_runners/source-map-support.js
+++ b/lib/opal/cli_runners/source-map-support.js
@@ -515,12 +515,17 @@ function printErrorAndExit (error) {
     process.stderr._handle.setBlocking(true);
   }
 
-  if (source) {
-    console.error();
-    console.error(source);
+  if (typeof error.$full_message === 'function') {
+    console.error(error.$full_message().$chomp());
   }
+  else {
+    if (source) {
+      console.error();
+      console.error(source);
+    }
 
-  console.error(error.stack);
+    console.error(error.stack);
+  }
   process.exit(1);
 }
 


### PR DESCRIPTION
Before:
```
[user@localhost opal]# bin/opal <<< 'test'
  from -:1:1:in `undefined'
  from /tmp/opal-system-runner-20210814-752381-bplkgc:25233:3:in `null'
  from <js:internal/modules/cjs/loader.js>:1068:30:in `Module._compile'
  from <js:internal/modules/cjs/loader.js>:1097:10:in `Module._extensions..js'
  from <js:internal/modules/cjs/loader.js>:933:32:in `Module.load'
  from <js:internal/modules/cjs/loader.js>:774:14:in `Module._load'
  from <js:internal/modules/run_main.js>:72:12:in `executeUserEntryPoint'
```

After:
```
[user@localhost opal]# bin/opal <<< 'test'
-:1:1:in `undefined': undefined method `test' for main (NoMethodError)
	from /tmp/opal-system-runner-20210814-753127-xwfdfg:25233:3:in `null'
	from <js:internal/modules/cjs/loader.js>:1068:30:in `Module._compile'
	from <js:internal/modules/cjs/loader.js>:1097:10:in `Module._extensions..js'
	from <js:internal/modules/cjs/loader.js>:933:32:in `Module.load'
	from <js:internal/modules/cjs/loader.js>:774:14:in `Module._load'
	from <js:internal/modules/run_main.js>:72:12:in `executeUserEntryPoint'
[user@localhost opal]#
```