### PR TITLE
Fix super without explicit arguments

### DIFF
--- a/lib/opal/nodes/args/extract_kwrestarg.rb
+++ b/lib/opal/nodes/args/extract_kwrestarg.rb
@@ -16,10 +16,12 @@ module Opal
         children :name
 
         def compile
-          if name
-            add_temp name
-            line "#{name} = Opal.kwrestargs($kwargs, #{used_kwargs});"
-          end
+          # def m(**)
+          # arguments are assigned to `$kw_rest_arg` for super call
+          name = self.name || '$kw_rest_arg'
+
+          add_temp name
+          line "#{name} = Opal.kwrestargs($kwargs, #{used_kwargs});"
         end
 
         def used_kwargs

--- a/lib/opal/nodes/args/extract_restarg.rb
+++ b/lib/opal/nodes/args/extract_restarg.rb
@@ -19,19 +19,17 @@ module Opal
         children :name, :args_to_keep
 
         def compile
-          if name
-            add_temp name
+          # def m(*)
+          # arguments are assigned to `$rest_arg` for super call
+          name = self.name || '$rest_arg'
 
-            if args_to_keep == 0
-              # no post-args, we are free to grab everything
-              line "#{name} = $post_args;"
-            else
-              line "#{name} = $post_args.splice(0, $post_args.length - #{args_to_keep});"
-            end
-          elsif args_to_keep != 0
-            # def m(*, a)
-            # We still have to "cut" our splat
-            line "$post_args.splice(0, $post_args.length - #{args_to_keep});"
+          add_temp name
+
+          if args_to_keep == 0
+            # no post-args, we are free to grab everything
+            line "#{name} = $post_args;"
+          else
+            line "#{name} = $post_args.splice(0, $post_args.length - #{args_to_keep});"
           end
         end
       end

--- a/lib/opal/nodes/def.rb
+++ b/lib/opal/nodes/def.rb
@@ -33,10 +33,6 @@ module Opal
 
           compile_arity_check
 
-          if scope.uses_zuper
-            prepare_super
-          end
-
           unshift "\n#{current_indent}", scope.to_vars
 
           line stmt_code
@@ -93,17 +89,6 @@ module Opal
 
       def comments_code
         '[' + comments.map { |comment| comment.text.inspect }.join(', ') + ']'
-      end
-
-      def prepare_super
-        add_local '$zuper'
-        add_local '$zuper_i'
-        add_local '$zuper_ii'
-
-        line '// Prepare super implicit arguments'
-        line 'for($zuper_i = 0, $zuper_ii = arguments.length, $zuper = new Array($zuper_ii); $zuper_i < $zuper_ii; $zuper_i++) {'
-        line '  $zuper[$zuper_i] = arguments[$zuper_i];'
-        line '}'
       end
     end
   end

--- a/lib/opal/nodes/scope.rb
+++ b/lib/opal/nodes/scope.rb
@@ -27,10 +27,6 @@ module Opal
       # used by modules to know what methods to donate to includees
       attr_reader :methods
 
-      # uses parents super method
-      attr_accessor :uses_super
-      attr_accessor :uses_zuper
-
       attr_accessor :catch_return, :has_break, :has_retry
 
       attr_accessor :rescue_else_sexp

--- a/lib/opal/rewriters/js_reserved_words.rb
+++ b/lib/opal/rewriters/js_reserved_words.rb
@@ -86,9 +86,9 @@ module Opal
         super(node)
       end
 
-      # Restarg is a special case
-      # because it may have no name
-      # def m(*); end
+      # Restarg and kwrestarg are special cases
+      # because they may have no name
+      # def m(*, **); end
       def on_restarg(node)
         name, _ = *node
 
@@ -98,6 +98,8 @@ module Opal
 
         node
       end
+
+      alias on_kwrestarg on_restarg
 
       def on_argument(node)
         node = super(node)

--- a/opal/corelib/array.rb
+++ b/opal/corelib/array.rb
@@ -647,8 +647,8 @@ class Array < `Array`
     self
   end
 
-  def count(object = nil, &block)
-    if object || block
+  def count(object = undefined, &block)
+    if `object !== undefined` || block
       super
     else
       size

--- a/spec/filters/bugs/language.rb
+++ b/spec/filters/bugs/language.rb
@@ -317,22 +317,8 @@ opal_filter "language" do
   fails "The return keyword at top level return with argument warns but does not affect exit status" # Exception: path.substr is not a function
   fails "The return keyword at top level within a block within a class is allowed" # Exception: path.substr is not a function
   fails "The return keyword at top level within a block within a class is not allowed" # Exception: path.substr is not a function
-  fails "The super keyword passes along modified rest args when they were originally empty"
-  fails "The super keyword passes along modified rest args when they weren't originally empty"
-  fails "The super keyword passes along reassigned rest args" # Expected ["bar"] to equal ["foo"]
   fails "The super keyword uses block argument given to method when used in a block" # LocalJumpError: no block given
   fails "The super keyword uses given block even if arguments are passed explicitly"
-  fails "The super keyword when using keyword arguments passes any given keyword arguments including optional and required ones to the parent"
-  fails "The super keyword when using keyword arguments passes default argument values to the parent" # Expected {} to equal {"b"=>"b"}
-  fails "The super keyword when using regular and keyword arguments passes default argument values to the parent" # Expected ["a", {}] to equal ["a", {"c"=>"c"}]
-  fails "The super keyword without explicit arguments passes arguments and rest arguments including any modifications"
-  fails "The super keyword without explicit arguments passes arguments, rest arguments including modifications, and post arguments" # Expected [1, 2, 3] == [1, 14, 3] to be truthy but was false
-  fails "The super keyword without explicit arguments passes optional arguments that have a default value but were modified"
-  fails "The super keyword without explicit arguments passes optional arguments that have a default value"
-  fails "The super keyword without explicit arguments passes optional arguments that have a non-default value but were modified"
-  fails "The super keyword without explicit arguments passes rest arguments including any modifications"
-  fails "The super keyword without explicit arguments that are '_' including any modifications" # Expected [1, 2] to equal [14, 2]
-  fails "The super keyword wraps into array and passes along reassigned rest args with non-array scalar value" # Expected ["bar"] to equal ["foo"]
   fails "The throw keyword raises an UncaughtThrowError if used to exit a thread" # NotImplementedError: Thread creation not available
   fails "The unpacking splat operator (*) when applied to a BasicObject coerces it to Array if it respond_to?(:to_a)" # NoMethodError: undefined method `respond_to?' for BasicObject
   fails "The until expression restarts the current iteration without reevaluating condition with redo"


### PR DESCRIPTION
`super` keyword's implicit argument is not compliant to MRI.

```ruby
class Parent
  def foo(*a)
    p a
  end
end

class Child < Parent
  def foo(a, b = 12, c: 34)
    a = 'reassigned'
    super
  end
end

Child.new.foo(1)
# MRI => ["reassigned", 12, {:c=>34}]
# opal => [1]
```

This PR resolves this problem.

Fixes #408