### PR TITLE
Add support for ECMAScript modules with an --esm option

### DIFF
--- a/lib/opal/cli.rb
+++ b/lib/opal/cli.rb
@@ -140,6 +140,7 @@ module Opal
         enable_source_location
         use_strict
         parse_comments
+        esm
       ]
     end
 

--- a/lib/opal/cli_options.rb
+++ b/lib/opal/cli_options.rb
@@ -180,6 +180,10 @@ module Opal
         options[:no_cache] = true
       end
 
+      on('--esm', 'Wraps compiled bundle as for ES6 module(requires -c or -L)') do
+        options[:esm] = true
+      end
+
       separator ''
     end
 

--- a/lib/opal/compiler.rb
+++ b/lib/opal/compiler.rb
@@ -137,6 +137,11 @@ module Opal
     # Prepare the code for future requires
     compiler_option :requirable, default: false, as: :requirable?
 
+    # @!method esm?
+    #
+    # Wrap compiler result as self contained ES6 module
+    compiler_option :esm, default: false, as: :esm?
+
     # @!method inline_operators?
     #
     # are operators compiled inline

--- a/lib/opal/nodes/top.rb
+++ b/lib/opal/nodes/top.rb
@@ -51,6 +51,8 @@ module Opal
           line "Opal.modules[#{Opal::Compiler.module_name(compiler.file).inspect}] = function(Opal) {"
         elsif compiler.eval?
           line '(function(Opal, self) {'
+        elsif compiler.esm?
+          line 'export default (function(Opal) {'
         else
           line '(function(Opal) {'
         end


### PR DESCRIPTION
Simply wraps the compiler result as self executing es6 module, mainly intended for Opal::Builder to create a importable opal code bundle
```javascript

// ... lots of opal code ...

// ... final wrap:

/* Generated by Opal 1.2.0 */
export default (function(Opal) {
  var self = Opal.top, $nesting = [], nil = Opal.nil, $$$ = Opal.$$$, $$ = Opal.$$;

  Opal.add_stubs(['$require']);
  
  self.$require("opal");
  return self.$require("opal-builder");
})(Opal);
```
for a example entry file:
```ruby
require 'opal'
require 'opal-builder'
```

Resulting file can be imported like this:
```javascript
import "resulting_file.js";
```
and after that Opal will be available