### PR TITLE
Make REPL actually very useful

### DIFF
--- a/lib/opal/repl.rb
+++ b/lib/opal/repl.rb
@@ -10,6 +10,8 @@ module Opal
     HISTORY_PATH = File.expand_path('~/.opal-repl-history')
 
     def initialize
+      @exit = @exit_status = nil
+
       begin
         require 'mini_racer'
       rescue LoadError
@@ -57,11 +59,12 @@ module Opal
       v8.attach('crypto.randomBytes', method(:random_bytes).to_proc)
       v8.eval Opal::Builder.new.build('opal').to_s
       v8.eval Opal::Builder.new.build('opal/replutils').to_s
-      v8.attach('Opal.exit', method(:exit).to_proc)
+      v8.attach('Opal.exit', ->(status) { @exit = true; @exit_status = status })
     end
 
     def run_line(line)
       result = eval_ruby(line)
+      Kernel.exit(@exit_status) if @exit
       puts result.to_s if result
     end
 

--- a/opal/corelib/boolean.rb
+++ b/opal/corelib/boolean.rb
@@ -15,6 +15,16 @@ class Boolean < `Boolean`
         }
       });
     }
+
+    Object.defineProperty(self.$$prototype, "$$id", {
+      configurable: true,
+      enumerable: false,
+      get: function() {
+        return this == true  ? 2 :
+               this == false ? 0 :
+                               nil;
+      }
+    });
   }
 
   class << self
@@ -61,6 +71,8 @@ class Boolean < `Boolean`
   def to_s
     `(self == true) ? 'true' : 'false'`
   end
+
+  alias inspect to_s
 
   def dup
     self

--- a/opal/corelib/class.rb
+++ b/opal/corelib/class.rb
@@ -60,4 +60,6 @@ class Class
       return #{super()};
     }
   end
+
+  alias inspect to_s
 end

--- a/opal/corelib/kernel.rb
+++ b/opal/corelib/kernel.rb
@@ -246,7 +246,11 @@ module Kernel
   end
 
   def inspect
-    to_s
+    ivs = ''
+    instance_variables.each do |i|
+      ivs += " #{i}=#{instance_variable_get(i)}"
+    end
+    "#<#{self.class}:0x#{__id__.to_s(16)}#{ivs}>"
   end
 
   def instance_of?(klass)

--- a/opal/corelib/module.rb
+++ b/opal/corelib/module.rb
@@ -629,6 +629,8 @@ class Module
     `Opal.Module.$name.call(self)` || "#<#{`self.$$is_module ? 'Module' : 'Class'`}:0x#{__id__.to_s(16)}>"
   end
 
+  alias inspect to_s
+
   def undef_method(*names)
     %x{
       for (var i = 0, length = names.length; i < length; i++) {

--- a/spec/filters/bugs/array.rb
+++ b/spec/filters/bugs/array.rb
@@ -31,7 +31,6 @@ opal_filter "Array" do
   fails "Array#flatten performs respond_to? and method_missing-aware checks when coercing elements to array"
   fails "Array#flatten with a non-Array object in the Array calls #method_missing if defined"
   fails "Array#inspect does not call #to_str on the object returned from #to_s when it is not a String" # Exception: Cannot convert object to primitive value
-  fails "Array#join raises a NoMethodError if an element does not respond to #to_str, #to_ary, or #to_s"
   fails "Array#partition returns in the left array values for which the block evaluates to true"
   fails "Array#rassoc calls elem == obj on the second element of each contained array"
   fails "Array#rassoc does not check the last element in each contained but specifically the second" # Expected [1, "foobar", #<MockObject:0x4ef6e>] to equal [2, #<MockObject:0x4ef6e>, 1]

--- a/stdlib/bigdecimal.rb
+++ b/stdlib/bigdecimal.rb
@@ -234,6 +234,7 @@ class BigDecimal < Numeric
   def to_s(s = '')
     bignumber.JS.toString
   end
+  alias inspect to_s
 
   def zero?
     bignumber.JS.isZero

--- a/stdlib/opal/replutils.rb
+++ b/stdlib/opal/replutils.rb
@@ -5,7 +5,6 @@ require 'stringio'
 module REPLUtils
   module_function
 
-  # rubocop:disable Style/LambdaCall
   def ls(object)
     methods = imethods = object.methods
     ancestors = object.class.ancestors
@@ -20,28 +19,25 @@ module REPLUtils
       cvs = object.class_variables
     end
 
-    # Blue color
-    b = proc { |i| "\e[1;34m" + i + "\e[0m" }
-    # Dark blue color
-    db = proc { |i| "\e[34m" + i + "\e[0m" }
+    blue      = ->(i) { "\e[1;34m#{i}\e[0m" }
+    dark_blue = ->(i) { "\e[34m#{i}\e[0m" }
 
     out = ''
-    out = "#{b.('class variables')}: #{cvs.map { |i| db.(i) }.sort.join('  ')}\n" + out unless cvs.empty?
-    out = "#{b.('instance variables')}: #{ivs.map { |i| db.(i) }.sort.join('  ')}\n" + out unless ivs.empty?
+    out = "#{blue['class variables']}: #{cvs.map { |i| dark_blue[i] }.sort.join('  ')}\n" + out unless cvs.empty?
+    out = "#{blue['instance variables']}: #{ivs.map { |i| dark_blue[i] }.sort.join('  ')}\n" + out unless ivs.empty?
     ancestors.each do |a|
       im = a.instance_methods(false)
       meths = (im & imethods)
       methods -= meths
       imethods -= meths
       next if meths.empty? || [Object, BasicObject, Kernel, PP::ObjectMixin].include?(a)
-      out = "#{b.("#{a.name}#methods")}: #{meths.sort.join('  ')}\n" + out
+      out = "#{blue["#{a.name}#methods"]}: #{meths.sort.join('  ')}\n" + out
     end
     methods &= object.methods(false)
-    out = "#{b.('self.methods')}: #{methods.sort.join('  ')}\n" + out unless methods.empty?
-    out = "#{b.('constants')}: #{constants.map { |i| db.(i) }.sort.join('  ')}\n" + out unless constants.empty?
+    out = "#{blue['self.methods']}: #{methods.sort.join('  ')}\n" + out unless methods.empty?
+    out = "#{blue['constants']}: #{constants.map { |i| dark_blue[i] }.sort.join('  ')}\n" + out unless constants.empty?
     out
   end
-  # rubocop:enable Style/LambdaCall
 
   def eval_and_print(func, mode)
     %x{

--- a/stdlib/opal/replutils.rb
+++ b/stdlib/opal/replutils.rb
@@ -1,0 +1,34 @@
+module REPLUtils
+  module_function
+
+  def ls(object)
+    methods = imethods = object.methods
+    ancestors = object.class.ancestors
+    constants = []
+    ivs = object.instance_variables
+    cvs = []
+
+    if [Class, Module].include? object.class
+      imethods = object.instance_methods
+      ancestors = object.ancestors
+      constants = object.constants
+      cvs = object.class_variables
+    end
+
+    out = ''
+    out = "class variables: #{cvs.sort.join('  ')}\n" + out unless cvs.empty?
+    out = "instance variables: #{ivs.sort.join('  ')}\n" + out unless ivs.empty?
+    ancestors.each do |a|
+      im = a.instance_methods(false)
+      meths = (im & imethods)
+      methods -= meths
+      imethods -= meths
+      next if meths.empty? || [Object, BasicObject, Kernel, PP::ObjectMixin].include?(a)
+      out = "#{a.name}#methods: #{meths.sort.join('  ')}\n" + out
+    end
+    methods &= object.methods(false)
+    out = "self.methods: #{methods.sort.join('  ')}\n" + out unless methods.empty?
+    out = "constants: #{constants.sort.join('  ')}\n" + out unless constants.empty?
+    out
+  end
+end

--- a/stdlib/opal/replutils.rb
+++ b/stdlib/opal/replutils.rb
@@ -1,8 +1,11 @@
 require 'pp'
+require 'stringio'
+
 
 module REPLUtils
   module_function
 
+  # rubocop:disable Style/LambdaCall
   def ls(object)
     methods = imethods = object.methods
     ancestors = object.class.ancestors
@@ -17,22 +20,28 @@ module REPLUtils
       cvs = object.class_variables
     end
 
+    # Blue color
+    b = proc { |i| "\e[1;34m" + i + "\e[0m" }
+    # Dark blue color
+    db = proc { |i| "\e[34m" + i + "\e[0m" }
+
     out = ''
-    out = "class variables: #{cvs.sort.join('  ')}\n" + out unless cvs.empty?
-    out = "instance variables: #{ivs.sort.join('  ')}\n" + out unless ivs.empty?
+    out = "#{b.('class variables')}: #{cvs.map { |i| db.(i) }.sort.join('  ')}\n" + out unless cvs.empty?
+    out = "#{b.('instance variables')}: #{ivs.map { |i| db.(i) }.sort.join('  ')}\n" + out unless ivs.empty?
     ancestors.each do |a|
       im = a.instance_methods(false)
       meths = (im & imethods)
       methods -= meths
       imethods -= meths
       next if meths.empty? || [Object, BasicObject, Kernel, PP::ObjectMixin].include?(a)
-      out = "#{a.name}#methods: #{meths.sort.join('  ')}\n" + out
+      out = "#{b.("#{a.name}#methods")}: #{meths.sort.join('  ')}\n" + out
     end
     methods &= object.methods(false)
-    out = "self.methods: #{methods.sort.join('  ')}\n" + out unless methods.empty?
-    out = "constants: #{constants.sort.join('  ')}\n" + out unless constants.empty?
+    out = "#{b.('self.methods')}: #{methods.sort.join('  ')}\n" + out unless methods.empty?
+    out = "#{b.('constants')}: #{constants.map { |i| db.(i) }.sort.join('  ')}\n" + out unless constants.empty?
     out
   end
+  # rubocop:enable Style/LambdaCall
 
   def eval_and_print(func, mode)
     %x{
@@ -46,7 +55,9 @@ module REPLUtils
       }
       else if (typeof $_result.$$class === 'undefined') {
         try {
-          return "=> " + $_result.toString() + " => " + JSON.stringify($_result, null, 2);
+          var json = JSON.stringify($_result, null, 2);
+          json = #{ColorPrinter.colorize(`json`)}
+          return "=> " + $_result.toString() + " => " + json;
         }
         catch(e) {
           return "=> " + $_result.toString();
@@ -57,7 +68,7 @@ module REPLUtils
           return #{ls(`$_result`)};
         }
         else {
-          var pretty = #{`$_result`.pretty_inspect};
+          var pretty = #{ColorPrinter.default(`$_result`)};
           // Is it multiline? If yes, add a linebreak
           if (pretty.match(/\n.*?\n/)) pretty = "\n" + pretty;
           return "=> " + pretty;
@@ -67,5 +78,177 @@ module REPLUtils
     `ret`
   rescue Exception => e # rubocop:disable Lint/RescueException
     e.full_message(highlight: true)
+  end
+
+  # Slightly based on Pry's implementation
+  class ColorPrinter < ::PP
+    # Taken from CodeRay
+    TOKEN_COLORS = {
+      debug: "\e[1;37;44m",
+
+      annotation: "\e[34m",
+      attribute_name: "\e[35m",
+      attribute_value: "\e[31m",
+      binary: {
+        self: "\e[31m",
+        char: "\e[1;31m",
+        delimiter: "\e[1;31m",
+      },
+      char: {
+        self: "\e[35m",
+        delimiter: "\e[1;35m"
+      },
+      class: "\e[1;35;4m",
+      class_variable: "\e[36m",
+      color: "\e[32m",
+      comment: {
+        self: "\e[1;30m",
+        char: "\e[37m",
+        delimiter: "\e[37m",
+      },
+      constant: "\e[1;34;4m",
+      decorator: "\e[35m",
+      definition: "\e[1;33m",
+      directive: "\e[33m",
+      docstring: "\e[31m",
+      doctype: "\e[1;34m",
+      done: "\e[1;30;2m",
+      entity: "\e[31m",
+      error: "\e[1;37;41m",
+      exception: "\e[1;31m",
+      float: "\e[1;35m",
+      function: "\e[1;34m",
+      global_variable: "\e[1;32m",
+      hex: "\e[1;36m",
+      id: "\e[1;34m",
+      include: "\e[31m",
+      integer: "\e[1;34m",
+      imaginary: "\e[1;34m",
+      important: "\e[1;31m",
+      key: {
+        self: "\e[35m",
+        char: "\e[1;35m",
+        delimiter: "\e[1;35m",
+      },
+      keyword: "\e[32m",
+      label: "\e[1;33m",
+      local_variable: "\e[33m",
+      namespace: "\e[1;35m",
+      octal: "\e[1;34m",
+      predefined: "\e[36m",
+      predefined_constant: "\e[1;36m",
+      predefined_type: "\e[1;32m",
+      preprocessor: "\e[1;36m",
+      pseudo_class: "\e[1;34m",
+      regexp: {
+        self: "\e[35m",
+        delimiter: "\e[1;35m",
+        modifier: "\e[35m",
+        char: "\e[1;35m",
+      },
+      reserved: "\e[32m",
+      shell: {
+        self: "\e[33m",
+        char: "\e[1;33m",
+        delimiter: "\e[1;33m",
+        escape: "\e[1;33m",
+      },
+      string: {
+        self: "\e[31m",
+        modifier: "\e[1;31m",
+        char: "\e[1;35m",
+        delimiter: "\e[1;31m",
+        escape: "\e[1;31m",
+      },
+      symbol: {
+        self: "\e[33m",
+        delimiter: "\e[1;33m",
+      },
+      tag: "\e[32m",
+      type: "\e[1;34m",
+      value: "\e[36m",
+      variable: "\e[34m",
+
+      insert: {
+        self: "\e[42m",
+        insert: "\e[1;32;42m",
+        eyecatcher: "\e[102m",
+      },
+      delete: {
+        self: "\e[41m",
+        delete: "\e[1;31;41m",
+        eyecatcher: "\e[101m",
+      },
+      change: {
+        self: "\e[44m",
+        change: "\e[37;44m",
+      },
+      head: {
+        self: "\e[45m",
+        filename: "\e[37;45m"
+      },
+    }
+
+    TOKEN_COLORS[:keyword] = TOKEN_COLORS[:reserved]
+    TOKEN_COLORS[:method] = TOKEN_COLORS[:function]
+    TOKEN_COLORS[:escape] = TOKEN_COLORS[:delimiter]
+
+    def self.default(obj, width = 79)
+      pager = StringIO.new
+      pp(obj, pager, width)
+      pager.string
+    end
+
+    def self.pp(obj, output = $DEFAULT_OUTPUT, max_width = 79)
+      queue = ColorPrinter.new(output, max_width, "\n")
+      queue.guard_inspect_key { queue.pp(obj) }
+      queue.flush
+      output << "\n"
+    end
+
+    def text(str, max_width = str.length)
+      super(ColorPrinter.colorize(str), max_width)
+    end
+
+    def self.token(string, *name)
+      TOKEN_COLORS.dig(*name) + string + "\e[0m"
+    end
+
+    NUMBER = '[+-]?[0-9.]+(?:e[+-][0-9]+|i)?'
+    REGEXP = '/.*?/[iesu]*'
+    TOKEN_REGEXP = /(\s+|=>|[@$:]?[a-z]\w+|[A-Z]\w+|#{NUMBER}|#{REGEXP}|".*?"|#<.*?[> ]|.)/
+
+    def self.tokenize(str)
+      str.scan(TOKEN_REGEXP).map(&:first)
+    end
+
+    def self.colorize(str)
+      tokens = tokenize(str)
+
+      tokens.map do |tok|
+        case tok
+        when /^[0-9+-]/
+          if /[.e]/ =~ tok
+            token(tok, :float)
+          else
+            token(tok, :integer)
+          end
+        when /^"/
+          token(tok, :string, :self)
+        when /^:/
+          token(tok, :symbol, :self)
+        when /^[A-Z]/
+          token(tok, :constant)
+        when /^#</, '=', '>'
+          token(tok, :keyword)
+        when /^\/./
+          token(tok, :regexp, :self)
+        when 'true', 'false', 'nil'
+          token(tok, :predefined_constant)
+        else
+          tok
+        end
+      end.join
+    end
   end
 end


### PR DESCRIPTION
Just having some fun with REPL:

```ruby
[user@localhost opal]# bin/opal-repl
>> error
<anonymous>:1434:35:in `constructor.method_missing_stub': undefined method `error' for main (NoMethodError)
	from <anonymous>:9:53:in `undefined'
	from <anonymous>:10:3:in `undefined'
	from <anonymous>:41:11:in `undefined'
>> syntax^^^error
(irb):1:8: error: unexpected token tCARET
(irb):1: syntax^^^error
(irb):1:        ^      
>> if true
..   5
.. end
=> 5
>> `{}`
=> [object Object] => {}
>> ls 123
Comparable#methods: between?  clamp
Numeric#methods: __coerced__  clone  conj  conjugate  div  dup  i  imag  imaginary  polar  pretty_print  pretty_print_cycle  real  real?  rect  rectangular  step  to_c
Number#methods: %  &  *  **  +  +@  -  -@  /  <  <<  <=  <=>  ==  ===  >  >=  >>  []  ^  __id__  abs  abs2  allbits?  angle  anybits?  arg  bit_length  ceil  chr  coerce  denominator  digits  divmod  downto  eql?  equal?  even?  fdiv  finite?  floor  gcd  gcdlcm  infinite?  inspect  instance_of?  integer?  is_a?  kind_of?  lcm  magnitude  modulo  nan?  negative?  next  nobits?  nonzero?  numerator  object_id  odd?  ord  phase  positive?  pow  pred  quo  rationalize  remainder  round  size  succ  times  to_f  to_i  to_int  to_r  to_s  truncate  upto  zero?  |  ~
>> 
```