### PR TITLE
Bug: #to_json output differs between Ruby and Opal

### DIFF
--- a/spec/opal/stdlib/json/ext_spec.rb
+++ b/spec/opal/stdlib/json/ext_spec.rb
@@ -13,8 +13,8 @@ end
 describe "Array#to_json" do
   it "returns a string of all array elements converted to json" do
     [].to_json.should == "[]"
-    [1, 2, 3].to_json.should == "[1, 2, 3]"
-    [true, nil, false, "3", 42].to_json.should == '[true, null, false, "3", 42]'
+    [1, 2, 3].to_json.should == "[1,2,3]"
+    [true, nil, false, "3", 42].to_json.should == '[true,null,false,"3",42]'
   end
 end
 

--- a/stdlib/json.rb
+++ b/stdlib/json.rb
@@ -139,7 +139,7 @@ class Array
         result.push(#{`self[i]`.to_json});
       }
 
-      return '[' + result.join(', ') + ']';
+      return '[' + result.join(',') + ']';
     }
   end
 end


### PR DESCRIPTION
This fixes #2234

This change aligns the behavior of the hash return value with that of pry.