### PR TITLE
Fix: warning: The "typeof" operator will never evaluate to "null": ca…

### DIFF
--- a/stdlib/json.rb
+++ b/stdlib/json.rb
@@ -29,7 +29,7 @@ module JSON
         case 'boolean':
           return !!value;
 
-        case 'null':
+        case 'undefined':
           return nil;
 
         case 'object':


### PR DESCRIPTION
Fix
: warning: The "typeof" operator will never evaluate to "null"
  40641 |         case 'null':

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof

Possibly still missing: symbol, bigint, function (for future PRs)