### PR TITLE
GJS Runner

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -10,7 +10,7 @@
   "undef"         : true, // Prohibit the use of explicitly undeclared variables
   "unused"        : true, // Warn when you define and never use your variables
 
-  "predef"        : ["Opal", "JSON", "Java", "OpalNode", "jsyaml", "globalThis", "FinalizationRegistry", "WeakMap"],
+  "predef"        : ["Opal", "JSON", "Java", "OpalNode", "jsyaml", "globalThis", "FinalizationRegistry", "WeakMap", "imports", "ARGV"],
 
   "browser": true,
   "node": true,

--- a/lib/opal/cli_runners.rb
+++ b/lib/opal/cli_runners.rb
@@ -65,6 +65,7 @@ module Opal
     register_runner :compiler,    :Compiler,    'opal/cli_runners/compiler'
     register_runner :nashorn,     :Nashorn,     'opal/cli_runners/nashorn'
     register_runner :nodejs,      :Nodejs,      'opal/cli_runners/nodejs'
+    register_runner :gjs,         :Gjs,         'opal/cli_runners/gjs'
     register_runner :server,      :Server,      'opal/cli_runners/server'
 
     alias_runner :osascript, :applescript

--- a/lib/opal/cli_runners/gjs.rb
+++ b/lib/opal/cli_runners/gjs.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'opal/paths'
+require 'opal/cli_runners/system_runner'
+require 'shellwords'
+
+module Opal
+  module CliRunners
+    # Gjs is GNOME's JavaScript runtime based on Mozilla SpiderMonkey
+    class Gjs
+      def self.call(data)
+        exe = ENV['GJS_PATH'] || 'gjs'
+
+        opts = Shellwords.shellwords(ENV['GJS_OPTS'] || '')
+
+        SystemRunner.call(data) do |tempfile|
+          [exe, *opts, tempfile.path, *data[:argv]]
+        end
+      rescue Errno::ENOENT
+        raise MissingGjs, 'Please install Gjs to be able to run Opal scripts.'
+      end
+
+      class MissingGjs < RunnerError
+      end
+    end
+  end
+end

--- a/spec/mspec-opal/formatters.rb
+++ b/spec/mspec-opal/formatters.rb
@@ -124,17 +124,17 @@ class BrowserFormatter < BaseOpalFormatter
   end
 end
 
-class NodeJSFormatter < BaseOpalFormatter
+class ColoredDottedFormatter < BaseOpalFormatter
   def red(str)
-    `process.stdout.write("\u001b[31m"+#{str}+"\u001b[0m")`
+    print "\e[31m"+str+"\e[0m"
   end
 
   def green(str)
-    `process.stdout.write("\u001b[32m"+#{str}+"\u001b[0m")`
+    print "\e[32m"+str+"\e[0m"
   end
 
   def cyan(str)
-    `process.stdout.write("\u001b[36m"+#{str}+"\u001b[0m")`
+    print "\e[36m"+str+"\e[0m"
   end
 
   def log(str)
@@ -156,6 +156,20 @@ class NodeJSFormatter < BaseOpalFormatter
 
   def finish_with_code(code)
     exit(code)
+  end
+end
+
+class NodeJSFormatter < ColoredDottedFormatter
+  def red(str)
+    `process.stdout.write("\u001b[31m"+#{str}+"\u001b[0m")`
+  end
+
+  def green(str)
+    `process.stdout.write("\u001b[32m"+#{str}+"\u001b[0m")`
+  end
+
+  def cyan(str)
+    `process.stdout.write("\u001b[36m"+#{str}+"\u001b[0m")`
   end
 end
 

--- a/spec/mspec-opal/runner.rb
+++ b/spec/mspec-opal/runner.rb
@@ -81,6 +81,7 @@ class OSpecFormatter
       'chrome'       => DottedFormatter,
       'node'         => NodeJSFormatter,
       'nodejs'       => NodeJSFormatter,
+      'gjs'          => ColoredDottedFormatter,
       'nodedoc'      => NodeJSDocFormatter,
       'nodejsdoc'    => NodeJSDocFormatter,
       'dotted'       => DottedFormatter

--- a/stdlib/gjs.rb
+++ b/stdlib/gjs.rb
@@ -1,0 +1,2 @@
+require 'gjs/io'
+require 'gjs/kernel'

--- a/stdlib/gjs/io.rb
+++ b/stdlib/gjs/io.rb
@@ -1,0 +1,25 @@
+# Basic version, appends \n:
+# $stdout.write_proc = `function(s){print(s)}`
+# $stderr.write_proc = `function(s){printerr(s)}`
+
+# Advanced version:
+%x{
+  var GLib = imports.gi.GLib;
+  var ByteArray = imports.byteArray;
+
+  var stdin = GLib.IOChannel.unix_new(0);
+  var stdout = GLib.IOChannel.unix_new(1);
+  var stderr = GLib.IOChannel.unix_new(2);
+
+  Opal.gvars.stdout.write_proc = function(s) {
+    var buf = ByteArray.fromString(s);
+    stdout.write_chars(buf, buf.length);
+    stdout.flush();
+  }
+
+  Opal.gvars.stderr.write_proc = function(s) {
+    var buf = ByteArray.fromString(s);
+    stderr.write_chars(buf, buf.length);
+    stderr.flush();
+  }
+}

--- a/stdlib/gjs/kernel.rb
+++ b/stdlib/gjs/kernel.rb
@@ -1,0 +1,3 @@
+ARGV = `ARGV`
+
+`Opal.exit = imports.system.exit`

--- a/stdlib/opal-platform.rb
+++ b/stdlib/opal-platform.rb
@@ -2,6 +2,7 @@ browser         = `typeof(document) !== "undefined"`
 node            = `typeof(process) !== "undefined" && process.versions && process.versions.node`
 nashorn         = `typeof(Java) !== "undefined" && Java.type`
 headless_chrome = `typeof(navigator) !== "undefined" && /\bHeadlessChrome\//.test(navigator.userAgent)`
+gjs             = `typeof(window) !== "undefined" && typeof(GjsFileImporter) !== 'undefined'`
 
 OPAL_PLATFORM = if nashorn
                   'nashorn'
@@ -9,5 +10,7 @@ OPAL_PLATFORM = if nashorn
                   'nodejs'
                 elsif headless_chrome
                   'headless-chrome'
+                elsif gjs
+                  'gjs'
                 else # possibly browser, which is the primary target
                 end

--- a/stdlib/opal/platform.rb
+++ b/stdlib/opal/platform.rb
@@ -3,6 +3,8 @@ require 'opal-platform'
 case OPAL_PLATFORM
 when 'nashorn'
   require 'nashorn'
+when 'gjs'
+  require 'gjs'
 when 'nodejs'
   require 'nodejs/kernel'
   require 'nodejs/io'

--- a/tasks/testing.rake
+++ b/tasks/testing.rake
@@ -284,7 +284,7 @@ Use PATTERN environment variable to manually set the glob for specs:
   bundle exec rake mspec_nodejs PATTERN=spec/ruby/core/numeric/**_spec.rb
 DESC
 
-platforms = %w[nodejs server chrome]
+platforms = %w[nodejs server chrome gjs]
 mspec_suites = %w[ruby opal]
 minitest_suites = %w[cruby]
 


### PR DESCRIPTION
First, what is GJS:
- it's GNOME's JavaScript runtime, available as /usr/bin/gjs in your Linux distribution
- it's based on Mozilla SpiderMonkey
- as it can interface libraries like GLib, Gtk, it can be used to create graphical applications, example: https://github.com/tchx84/flatseal
- it may have a feature parity with Node.js (but API may be a little bit rough, as it is quite... close to the metal)
- it can be used to for example create GNOME Shell plugins
- it's probably not too much cross-platform :D

What this commit does:
- it adds a `gjs` CLI runner
- it adds a ColoredDottedFormatter, by abstracting NodeJSFormatter
- it implements a basic `gjs` opal/platform (stdout, stderr, ARGV, exit)
- it allows to run our tests on `gjs`:
![image](https://user-images.githubusercontent.com/54514036/130541851-36261e5e-7a50-49f3-9106-7166453a931a.png)
