### PR TITLE
Escape str components in dstrs correctly

### DIFF
--- a/lib/opal/nodes/literal.rb
+++ b/lib/opal/nodes/literal.rb
@@ -235,7 +235,7 @@ module Opal
           push ' + '
 
           if part.type == :str
-            push part.children[0].inspect
+            push expr(part)
           else
             push '(', expr(part), ')'
           end

--- a/spec/lib/compiler_spec.rb
+++ b/spec/lib/compiler_spec.rb
@@ -42,6 +42,11 @@ RSpec.describe Opal::Compiler do
     expect_compiled('"hello #{100}"').to include('"hello "', '100')
   end
 
+  it "should compile ruby strings with escapes" do
+    expect_compiled('"hello \e"').to include('\u001b')
+    expect_compiled('"hello \e#{nil}"').to include('\u001b')
+  end
+
   it "should compile ruby ranges" do
     expect_compiled('1..1').to include('$range(1, 1, false)')
     expect_compiled('1...1').to include('$range(1, 1, true)')


### PR DESCRIPTION
This includes strings like "\e#{nil}" where "\e" was previously
inspected, which doesn't make sense in JavaScript.

Fixes #2281