### PR TITLE
Opal-in-Opal workshop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -54,6 +54,8 @@ AllCops:
     - 'stdlib/prettyprint.rb'
     - 'stdlib/optparse.rb'
     - 'stdlib/optparse/*.rb'
+    - 'stdlib/tmpdir.rb'
+    - 'stdlib/tempfile.rb'
 
 inherit_mode:
   merge:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,6 +52,8 @@ AllCops:
     - 'stdlib/matrix/*.rb'
     - 'stdlib/pp.rb'
     - 'stdlib/prettyprint.rb'
+    - 'stdlib/optparse.rb'
+    - 'stdlib/optparse/*.rb'
 
 inherit_mode:
   merge:

--- a/lib/opal.rb
+++ b/lib/opal.rb
@@ -1,19 +1,3 @@
 # frozen_string_literal: true
 
-require 'opal/config'
-require 'opal/compiler'
-require 'opal/builder'
-require 'opal/builder_processors'
-require 'opal/erb'
-require 'opal/paths'
-require 'opal/version'
-require 'opal/errors'
-require 'opal/source_map'
-require 'opal/deprecations'
-
-# Opal is a ruby to javascript compiler, with a runtime for running
-# in any JavaScript environment.
-module Opal
-  autoload :Server, 'opal/server'
-  autoload :SimpleServer, 'opal/simple_server'
-end
+require 'opal/requires'

--- a/lib/opal/cli.rb
+++ b/lib/opal/cli.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'opal'
+require 'opal/requires'
 require 'opal/builder'
 require 'opal/cli_runners'
 

--- a/lib/opal/cli_runners/nodejs.rb
+++ b/lib/opal/cli_runners/nodejs.rb
@@ -7,7 +7,14 @@ require 'opal/cli_runners/system_runner'
 module Opal
   module CliRunners
     class Nodejs
-      NODE_PATH = File.expand_path('../stdlib/nodejs/node_modules', ::Opal.gem_dir)
+      if RUBY_ENGINE == 'opal'
+        # We can't rely on Opal.gem_dir for now...
+        NODE_PATH = 'stdlib/nodejs/node_modules'
+        DIR = './lib/opal/cli_runners'
+      else
+        NODE_PATH = File.expand_path('../stdlib/nodejs/node_modules', ::Opal.gem_dir)
+        DIR = __dir__
+      end
 
       def self.call(data)
         (data[:options] ||= {})[:env] = { 'NODE_PATH' => node_modules }
@@ -20,7 +27,7 @@ module Opal
         SystemRunner.call(data) do |tempfile|
           [
             'node',
-            '--require', "#{__dir__}/source-map-support-node",
+            '--require', "#{DIR}/source-map-support-node",
             *opts,
             tempfile.path,
             *argv

--- a/lib/opal/cli_runners/source-map-support-browser.js
+++ b/lib/opal/cli_runners/source-map-support-browser.js
@@ -154,9 +154,12 @@ function fromByteArray (uint8) {
 
 },{}],3:[function(require,module,exports){
 (function (Buffer){(function (){
+/* eslint-disable node/no-deprecated-api */
+
 var toString = Object.prototype.toString
 
 var isModern = (
+  typeof Buffer !== 'undefined' &&
   typeof Buffer.alloc === 'function' &&
   typeof Buffer.allocUnsafe === 'function' &&
   typeof Buffer.from === 'function'
@@ -3470,19 +3473,19 @@ var ArraySet = require('./array-set').ArraySet;
 var base64VLQ = require('./base64-vlq');
 var quickSort = require('./quick-sort').quickSort;
 
-function SourceMapConsumer(aSourceMap, aSourceMapURL) {
+function SourceMapConsumer(aSourceMap) {
   var sourceMap = aSourceMap;
   if (typeof aSourceMap === 'string') {
-    sourceMap = util.parseSourceMapInput(aSourceMap);
+    sourceMap = JSON.parse(aSourceMap.replace(/^\)\]\}'/, ''));
   }
 
   return sourceMap.sections != null
-    ? new IndexedSourceMapConsumer(sourceMap, aSourceMapURL)
-    : new BasicSourceMapConsumer(sourceMap, aSourceMapURL);
+    ? new IndexedSourceMapConsumer(sourceMap)
+    : new BasicSourceMapConsumer(sourceMap);
 }
 
-SourceMapConsumer.fromSourceMap = function(aSourceMap, aSourceMapURL) {
-  return BasicSourceMapConsumer.fromSourceMap(aSourceMap, aSourceMapURL);
+SourceMapConsumer.fromSourceMap = function(aSourceMap) {
+  return BasicSourceMapConsumer.fromSourceMap(aSourceMap);
 }
 
 /**
@@ -3522,8 +3525,6 @@ SourceMapConsumer.prototype._version = 3;
 
 SourceMapConsumer.prototype.__generatedMappings = null;
 Object.defineProperty(SourceMapConsumer.prototype, '_generatedMappings', {
-  configurable: true,
-  enumerable: true,
   get: function () {
     if (!this.__generatedMappings) {
       this._parseMappings(this._mappings, this.sourceRoot);
@@ -3535,8 +3536,6 @@ Object.defineProperty(SourceMapConsumer.prototype, '_generatedMappings', {
 
 SourceMapConsumer.prototype.__originalMappings = null;
 Object.defineProperty(SourceMapConsumer.prototype, '_originalMappings', {
-  configurable: true,
-  enumerable: true,
   get: function () {
     if (!this.__originalMappings) {
       this._parseMappings(this._mappings, this.sourceRoot);
@@ -3604,7 +3603,9 @@ SourceMapConsumer.prototype.eachMapping =
     var sourceRoot = this.sourceRoot;
     mappings.map(function (mapping) {
       var source = mapping.source === null ? null : this._sources.at(mapping.source);
-      source = util.computeSourceURL(sourceRoot, source, this._sourceMapURL);
+      if (source != null && sourceRoot != null) {
+        source = util.join(sourceRoot, source);
+      }
       return {
         source: source,
         generatedLine: mapping.generatedLine,
@@ -3627,16 +3628,13 @@ SourceMapConsumer.prototype.eachMapping =
  * The only argument is an object with the following properties:
  *
  *   - source: The filename of the original source.
- *   - line: The line number in the original source.  The line number is 1-based.
+ *   - line: The line number in the original source.
  *   - column: Optional. the column number in the original source.
- *    The column number is 0-based.
  *
  * and an array of objects is returned, each with the following properties:
  *
- *   - line: The line number in the generated source, or null.  The
- *    line number is 1-based.
+ *   - line: The line number in the generated source, or null.
  *   - column: The column number in the generated source, or null.
- *    The column number is 0-based.
  */
 SourceMapConsumer.prototype.allGeneratedPositionsFor =
   function SourceMapConsumer_allGeneratedPositionsFor(aArgs) {
@@ -3652,10 +3650,13 @@ SourceMapConsumer.prototype.allGeneratedPositionsFor =
       originalColumn: util.getArg(aArgs, 'column', 0)
     };
 
-    needle.source = this._findSourceIndex(needle.source);
-    if (needle.source < 0) {
+    if (this.sourceRoot != null) {
+      needle.source = util.relative(this.sourceRoot, needle.source);
+    }
+    if (!this._sources.has(needle.source)) {
       return [];
     }
+    needle.source = this._sources.indexOf(needle.source);
 
     var mappings = [];
 
@@ -3715,7 +3716,7 @@ exports.SourceMapConsumer = SourceMapConsumer;
  * query for information about the original file positions by giving it a file
  * position in the generated source.
  *
- * The first parameter is the raw source map (either as a JSON string, or
+ * The only parameter is the raw source map (either as a JSON string, or
  * already parsed to an object). According to the spec, source maps have the
  * following attributes:
  *
@@ -3738,16 +3739,12 @@ exports.SourceMapConsumer = SourceMapConsumer;
  *       mappings: "AA,AB;;ABCDE;"
  *     }
  *
- * The second parameter, if given, is a string whose value is the URL
- * at which the source map was found.  This URL is used to compute the
- * sources array.
- *
  * [0]: https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit?pli=1#
  */
-function BasicSourceMapConsumer(aSourceMap, aSourceMapURL) {
+function BasicSourceMapConsumer(aSourceMap) {
   var sourceMap = aSourceMap;
   if (typeof aSourceMap === 'string') {
-    sourceMap = util.parseSourceMapInput(aSourceMap);
+    sourceMap = JSON.parse(aSourceMap.replace(/^\)\]\}'/, ''));
   }
 
   var version = util.getArg(sourceMap, 'version');
@@ -3764,10 +3761,6 @@ function BasicSourceMapConsumer(aSourceMap, aSourceMapURL) {
   // string rather than a number, so we use loose equality checking here.
   if (version != this._version) {
     throw new Error('Unsupported version: ' + version);
-  }
-
-  if (sourceRoot) {
-    sourceRoot = util.normalize(sourceRoot);
   }
 
   sources = sources
@@ -3793,14 +3786,9 @@ function BasicSourceMapConsumer(aSourceMap, aSourceMapURL) {
   this._names = ArraySet.fromArray(names.map(String), true);
   this._sources = ArraySet.fromArray(sources, true);
 
-  this._absoluteSources = this._sources.toArray().map(function (s) {
-    return util.computeSourceURL(sourceRoot, s, aSourceMapURL);
-  });
-
   this.sourceRoot = sourceRoot;
   this.sourcesContent = sourcesContent;
   this._mappings = mappings;
-  this._sourceMapURL = aSourceMapURL;
   this.file = file;
 }
 
@@ -3808,42 +3796,14 @@ BasicSourceMapConsumer.prototype = Object.create(SourceMapConsumer.prototype);
 BasicSourceMapConsumer.prototype.consumer = SourceMapConsumer;
 
 /**
- * Utility function to find the index of a source.  Returns -1 if not
- * found.
- */
-BasicSourceMapConsumer.prototype._findSourceIndex = function(aSource) {
-  var relativeSource = aSource;
-  if (this.sourceRoot != null) {
-    relativeSource = util.relative(this.sourceRoot, relativeSource);
-  }
-
-  if (this._sources.has(relativeSource)) {
-    return this._sources.indexOf(relativeSource);
-  }
-
-  // Maybe aSource is an absolute URL as returned by |sources|.  In
-  // this case we can't simply undo the transform.
-  var i;
-  for (i = 0; i < this._absoluteSources.length; ++i) {
-    if (this._absoluteSources[i] == aSource) {
-      return i;
-    }
-  }
-
-  return -1;
-};
-
-/**
  * Create a BasicSourceMapConsumer from a SourceMapGenerator.
  *
  * @param SourceMapGenerator aSourceMap
  *        The source map that will be consumed.
- * @param String aSourceMapURL
- *        The URL at which the source map can be found (optional)
  * @returns BasicSourceMapConsumer
  */
 BasicSourceMapConsumer.fromSourceMap =
-  function SourceMapConsumer_fromSourceMap(aSourceMap, aSourceMapURL) {
+  function SourceMapConsumer_fromSourceMap(aSourceMap) {
     var smc = Object.create(BasicSourceMapConsumer.prototype);
 
     var names = smc._names = ArraySet.fromArray(aSourceMap._names.toArray(), true);
@@ -3852,10 +3812,6 @@ BasicSourceMapConsumer.fromSourceMap =
     smc.sourcesContent = aSourceMap._generateSourcesContent(smc._sources.toArray(),
                                                             smc.sourceRoot);
     smc.file = aSourceMap._file;
-    smc._sourceMapURL = aSourceMapURL;
-    smc._absoluteSources = smc._sources.toArray().map(function (s) {
-      return util.computeSourceURL(smc.sourceRoot, s, aSourceMapURL);
-    });
 
     // Because we are modifying the entries (by converting string sources and
     // names to indices into the sources and names ArraySets), we have to make
@@ -3902,7 +3858,9 @@ BasicSourceMapConsumer.prototype._version = 3;
  */
 Object.defineProperty(BasicSourceMapConsumer.prototype, 'sources', {
   get: function () {
-    return this._absoluteSources.slice();
+    return this._sources.toArray().map(function (s) {
+      return this.sourceRoot != null ? util.join(this.sourceRoot, s) : s;
+    }, this);
   }
 });
 
@@ -4083,10 +4041,8 @@ BasicSourceMapConsumer.prototype.computeColumnSpans =
  * source's line and column positions provided. The only argument is an object
  * with the following properties:
  *
- *   - line: The line number in the generated source.  The line number
- *     is 1-based.
- *   - column: The column number in the generated source.  The column
- *     number is 0-based.
+ *   - line: The line number in the generated source.
+ *   - column: The column number in the generated source.
  *   - bias: Either 'SourceMapConsumer.GREATEST_LOWER_BOUND' or
  *     'SourceMapConsumer.LEAST_UPPER_BOUND'. Specifies whether to return the
  *     closest element that is smaller than or greater than the one we are
@@ -4096,10 +4052,8 @@ BasicSourceMapConsumer.prototype.computeColumnSpans =
  * and an object is returned with the following properties:
  *
  *   - source: The original source file, or null.
- *   - line: The line number in the original source, or null.  The
- *     line number is 1-based.
- *   - column: The column number in the original source, or null.  The
- *     column number is 0-based.
+ *   - line: The line number in the original source, or null.
+ *   - column: The column number in the original source, or null.
  *   - name: The original identifier, or null.
  */
 BasicSourceMapConsumer.prototype.originalPositionFor =
@@ -4125,7 +4079,9 @@ BasicSourceMapConsumer.prototype.originalPositionFor =
         var source = util.getArg(mapping, 'source', null);
         if (source !== null) {
           source = this._sources.at(source);
-          source = util.computeSourceURL(this.sourceRoot, source, this._sourceMapURL);
+          if (this.sourceRoot != null) {
+            source = util.join(this.sourceRoot, source);
+          }
         }
         var name = util.getArg(mapping, 'name', null);
         if (name !== null) {
@@ -4172,14 +4128,12 @@ BasicSourceMapConsumer.prototype.sourceContentFor =
       return null;
     }
 
-    var index = this._findSourceIndex(aSource);
-    if (index >= 0) {
-      return this.sourcesContent[index];
+    if (this.sourceRoot != null) {
+      aSource = util.relative(this.sourceRoot, aSource);
     }
 
-    var relativeSource = aSource;
-    if (this.sourceRoot != null) {
-      relativeSource = util.relative(this.sourceRoot, relativeSource);
+    if (this._sources.has(aSource)) {
+      return this.sourcesContent[this._sources.indexOf(aSource)];
     }
 
     var url;
@@ -4189,15 +4143,15 @@ BasicSourceMapConsumer.prototype.sourceContentFor =
       // many users. We can help them out when they expect file:// URIs to
       // behave like it would if they were running a local HTTP server. See
       // https://bugzilla.mozilla.org/show_bug.cgi?id=885597.
-      var fileUriAbsPath = relativeSource.replace(/^file:\/\//, "");
+      var fileUriAbsPath = aSource.replace(/^file:\/\//, "");
       if (url.scheme == "file"
           && this._sources.has(fileUriAbsPath)) {
         return this.sourcesContent[this._sources.indexOf(fileUriAbsPath)]
       }
 
       if ((!url.path || url.path == "/")
-          && this._sources.has("/" + relativeSource)) {
-        return this.sourcesContent[this._sources.indexOf("/" + relativeSource)];
+          && this._sources.has("/" + aSource)) {
+        return this.sourcesContent[this._sources.indexOf("/" + aSource)];
       }
     }
 
@@ -4209,7 +4163,7 @@ BasicSourceMapConsumer.prototype.sourceContentFor =
       return null;
     }
     else {
-      throw new Error('"' + relativeSource + '" is not in the SourceMap.');
+      throw new Error('"' + aSource + '" is not in the SourceMap.');
     }
   };
 
@@ -4219,10 +4173,8 @@ BasicSourceMapConsumer.prototype.sourceContentFor =
  * the following properties:
  *
  *   - source: The filename of the original source.
- *   - line: The line number in the original source.  The line number
- *     is 1-based.
- *   - column: The column number in the original source.  The column
- *     number is 0-based.
+ *   - line: The line number in the original source.
+ *   - column: The column number in the original source.
  *   - bias: Either 'SourceMapConsumer.GREATEST_LOWER_BOUND' or
  *     'SourceMapConsumer.LEAST_UPPER_BOUND'. Specifies whether to return the
  *     closest element that is smaller than or greater than the one we are
@@ -4231,22 +4183,23 @@ BasicSourceMapConsumer.prototype.sourceContentFor =
  *
  * and an object is returned with the following properties:
  *
- *   - line: The line number in the generated source, or null.  The
- *     line number is 1-based.
+ *   - line: The line number in the generated source, or null.
  *   - column: The column number in the generated source, or null.
- *     The column number is 0-based.
  */
 BasicSourceMapConsumer.prototype.generatedPositionFor =
   function SourceMapConsumer_generatedPositionFor(aArgs) {
     var source = util.getArg(aArgs, 'source');
-    source = this._findSourceIndex(source);
-    if (source < 0) {
+    if (this.sourceRoot != null) {
+      source = util.relative(this.sourceRoot, source);
+    }
+    if (!this._sources.has(source)) {
       return {
         line: null,
         column: null,
         lastColumn: null
       };
     }
+    source = this._sources.indexOf(source);
 
     var needle = {
       source: source,
@@ -4290,7 +4243,7 @@ exports.BasicSourceMapConsumer = BasicSourceMapConsumer;
  * that it takes "indexed" source maps (i.e. ones with a "sections" field) as
  * input.
  *
- * The first parameter is a raw source map (either as a JSON string, or already
+ * The only parameter is a raw source map (either as a JSON string, or already
  * parsed to an object). According to the spec for indexed source maps, they
  * have the following attributes:
  *
@@ -4327,16 +4280,12 @@ exports.BasicSourceMapConsumer = BasicSourceMapConsumer;
  *    }],
  *  }
  *
- * The second parameter, if given, is a string whose value is the URL
- * at which the source map was found.  This URL is used to compute the
- * sources array.
- *
  * [0]: https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit#heading=h.535es3xeprgt
  */
-function IndexedSourceMapConsumer(aSourceMap, aSourceMapURL) {
+function IndexedSourceMapConsumer(aSourceMap) {
   var sourceMap = aSourceMap;
   if (typeof aSourceMap === 'string') {
-    sourceMap = util.parseSourceMapInput(aSourceMap);
+    sourceMap = JSON.parse(aSourceMap.replace(/^\)\]\}'/, ''));
   }
 
   var version = util.getArg(sourceMap, 'version');
@@ -4376,7 +4325,7 @@ function IndexedSourceMapConsumer(aSourceMap, aSourceMapURL) {
         generatedLine: offsetLine + 1,
         generatedColumn: offsetColumn + 1
       },
-      consumer: new SourceMapConsumer(util.getArg(s, 'map'), aSourceMapURL)
+      consumer: new SourceMapConsumer(util.getArg(s, 'map'))
     }
   });
 }
@@ -4409,18 +4358,14 @@ Object.defineProperty(IndexedSourceMapConsumer.prototype, 'sources', {
  * source's line and column positions provided. The only argument is an object
  * with the following properties:
  *
- *   - line: The line number in the generated source.  The line number
- *     is 1-based.
- *   - column: The column number in the generated source.  The column
- *     number is 0-based.
+ *   - line: The line number in the generated source.
+ *   - column: The column number in the generated source.
  *
  * and an object is returned with the following properties:
  *
  *   - source: The original source file, or null.
- *   - line: The line number in the original source, or null.  The
- *     line number is 1-based.
- *   - column: The column number in the original source, or null.  The
- *     column number is 0-based.
+ *   - line: The line number in the original source, or null.
+ *   - column: The column number in the original source, or null.
  *   - name: The original identifier, or null.
  */
 IndexedSourceMapConsumer.prototype.originalPositionFor =
@@ -4504,17 +4449,13 @@ IndexedSourceMapConsumer.prototype.sourceContentFor =
  * the following properties:
  *
  *   - source: The filename of the original source.
- *   - line: The line number in the original source.  The line number
- *     is 1-based.
- *   - column: The column number in the original source.  The column
- *     number is 0-based.
+ *   - line: The line number in the original source.
+ *   - column: The column number in the original source.
  *
  * and an object is returned with the following properties:
  *
- *   - line: The line number in the generated source, or null.  The
- *     line number is 1-based. 
+ *   - line: The line number in the generated source, or null.
  *   - column: The column number in the generated source, or null.
- *     The column number is 0-based.
  */
 IndexedSourceMapConsumer.prototype.generatedPositionFor =
   function IndexedSourceMapConsumer_generatedPositionFor(aArgs) {
@@ -4523,7 +4464,7 @@ IndexedSourceMapConsumer.prototype.generatedPositionFor =
 
       // Only consider this section if the requested source is in the list of
       // sources of the consumer.
-      if (section.consumer._findSourceIndex(util.getArg(aArgs, 'source')) === -1) {
+      if (section.consumer.sources.indexOf(util.getArg(aArgs, 'source')) === -1) {
         continue;
       }
       var generatedPosition = section.consumer.generatedPositionFor(aArgs);
@@ -4562,16 +4503,15 @@ IndexedSourceMapConsumer.prototype._parseMappings =
         var mapping = sectionMappings[j];
 
         var source = section.consumer._sources.at(mapping.source);
-        source = util.computeSourceURL(section.consumer.sourceRoot, source, this._sourceMapURL);
+        if (section.consumer.sourceRoot !== null) {
+          source = util.join(section.consumer.sourceRoot, source);
+        }
         this._sources.add(source);
         source = this._sources.indexOf(source);
 
-        var name = null;
-        if (mapping.name) {
-          name = section.consumer._names.at(mapping.name);
-          this._names.add(name);
-          name = this._names.indexOf(name);
-        }
+        var name = section.consumer._names.at(mapping.name);
+        this._names.add(name);
+        name = this._names.indexOf(name);
 
         // The mappings coming from the consumer for the section have
         // generated positions relative to the start of the section, so we
@@ -4678,15 +4618,6 @@ SourceMapGenerator.fromSourceMap =
       generator.addMapping(newMapping);
     });
     aSourceMapConsumer.sources.forEach(function (sourceFile) {
-      var sourceRelative = sourceFile;
-      if (sourceRoot !== null) {
-        sourceRelative = util.relative(sourceRoot, sourceFile);
-      }
-
-      if (!generator._sources.has(sourceRelative)) {
-        generator._sources.add(sourceRelative);
-      }
-
       var content = aSourceMapConsumer.sourceContentFor(sourceFile);
       if (content != null) {
         generator.setSourceContent(sourceFile, content);
@@ -5130,7 +5061,7 @@ SourceNode.fromStringWithSourceMap =
           // There is no new line in between.
           // Associate the code between "lastGeneratedColumn" and
           // "mapping.generatedColumn" with "lastMapping"
-          var nextLine = remainingLines[remainingLinesIndex] || '';
+          var nextLine = remainingLines[remainingLinesIndex];
           var code = nextLine.substr(0, mapping.generatedColumn -
                                         lastGeneratedColumn);
           remainingLines[remainingLinesIndex] = nextLine.substr(mapping.generatedColumn -
@@ -5150,7 +5081,7 @@ SourceNode.fromStringWithSourceMap =
         lastGeneratedLine++;
       }
       if (lastGeneratedColumn < mapping.generatedColumn) {
-        var nextLine = remainingLines[remainingLinesIndex] || '';
+        var nextLine = remainingLines[remainingLinesIndex];
         node.add(nextLine.substr(0, mapping.generatedColumn));
         remainingLines[remainingLinesIndex] = nextLine.substr(mapping.generatedColumn);
         lastGeneratedColumn = mapping.generatedColumn;
@@ -5474,7 +5405,7 @@ function getArg(aArgs, aName, aDefaultValue) {
 }
 exports.getArg = getArg;
 
-var urlRegexp = /^(?:([\w+\-.]+):)?\/\/(?:(\w+:\w+)@)?([\w.-]*)(?::(\d+))?(.*)$/;
+var urlRegexp = /^(?:([\w+\-.]+):)?\/\/(?:(\w+:\w+)@)?([\w.]*)(?::(\d+))?(\S*)$/;
 var dataUrlRegexp = /^data:.+\,.+$/;
 
 function urlParse(aUrl) {
@@ -5630,7 +5561,7 @@ function join(aRoot, aPath) {
 exports.join = join;
 
 exports.isAbsolute = function (aPath) {
-  return aPath.charAt(0) === '/' || urlRegexp.test(aPath);
+  return aPath.charAt(0) === '/' || !!aPath.match(urlRegexp);
 };
 
 /**
@@ -5750,7 +5681,7 @@ function isProtoString(s) {
  * stubbed out mapping.
  */
 function compareByOriginalPositions(mappingA, mappingB, onlyCompareOriginal) {
-  var cmp = strcmp(mappingA.source, mappingB.source);
+  var cmp = mappingA.source - mappingB.source;
   if (cmp !== 0) {
     return cmp;
   }
@@ -5775,7 +5706,7 @@ function compareByOriginalPositions(mappingA, mappingB, onlyCompareOriginal) {
     return cmp;
   }
 
-  return strcmp(mappingA.name, mappingB.name);
+  return mappingA.name - mappingB.name;
 }
 exports.compareByOriginalPositions = compareByOriginalPositions;
 
@@ -5799,7 +5730,7 @@ function compareByGeneratedPositionsDeflated(mappingA, mappingB, onlyCompareGene
     return cmp;
   }
 
-  cmp = strcmp(mappingA.source, mappingB.source);
+  cmp = mappingA.source - mappingB.source;
   if (cmp !== 0) {
     return cmp;
   }
@@ -5814,21 +5745,13 @@ function compareByGeneratedPositionsDeflated(mappingA, mappingB, onlyCompareGene
     return cmp;
   }
 
-  return strcmp(mappingA.name, mappingB.name);
+  return mappingA.name - mappingB.name;
 }
 exports.compareByGeneratedPositionsDeflated = compareByGeneratedPositionsDeflated;
 
 function strcmp(aStr1, aStr2) {
   if (aStr1 === aStr2) {
     return 0;
-  }
-
-  if (aStr1 === null) {
-    return 1; // aStr2 !== null
-  }
-
-  if (aStr2 === null) {
-    return -1; // aStr1 !== null
   }
 
   if (aStr1 > aStr2) {
@@ -5871,69 +5794,6 @@ function compareByGeneratedPositionsInflated(mappingA, mappingB) {
   return strcmp(mappingA.name, mappingB.name);
 }
 exports.compareByGeneratedPositionsInflated = compareByGeneratedPositionsInflated;
-
-/**
- * Strip any JSON XSSI avoidance prefix from the string (as documented
- * in the source maps specification), and then parse the string as
- * JSON.
- */
-function parseSourceMapInput(str) {
-  return JSON.parse(str.replace(/^\)]}'[^\n]*\n/, ''));
-}
-exports.parseSourceMapInput = parseSourceMapInput;
-
-/**
- * Compute the URL of a source given the the source root, the source's
- * URL, and the source map's URL.
- */
-function computeSourceURL(sourceRoot, sourceURL, sourceMapURL) {
-  sourceURL = sourceURL || '';
-
-  if (sourceRoot) {
-    // This follows what Chrome does.
-    if (sourceRoot[sourceRoot.length - 1] !== '/' && sourceURL[0] !== '/') {
-      sourceRoot += '/';
-    }
-    // The spec says:
-    //   Line 4: An optional source root, useful for relocating source
-    //   files on a server or removing repeated values in the
-    //   “sources” entry.  This value is prepended to the individual
-    //   entries in the “source” field.
-    sourceURL = sourceRoot + sourceURL;
-  }
-
-  // Historically, SourceMapConsumer did not take the sourceMapURL as
-  // a parameter.  This mode is still somewhat supported, which is why
-  // this code block is conditional.  However, it's preferable to pass
-  // the source map URL to SourceMapConsumer, so that this function
-  // can implement the source URL resolution algorithm as outlined in
-  // the spec.  This block is basically the equivalent of:
-  //    new URL(sourceURL, sourceMapURL).toString()
-  // ... except it avoids using URL, which wasn't available in the
-  // older releases of node still supported by this library.
-  //
-  // The spec says:
-  //   If the sources are not absolute URLs after prepending of the
-  //   “sourceRoot”, the sources are resolved relative to the
-  //   SourceMap (like resolving script src in a html document).
-  if (sourceMapURL) {
-    var parsed = urlParse(sourceMapURL);
-    if (!parsed) {
-      throw new Error("sourceMapURL could not be parsed");
-    }
-    if (parsed.path) {
-      // Strip the last path component, but keep the "/".
-      var index = parsed.path.lastIndexOf('/');
-      if (index >= 0) {
-        parsed.path = parsed.path.substring(0, index + 1);
-      }
-    }
-    sourceURL = join(urlGenerate(parsed), sourceURL);
-  }
-
-  return normalize(sourceURL);
-}
-exports.computeSourceURL = computeSourceURL;
 
 },{}],18:[function(require,module,exports){
 /*
@@ -6465,7 +6325,11 @@ function printErrorAndExit (error) {
   }
 
   if (typeof error.$full_message === 'function') {
-    console.error(error.$full_message().$chomp());
+    var full_message = error.$full_message();
+    while (full_message[full_message.length - 1] == "\n") {
+      full_message = full_message.slice(0, full_message.length - 1);
+    }
+    console.error(full_message);
   }
   else {
     if (source) {

--- a/lib/opal/cli_runners/source-map-support-node.js
+++ b/lib/opal/cli_runners/source-map-support-node.js
@@ -1,7 +1,10 @@
 (function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.sourceMapSupport = f()}})(function(){var define,module,exports;return (function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
+/* eslint-disable node/no-deprecated-api */
+
 var toString = Object.prototype.toString
 
 var isModern = (
+  typeof Buffer !== 'undefined' &&
   typeof Buffer.alloc === 'function' &&
   typeof Buffer.allocUnsafe === 'function' &&
   typeof Buffer.from === 'function'
@@ -727,19 +730,19 @@ var ArraySet = require('./array-set').ArraySet;
 var base64VLQ = require('./base64-vlq');
 var quickSort = require('./quick-sort').quickSort;
 
-function SourceMapConsumer(aSourceMap, aSourceMapURL) {
+function SourceMapConsumer(aSourceMap) {
   var sourceMap = aSourceMap;
   if (typeof aSourceMap === 'string') {
-    sourceMap = util.parseSourceMapInput(aSourceMap);
+    sourceMap = JSON.parse(aSourceMap.replace(/^\)\]\}'/, ''));
   }
 
   return sourceMap.sections != null
-    ? new IndexedSourceMapConsumer(sourceMap, aSourceMapURL)
-    : new BasicSourceMapConsumer(sourceMap, aSourceMapURL);
+    ? new IndexedSourceMapConsumer(sourceMap)
+    : new BasicSourceMapConsumer(sourceMap);
 }
 
-SourceMapConsumer.fromSourceMap = function(aSourceMap, aSourceMapURL) {
-  return BasicSourceMapConsumer.fromSourceMap(aSourceMap, aSourceMapURL);
+SourceMapConsumer.fromSourceMap = function(aSourceMap) {
+  return BasicSourceMapConsumer.fromSourceMap(aSourceMap);
 }
 
 /**
@@ -779,8 +782,6 @@ SourceMapConsumer.prototype._version = 3;
 
 SourceMapConsumer.prototype.__generatedMappings = null;
 Object.defineProperty(SourceMapConsumer.prototype, '_generatedMappings', {
-  configurable: true,
-  enumerable: true,
   get: function () {
     if (!this.__generatedMappings) {
       this._parseMappings(this._mappings, this.sourceRoot);
@@ -792,8 +793,6 @@ Object.defineProperty(SourceMapConsumer.prototype, '_generatedMappings', {
 
 SourceMapConsumer.prototype.__originalMappings = null;
 Object.defineProperty(SourceMapConsumer.prototype, '_originalMappings', {
-  configurable: true,
-  enumerable: true,
   get: function () {
     if (!this.__originalMappings) {
       this._parseMappings(this._mappings, this.sourceRoot);
@@ -861,7 +860,9 @@ SourceMapConsumer.prototype.eachMapping =
     var sourceRoot = this.sourceRoot;
     mappings.map(function (mapping) {
       var source = mapping.source === null ? null : this._sources.at(mapping.source);
-      source = util.computeSourceURL(sourceRoot, source, this._sourceMapURL);
+      if (source != null && sourceRoot != null) {
+        source = util.join(sourceRoot, source);
+      }
       return {
         source: source,
         generatedLine: mapping.generatedLine,
@@ -884,16 +885,13 @@ SourceMapConsumer.prototype.eachMapping =
  * The only argument is an object with the following properties:
  *
  *   - source: The filename of the original source.
- *   - line: The line number in the original source.  The line number is 1-based.
+ *   - line: The line number in the original source.
  *   - column: Optional. the column number in the original source.
- *    The column number is 0-based.
  *
  * and an array of objects is returned, each with the following properties:
  *
- *   - line: The line number in the generated source, or null.  The
- *    line number is 1-based.
+ *   - line: The line number in the generated source, or null.
  *   - column: The column number in the generated source, or null.
- *    The column number is 0-based.
  */
 SourceMapConsumer.prototype.allGeneratedPositionsFor =
   function SourceMapConsumer_allGeneratedPositionsFor(aArgs) {
@@ -909,10 +907,13 @@ SourceMapConsumer.prototype.allGeneratedPositionsFor =
       originalColumn: util.getArg(aArgs, 'column', 0)
     };
 
-    needle.source = this._findSourceIndex(needle.source);
-    if (needle.source < 0) {
+    if (this.sourceRoot != null) {
+      needle.source = util.relative(this.sourceRoot, needle.source);
+    }
+    if (!this._sources.has(needle.source)) {
       return [];
     }
+    needle.source = this._sources.indexOf(needle.source);
 
     var mappings = [];
 
@@ -972,7 +973,7 @@ exports.SourceMapConsumer = SourceMapConsumer;
  * query for information about the original file positions by giving it a file
  * position in the generated source.
  *
- * The first parameter is the raw source map (either as a JSON string, or
+ * The only parameter is the raw source map (either as a JSON string, or
  * already parsed to an object). According to the spec, source maps have the
  * following attributes:
  *
@@ -995,16 +996,12 @@ exports.SourceMapConsumer = SourceMapConsumer;
  *       mappings: "AA,AB;;ABCDE;"
  *     }
  *
- * The second parameter, if given, is a string whose value is the URL
- * at which the source map was found.  This URL is used to compute the
- * sources array.
- *
  * [0]: https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit?pli=1#
  */
-function BasicSourceMapConsumer(aSourceMap, aSourceMapURL) {
+function BasicSourceMapConsumer(aSourceMap) {
   var sourceMap = aSourceMap;
   if (typeof aSourceMap === 'string') {
-    sourceMap = util.parseSourceMapInput(aSourceMap);
+    sourceMap = JSON.parse(aSourceMap.replace(/^\)\]\}'/, ''));
   }
 
   var version = util.getArg(sourceMap, 'version');
@@ -1021,10 +1018,6 @@ function BasicSourceMapConsumer(aSourceMap, aSourceMapURL) {
   // string rather than a number, so we use loose equality checking here.
   if (version != this._version) {
     throw new Error('Unsupported version: ' + version);
-  }
-
-  if (sourceRoot) {
-    sourceRoot = util.normalize(sourceRoot);
   }
 
   sources = sources
@@ -1050,14 +1043,9 @@ function BasicSourceMapConsumer(aSourceMap, aSourceMapURL) {
   this._names = ArraySet.fromArray(names.map(String), true);
   this._sources = ArraySet.fromArray(sources, true);
 
-  this._absoluteSources = this._sources.toArray().map(function (s) {
-    return util.computeSourceURL(sourceRoot, s, aSourceMapURL);
-  });
-
   this.sourceRoot = sourceRoot;
   this.sourcesContent = sourcesContent;
   this._mappings = mappings;
-  this._sourceMapURL = aSourceMapURL;
   this.file = file;
 }
 
@@ -1065,42 +1053,14 @@ BasicSourceMapConsumer.prototype = Object.create(SourceMapConsumer.prototype);
 BasicSourceMapConsumer.prototype.consumer = SourceMapConsumer;
 
 /**
- * Utility function to find the index of a source.  Returns -1 if not
- * found.
- */
-BasicSourceMapConsumer.prototype._findSourceIndex = function(aSource) {
-  var relativeSource = aSource;
-  if (this.sourceRoot != null) {
-    relativeSource = util.relative(this.sourceRoot, relativeSource);
-  }
-
-  if (this._sources.has(relativeSource)) {
-    return this._sources.indexOf(relativeSource);
-  }
-
-  // Maybe aSource is an absolute URL as returned by |sources|.  In
-  // this case we can't simply undo the transform.
-  var i;
-  for (i = 0; i < this._absoluteSources.length; ++i) {
-    if (this._absoluteSources[i] == aSource) {
-      return i;
-    }
-  }
-
-  return -1;
-};
-
-/**
  * Create a BasicSourceMapConsumer from a SourceMapGenerator.
  *
  * @param SourceMapGenerator aSourceMap
  *        The source map that will be consumed.
- * @param String aSourceMapURL
- *        The URL at which the source map can be found (optional)
  * @returns BasicSourceMapConsumer
  */
 BasicSourceMapConsumer.fromSourceMap =
-  function SourceMapConsumer_fromSourceMap(aSourceMap, aSourceMapURL) {
+  function SourceMapConsumer_fromSourceMap(aSourceMap) {
     var smc = Object.create(BasicSourceMapConsumer.prototype);
 
     var names = smc._names = ArraySet.fromArray(aSourceMap._names.toArray(), true);
@@ -1109,10 +1069,6 @@ BasicSourceMapConsumer.fromSourceMap =
     smc.sourcesContent = aSourceMap._generateSourcesContent(smc._sources.toArray(),
                                                             smc.sourceRoot);
     smc.file = aSourceMap._file;
-    smc._sourceMapURL = aSourceMapURL;
-    smc._absoluteSources = smc._sources.toArray().map(function (s) {
-      return util.computeSourceURL(smc.sourceRoot, s, aSourceMapURL);
-    });
 
     // Because we are modifying the entries (by converting string sources and
     // names to indices into the sources and names ArraySets), we have to make
@@ -1159,7 +1115,9 @@ BasicSourceMapConsumer.prototype._version = 3;
  */
 Object.defineProperty(BasicSourceMapConsumer.prototype, 'sources', {
   get: function () {
-    return this._absoluteSources.slice();
+    return this._sources.toArray().map(function (s) {
+      return this.sourceRoot != null ? util.join(this.sourceRoot, s) : s;
+    }, this);
   }
 });
 
@@ -1340,10 +1298,8 @@ BasicSourceMapConsumer.prototype.computeColumnSpans =
  * source's line and column positions provided. The only argument is an object
  * with the following properties:
  *
- *   - line: The line number in the generated source.  The line number
- *     is 1-based.
- *   - column: The column number in the generated source.  The column
- *     number is 0-based.
+ *   - line: The line number in the generated source.
+ *   - column: The column number in the generated source.
  *   - bias: Either 'SourceMapConsumer.GREATEST_LOWER_BOUND' or
  *     'SourceMapConsumer.LEAST_UPPER_BOUND'. Specifies whether to return the
  *     closest element that is smaller than or greater than the one we are
@@ -1353,10 +1309,8 @@ BasicSourceMapConsumer.prototype.computeColumnSpans =
  * and an object is returned with the following properties:
  *
  *   - source: The original source file, or null.
- *   - line: The line number in the original source, or null.  The
- *     line number is 1-based.
- *   - column: The column number in the original source, or null.  The
- *     column number is 0-based.
+ *   - line: The line number in the original source, or null.
+ *   - column: The column number in the original source, or null.
  *   - name: The original identifier, or null.
  */
 BasicSourceMapConsumer.prototype.originalPositionFor =
@@ -1382,7 +1336,9 @@ BasicSourceMapConsumer.prototype.originalPositionFor =
         var source = util.getArg(mapping, 'source', null);
         if (source !== null) {
           source = this._sources.at(source);
-          source = util.computeSourceURL(this.sourceRoot, source, this._sourceMapURL);
+          if (this.sourceRoot != null) {
+            source = util.join(this.sourceRoot, source);
+          }
         }
         var name = util.getArg(mapping, 'name', null);
         if (name !== null) {
@@ -1429,14 +1385,12 @@ BasicSourceMapConsumer.prototype.sourceContentFor =
       return null;
     }
 
-    var index = this._findSourceIndex(aSource);
-    if (index >= 0) {
-      return this.sourcesContent[index];
+    if (this.sourceRoot != null) {
+      aSource = util.relative(this.sourceRoot, aSource);
     }
 
-    var relativeSource = aSource;
-    if (this.sourceRoot != null) {
-      relativeSource = util.relative(this.sourceRoot, relativeSource);
+    if (this._sources.has(aSource)) {
+      return this.sourcesContent[this._sources.indexOf(aSource)];
     }
 
     var url;
@@ -1446,15 +1400,15 @@ BasicSourceMapConsumer.prototype.sourceContentFor =
       // many users. We can help them out when they expect file:// URIs to
       // behave like it would if they were running a local HTTP server. See
       // https://bugzilla.mozilla.org/show_bug.cgi?id=885597.
-      var fileUriAbsPath = relativeSource.replace(/^file:\/\//, "");
+      var fileUriAbsPath = aSource.replace(/^file:\/\//, "");
       if (url.scheme == "file"
           && this._sources.has(fileUriAbsPath)) {
         return this.sourcesContent[this._sources.indexOf(fileUriAbsPath)]
       }
 
       if ((!url.path || url.path == "/")
-          && this._sources.has("/" + relativeSource)) {
-        return this.sourcesContent[this._sources.indexOf("/" + relativeSource)];
+          && this._sources.has("/" + aSource)) {
+        return this.sourcesContent[this._sources.indexOf("/" + aSource)];
       }
     }
 
@@ -1466,7 +1420,7 @@ BasicSourceMapConsumer.prototype.sourceContentFor =
       return null;
     }
     else {
-      throw new Error('"' + relativeSource + '" is not in the SourceMap.');
+      throw new Error('"' + aSource + '" is not in the SourceMap.');
     }
   };
 
@@ -1476,10 +1430,8 @@ BasicSourceMapConsumer.prototype.sourceContentFor =
  * the following properties:
  *
  *   - source: The filename of the original source.
- *   - line: The line number in the original source.  The line number
- *     is 1-based.
- *   - column: The column number in the original source.  The column
- *     number is 0-based.
+ *   - line: The line number in the original source.
+ *   - column: The column number in the original source.
  *   - bias: Either 'SourceMapConsumer.GREATEST_LOWER_BOUND' or
  *     'SourceMapConsumer.LEAST_UPPER_BOUND'. Specifies whether to return the
  *     closest element that is smaller than or greater than the one we are
@@ -1488,22 +1440,23 @@ BasicSourceMapConsumer.prototype.sourceContentFor =
  *
  * and an object is returned with the following properties:
  *
- *   - line: The line number in the generated source, or null.  The
- *     line number is 1-based.
+ *   - line: The line number in the generated source, or null.
  *   - column: The column number in the generated source, or null.
- *     The column number is 0-based.
  */
 BasicSourceMapConsumer.prototype.generatedPositionFor =
   function SourceMapConsumer_generatedPositionFor(aArgs) {
     var source = util.getArg(aArgs, 'source');
-    source = this._findSourceIndex(source);
-    if (source < 0) {
+    if (this.sourceRoot != null) {
+      source = util.relative(this.sourceRoot, source);
+    }
+    if (!this._sources.has(source)) {
       return {
         line: null,
         column: null,
         lastColumn: null
       };
     }
+    source = this._sources.indexOf(source);
 
     var needle = {
       source: source,
@@ -1547,7 +1500,7 @@ exports.BasicSourceMapConsumer = BasicSourceMapConsumer;
  * that it takes "indexed" source maps (i.e. ones with a "sections" field) as
  * input.
  *
- * The first parameter is a raw source map (either as a JSON string, or already
+ * The only parameter is a raw source map (either as a JSON string, or already
  * parsed to an object). According to the spec for indexed source maps, they
  * have the following attributes:
  *
@@ -1584,16 +1537,12 @@ exports.BasicSourceMapConsumer = BasicSourceMapConsumer;
  *    }],
  *  }
  *
- * The second parameter, if given, is a string whose value is the URL
- * at which the source map was found.  This URL is used to compute the
- * sources array.
- *
  * [0]: https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit#heading=h.535es3xeprgt
  */
-function IndexedSourceMapConsumer(aSourceMap, aSourceMapURL) {
+function IndexedSourceMapConsumer(aSourceMap) {
   var sourceMap = aSourceMap;
   if (typeof aSourceMap === 'string') {
-    sourceMap = util.parseSourceMapInput(aSourceMap);
+    sourceMap = JSON.parse(aSourceMap.replace(/^\)\]\}'/, ''));
   }
 
   var version = util.getArg(sourceMap, 'version');
@@ -1633,7 +1582,7 @@ function IndexedSourceMapConsumer(aSourceMap, aSourceMapURL) {
         generatedLine: offsetLine + 1,
         generatedColumn: offsetColumn + 1
       },
-      consumer: new SourceMapConsumer(util.getArg(s, 'map'), aSourceMapURL)
+      consumer: new SourceMapConsumer(util.getArg(s, 'map'))
     }
   });
 }
@@ -1666,18 +1615,14 @@ Object.defineProperty(IndexedSourceMapConsumer.prototype, 'sources', {
  * source's line and column positions provided. The only argument is an object
  * with the following properties:
  *
- *   - line: The line number in the generated source.  The line number
- *     is 1-based.
- *   - column: The column number in the generated source.  The column
- *     number is 0-based.
+ *   - line: The line number in the generated source.
+ *   - column: The column number in the generated source.
  *
  * and an object is returned with the following properties:
  *
  *   - source: The original source file, or null.
- *   - line: The line number in the original source, or null.  The
- *     line number is 1-based.
- *   - column: The column number in the original source, or null.  The
- *     column number is 0-based.
+ *   - line: The line number in the original source, or null.
+ *   - column: The column number in the original source, or null.
  *   - name: The original identifier, or null.
  */
 IndexedSourceMapConsumer.prototype.originalPositionFor =
@@ -1761,17 +1706,13 @@ IndexedSourceMapConsumer.prototype.sourceContentFor =
  * the following properties:
  *
  *   - source: The filename of the original source.
- *   - line: The line number in the original source.  The line number
- *     is 1-based.
- *   - column: The column number in the original source.  The column
- *     number is 0-based.
+ *   - line: The line number in the original source.
+ *   - column: The column number in the original source.
  *
  * and an object is returned with the following properties:
  *
- *   - line: The line number in the generated source, or null.  The
- *     line number is 1-based. 
+ *   - line: The line number in the generated source, or null.
  *   - column: The column number in the generated source, or null.
- *     The column number is 0-based.
  */
 IndexedSourceMapConsumer.prototype.generatedPositionFor =
   function IndexedSourceMapConsumer_generatedPositionFor(aArgs) {
@@ -1780,7 +1721,7 @@ IndexedSourceMapConsumer.prototype.generatedPositionFor =
 
       // Only consider this section if the requested source is in the list of
       // sources of the consumer.
-      if (section.consumer._findSourceIndex(util.getArg(aArgs, 'source')) === -1) {
+      if (section.consumer.sources.indexOf(util.getArg(aArgs, 'source')) === -1) {
         continue;
       }
       var generatedPosition = section.consumer.generatedPositionFor(aArgs);
@@ -1819,16 +1760,15 @@ IndexedSourceMapConsumer.prototype._parseMappings =
         var mapping = sectionMappings[j];
 
         var source = section.consumer._sources.at(mapping.source);
-        source = util.computeSourceURL(section.consumer.sourceRoot, source, this._sourceMapURL);
+        if (section.consumer.sourceRoot !== null) {
+          source = util.join(section.consumer.sourceRoot, source);
+        }
         this._sources.add(source);
         source = this._sources.indexOf(source);
 
-        var name = null;
-        if (mapping.name) {
-          name = section.consumer._names.at(mapping.name);
-          this._names.add(name);
-          name = this._names.indexOf(name);
-        }
+        var name = section.consumer._names.at(mapping.name);
+        this._names.add(name);
+        name = this._names.indexOf(name);
 
         // The mappings coming from the consumer for the section have
         // generated positions relative to the start of the section, so we
@@ -1935,15 +1875,6 @@ SourceMapGenerator.fromSourceMap =
       generator.addMapping(newMapping);
     });
     aSourceMapConsumer.sources.forEach(function (sourceFile) {
-      var sourceRelative = sourceFile;
-      if (sourceRoot !== null) {
-        sourceRelative = util.relative(sourceRoot, sourceFile);
-      }
-
-      if (!generator._sources.has(sourceRelative)) {
-        generator._sources.add(sourceRelative);
-      }
-
       var content = aSourceMapConsumer.sourceContentFor(sourceFile);
       if (content != null) {
         generator.setSourceContent(sourceFile, content);
@@ -2387,7 +2318,7 @@ SourceNode.fromStringWithSourceMap =
           // There is no new line in between.
           // Associate the code between "lastGeneratedColumn" and
           // "mapping.generatedColumn" with "lastMapping"
-          var nextLine = remainingLines[remainingLinesIndex] || '';
+          var nextLine = remainingLines[remainingLinesIndex];
           var code = nextLine.substr(0, mapping.generatedColumn -
                                         lastGeneratedColumn);
           remainingLines[remainingLinesIndex] = nextLine.substr(mapping.generatedColumn -
@@ -2407,7 +2338,7 @@ SourceNode.fromStringWithSourceMap =
         lastGeneratedLine++;
       }
       if (lastGeneratedColumn < mapping.generatedColumn) {
-        var nextLine = remainingLines[remainingLinesIndex] || '';
+        var nextLine = remainingLines[remainingLinesIndex];
         node.add(nextLine.substr(0, mapping.generatedColumn));
         remainingLines[remainingLinesIndex] = nextLine.substr(mapping.generatedColumn);
         lastGeneratedColumn = mapping.generatedColumn;
@@ -2731,7 +2662,7 @@ function getArg(aArgs, aName, aDefaultValue) {
 }
 exports.getArg = getArg;
 
-var urlRegexp = /^(?:([\w+\-.]+):)?\/\/(?:(\w+:\w+)@)?([\w.-]*)(?::(\d+))?(.*)$/;
+var urlRegexp = /^(?:([\w+\-.]+):)?\/\/(?:(\w+:\w+)@)?([\w.]*)(?::(\d+))?(\S*)$/;
 var dataUrlRegexp = /^data:.+\,.+$/;
 
 function urlParse(aUrl) {
@@ -2887,7 +2818,7 @@ function join(aRoot, aPath) {
 exports.join = join;
 
 exports.isAbsolute = function (aPath) {
-  return aPath.charAt(0) === '/' || urlRegexp.test(aPath);
+  return aPath.charAt(0) === '/' || !!aPath.match(urlRegexp);
 };
 
 /**
@@ -3007,7 +2938,7 @@ function isProtoString(s) {
  * stubbed out mapping.
  */
 function compareByOriginalPositions(mappingA, mappingB, onlyCompareOriginal) {
-  var cmp = strcmp(mappingA.source, mappingB.source);
+  var cmp = mappingA.source - mappingB.source;
   if (cmp !== 0) {
     return cmp;
   }
@@ -3032,7 +2963,7 @@ function compareByOriginalPositions(mappingA, mappingB, onlyCompareOriginal) {
     return cmp;
   }
 
-  return strcmp(mappingA.name, mappingB.name);
+  return mappingA.name - mappingB.name;
 }
 exports.compareByOriginalPositions = compareByOriginalPositions;
 
@@ -3056,7 +2987,7 @@ function compareByGeneratedPositionsDeflated(mappingA, mappingB, onlyCompareGene
     return cmp;
   }
 
-  cmp = strcmp(mappingA.source, mappingB.source);
+  cmp = mappingA.source - mappingB.source;
   if (cmp !== 0) {
     return cmp;
   }
@@ -3071,21 +3002,13 @@ function compareByGeneratedPositionsDeflated(mappingA, mappingB, onlyCompareGene
     return cmp;
   }
 
-  return strcmp(mappingA.name, mappingB.name);
+  return mappingA.name - mappingB.name;
 }
 exports.compareByGeneratedPositionsDeflated = compareByGeneratedPositionsDeflated;
 
 function strcmp(aStr1, aStr2) {
   if (aStr1 === aStr2) {
     return 0;
-  }
-
-  if (aStr1 === null) {
-    return 1; // aStr2 !== null
-  }
-
-  if (aStr2 === null) {
-    return -1; // aStr1 !== null
   }
 
   if (aStr1 > aStr2) {
@@ -3128,69 +3051,6 @@ function compareByGeneratedPositionsInflated(mappingA, mappingB) {
   return strcmp(mappingA.name, mappingB.name);
 }
 exports.compareByGeneratedPositionsInflated = compareByGeneratedPositionsInflated;
-
-/**
- * Strip any JSON XSSI avoidance prefix from the string (as documented
- * in the source maps specification), and then parse the string as
- * JSON.
- */
-function parseSourceMapInput(str) {
-  return JSON.parse(str.replace(/^\)]}'[^\n]*\n/, ''));
-}
-exports.parseSourceMapInput = parseSourceMapInput;
-
-/**
- * Compute the URL of a source given the the source root, the source's
- * URL, and the source map's URL.
- */
-function computeSourceURL(sourceRoot, sourceURL, sourceMapURL) {
-  sourceURL = sourceURL || '';
-
-  if (sourceRoot) {
-    // This follows what Chrome does.
-    if (sourceRoot[sourceRoot.length - 1] !== '/' && sourceURL[0] !== '/') {
-      sourceRoot += '/';
-    }
-    // The spec says:
-    //   Line 4: An optional source root, useful for relocating source
-    //   files on a server or removing repeated values in the
-    //   “sources” entry.  This value is prepended to the individual
-    //   entries in the “source” field.
-    sourceURL = sourceRoot + sourceURL;
-  }
-
-  // Historically, SourceMapConsumer did not take the sourceMapURL as
-  // a parameter.  This mode is still somewhat supported, which is why
-  // this code block is conditional.  However, it's preferable to pass
-  // the source map URL to SourceMapConsumer, so that this function
-  // can implement the source URL resolution algorithm as outlined in
-  // the spec.  This block is basically the equivalent of:
-  //    new URL(sourceURL, sourceMapURL).toString()
-  // ... except it avoids using URL, which wasn't available in the
-  // older releases of node still supported by this library.
-  //
-  // The spec says:
-  //   If the sources are not absolute URLs after prepending of the
-  //   “sourceRoot”, the sources are resolved relative to the
-  //   SourceMap (like resolving script src in a html document).
-  if (sourceMapURL) {
-    var parsed = urlParse(sourceMapURL);
-    if (!parsed) {
-      throw new Error("sourceMapURL could not be parsed");
-    }
-    if (parsed.path) {
-      // Strip the last path component, but keep the "/".
-      var index = parsed.path.lastIndexOf('/');
-      if (index >= 0) {
-        parsed.path = parsed.path.substring(0, index + 1);
-      }
-    }
-    sourceURL = join(urlGenerate(parsed), sourceURL);
-  }
-
-  return normalize(sourceURL);
-}
-exports.computeSourceURL = computeSourceURL;
 
 },{}],12:[function(require,module,exports){
 /*
@@ -3721,7 +3581,11 @@ function printErrorAndExit (error) {
   }
 
   if (typeof error.$full_message === 'function') {
-    console.error(error.$full_message().$chomp());
+    var full_message = error.$full_message();
+    while (full_message[full_message.length - 1] == "\n") {
+      full_message = full_message.slice(0, full_message.length - 1);
+    }
+    console.error(full_message);
   }
   else {
     if (source) {

--- a/lib/opal/cli_runners/source-map-support.js
+++ b/lib/opal/cli_runners/source-map-support.js
@@ -516,7 +516,11 @@ function printErrorAndExit (error) {
   }
 
   if (typeof error.$full_message === 'function') {
-    console.error(error.$full_message().$chomp());
+    var full_message = error.$full_message();
+    while (full_message[full_message.length - 1] == "\n") {
+      full_message = full_message.slice(0, full_message.length - 1);
+    }
+    console.error(full_message);
   }
   else {
     if (source) {

--- a/lib/opal/requires.rb
+++ b/lib/opal/requires.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'opal/config'
+require 'opal/compiler'
+require 'opal/builder'
+require 'opal/builder_processors'
+require 'opal/erb'
+require 'opal/paths'
+require 'opal/version'
+require 'opal/errors'
+require 'opal/source_map'
+require 'opal/deprecations'
+
+# Opal is a ruby to javascript compiler, with a runtime for running
+# in any JavaScript environment.
+module Opal
+  autoload :Server, 'opal/server' if RUBY_ENGINE != 'opal'
+  autoload :SimpleServer, 'opal/simple_server'
+end

--- a/opal/corelib/error.rb
+++ b/opal/corelib/error.rb
@@ -243,13 +243,40 @@ class ::ThreadError         < ::StandardError; end
 class ::FiberError          < ::StandardError; end
 
 module ::Errno
-  class EINVAL              < ::SystemCallError
-    def self.new(name = nil)
-      message = 'Invalid argument'
-      message += " - #{name}" if name
-      super(message)
-    end
-  end
+  errors = [
+    [:EINVAL, 'Invalid argument'],
+    [:EEXIST, 'File exists'],
+    [:EISDIR, 'Is a directory'],
+    [:EMFILE, 'Too many open files'],
+    [:EACCES, 'Permission denied'],
+    [:EPERM, 'Operation not permitted'],
+    [:ENOENT, 'No such file or directory']
+  ]
+
+  klass = nil
+  
+  %x{
+    var i;
+    for (i = 0; i < errors.length; i++) {
+      (function() { // Create a closure
+        var class_name = errors[i][0];
+        var default_message = errors[i][1];
+
+        klass = Opal.klass(self, Opal.SystemCallError, class_name);
+
+        #{
+          class << klass
+            def new(name = nil)
+              message = `default_message`
+              message += " - #{name}" if name
+              super(message)
+            end
+          end
+        }
+      })();
+    }
+  }
+
 end
 
 class ::UncaughtThrowError < ::ArgumentError

--- a/opal/corelib/error.rb
+++ b/opal/corelib/error.rb
@@ -254,7 +254,7 @@ module ::Errno
   ]
 
   klass = nil
-  
+
   %x{
     var i;
     for (i = 0; i < errors.length; i++) {
@@ -276,7 +276,6 @@ module ::Errno
       })();
     }
   }
-
 end
 
 class ::UncaughtThrowError < ::ArgumentError

--- a/opal/corelib/error.rb
+++ b/opal/corelib/error.rb
@@ -242,41 +242,7 @@ class ::RegexpError         < ::StandardError; end
 class ::ThreadError         < ::StandardError; end
 class ::FiberError          < ::StandardError; end
 
-module ::Errno
-  errors = [
-    [:EINVAL, 'Invalid argument'],
-    [:EEXIST, 'File exists'],
-    [:EISDIR, 'Is a directory'],
-    [:EMFILE, 'Too many open files'],
-    [:EACCES, 'Permission denied'],
-    [:EPERM, 'Operation not permitted'],
-    [:ENOENT, 'No such file or directory']
-  ]
-
-  klass = nil
-
-  %x{
-    var i;
-    for (i = 0; i < errors.length; i++) {
-      (function() { // Create a closure
-        var class_name = errors[i][0];
-        var default_message = errors[i][1];
-
-        klass = Opal.klass(self, Opal.SystemCallError, class_name);
-
-        #{
-          class << klass
-            def new(name = nil)
-              message = `default_message`
-              message += " - #{name}" if name
-              super(message)
-            end
-          end
-        }
-      })();
-    }
-  }
-end
+::Object.autoload :Errno, 'corelib/error/errno'
 
 class ::UncaughtThrowError < ::ArgumentError
   attr_reader :tag, :value

--- a/opal/corelib/error/errno.rb
+++ b/opal/corelib/error/errno.rb
@@ -1,0 +1,47 @@
+module ::Errno
+  errors = [
+    [:EINVAL, 'Invalid argument', 22],
+    [:EEXIST, 'File exists', 17],
+    [:EISDIR, 'Is a directory', 21],
+    [:EMFILE, 'Too many open files', 24],
+    [:EACCES, 'Permission denied', 13],
+    [:EPERM, 'Operation not permitted', 1],
+    [:ENOENT, 'No such file or directory', 2]
+  ]
+
+  klass = nil
+
+  %x{
+    var i;
+    for (i = 0; i < errors.length; i++) {
+      (function() { // Create a closure
+        var class_name = errors[i][0];
+        var default_message = errors[i][1];
+        var errno = errors[i][2];
+
+        klass = Opal.klass(self, Opal.SystemCallError, class_name);
+        klass.errno = errno;
+
+        #{
+          class << klass
+            def new(name = nil)
+              message = `default_message`
+              message += " - #{name}" if name
+              super(message)
+            end
+          end
+        }
+      })();
+    }
+  }
+end
+
+class ::SystemCallError < ::StandardError
+  def errno
+    self.class.errno
+  end
+
+  class << self
+    attr_reader :errno
+  end
+end

--- a/opal/corelib/helpers.rb
+++ b/opal/corelib/helpers.rb
@@ -105,11 +105,13 @@ module ::Opal
   end
 
   def self.const_name!(const_name)
-    const_name = ::Opal.coerce_to!(const_name, ::String, :to_str)
+    const_name = ::Opal.coerce_to!(const_name, ::String, :to_str) if defined? ::String
 
-    if const_name[0] != const_name[0].upcase
-      ::Kernel.raise ::NameError, "wrong constant name #{const_name}"
-    end
+    %x{
+      if (!const_name || const_name[0] != const_name[0].toUpperCase()) {
+        #{raise ::NameError, "wrong constant name #{const_name}"}
+      }
+    }
 
     const_name
   end

--- a/opal/corelib/main.rb
+++ b/opal/corelib/main.rb
@@ -1,16 +1,18 @@
-def self.to_s
-  'main'
-end
+class << self
+  def to_s
+    'main'
+  end
 
-def self.include(mod)
-  ::Object.include mod
-end
+  def include(mod)
+    ::Object.include mod
+  end
 
-def self.autoload(*args)
-  ::Object.autoload(*args)
-end
+  def autoload(*args)
+    `Opal.Object.$autoload.apply(Opal.Object, args)`
+  end
 
-# Compiler overrides this method
-def self.using(mod)
-  ::Kernel.raise 'main.using is permitted only at toplevel'
+  # Compiler overrides this method
+  def using(mod)
+    ::Kernel.raise 'main.using is permitted only at toplevel'
+  end
 end

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -552,7 +552,7 @@
       constructor = function(){};
     }
 
-    if (name) {
+    if (name && name !== nil) {
       $prop(constructor, 'displayName', '::'+name);
     }
 

--- a/opal/opal.rb
+++ b/opal/opal.rb
@@ -1,7 +1,6 @@
 ::Object.require 'opal/base'
 ::Object.require 'opal/mini'
 
-::Object.require 'corelib/main'
 ::Object.require 'corelib/kernel/format'
 ::Object.require 'corelib/string/encoding'
 ::Object.autoload :Math, 'corelib/math'

--- a/opal/opal/base.rb
+++ b/opal/opal/base.rb
@@ -4,6 +4,7 @@
 ::Object.require 'corelib/class'
 ::Object.require 'corelib/basic_object'
 ::Object.require 'corelib/kernel'
+::Object.require 'corelib/main'
 ::Object.require 'corelib/error'
 
 ::Object.require 'corelib/constants'

--- a/spec/filters/bugs/exception.rb
+++ b/spec/filters/bugs/exception.rb
@@ -73,7 +73,6 @@ opal_filter "Exception" do
   fails "StopIteration#result returns the method-returned-object from an Enumerator" # NoMethodError: undefined method `next' for #<Enumerator: #<Object:0x4fb42>:each>
   fails "SystemCallError#backtrace is nil if not raised" # Expected ["ruby/core/exception/system_call_error_spec.rb:141:5:in `new'",  "<internal:corelib/basic_object.rb>:119:1:in `instance_exec'",  "<internal:corelib/runtime.js>:1780:5:in `Opal.send2'",  "<internal:corelib/runtime.js>:1770:5:in `Opal.send'",  "mspec/runner/mspec.rb:114:7:in `instance_exec'",  "<internal:corelib/runtime.js>:1780:5:in `Opal.send2'",  "<internal:corelib/runtime.js>:1770:5:in `Opal.send'",  "mspec/runner/context.rb:176:34:in `protect'",  "<internal:corelib/runtime.js>:1569:5:in `Opal.yieldX'",  "<internal:corelib/enumerable.rb>:27:16:in `$$3'"] == nil to be truthy but was false
   fails "SystemCallError#dup copies the errno" # NoMethodError: undefined method `errno' for #<SystemCallError: message>
-  fails "SystemCallError#errno returns nil when no errno given" # NoMethodError: undefined method `errno' for #<SystemCallError: message>
   fails "SystemCallError#errno returns the errno given as optional argument to new" # NoMethodError: undefined method `errno' for #<SystemCallError: message>
   fails "SystemCallError#message returns the default message when no message is given" # Expected "268435456" =~ /Unknown error/i to be truthy but was nil
   fails "SystemCallError.=== returns false if errnos different" # NoMethodError: undefined method `+' for Errno

--- a/spec/filters/bugs/exception.rb
+++ b/spec/filters/bugs/exception.rb
@@ -7,8 +7,6 @@ opal_filter "Exception" do
   fails "Errno::EINVAL.new accepts an optional custom message and location" # ArgumentError: [EINVAL.new] wrong number of arguments(2 for -1)
   fails "Errno::EINVAL.new accepts an optional custom message" # NoMethodError: undefined method `errno' for #<Errno::EINVAL: Invalid argument - custom message>
   fails "Errno::EINVAL.new can be called with no arguments" # NoMethodError: undefined method `errno' for #<Errno::EINVAL: Invalid argument>
-  fails "Errno::EMFILE can be subclassed" # NameError: uninitialized constant Errno::EMFILE
-  fails "Errno::ENOENT lets subclasses inherit the default error message" # Expected "uninitialized constant Errno::ENOENT" == "No such file or directory - custom message" to be truthy but was false
   fails "Errno::ENOTSUP is defined" # Expected Errno to have constant 'ENOTSUP' but it does not
   fails "Errno::ENOTSUP is the same class as Errno::EOPNOTSUPP if they represent the same errno value" # NameError: uninitialized constant Errno::ENOTSUP
   fails "Exception#== returns true if both exceptions have the same class, no message, and no backtrace" # Expected #<RuntimeError: RuntimeError> == #<RuntimeError: RuntimeError> to be truthy but was false

--- a/spec/filters/bugs/module.rb
+++ b/spec/filters/bugs/module.rb
@@ -4,6 +4,7 @@ opal_filter "Module" do
   fails "Module#alias_method handles aliasing a method only present in a refinement" # NoMethodError: undefined method `refine' for #<Module:0x90fa>
   fails "Module#alias_method retains method visibility"
   fails "Module#alias_method returned value returns symbol of the defined method name" # Expected #<Class:0x1c94a> to be identical to "checking_return_value"
+  fails "Module#ancestors returns a list of modules included in self (including self)" # Expected [ModuleSpecs::Parent, Object, Shellwords, Kernel, BasicObject] == [ModuleSpecs::Parent, Object, Kernel, BasicObject] to be truthy but was false -- a random failure
   fails "Module#append_features on Class raises a TypeError if calling after rebinded to Class"
   fails "Module#attr applies current visibility to methods created"
   fails "Module#attr converts non string/symbol names to strings using to_str" # Expected false == true to be truthy but was false

--- a/spec/ruby_specs
+++ b/spec/ruby_specs
@@ -198,7 +198,9 @@ ruby/library/matrix/vector
 ruby/library/pp
 ruby/library/securerandom
 ruby/library/set
+ruby/library/shellwords
 ruby/library/singleton
 ruby/library/stringio/each_line_spec
 ruby/library/stringio/each_spec
 ruby/library/stringscanner
+ruby/library/optionparser

--- a/stdlib/optparse.rb
+++ b/stdlib/optparse.rb
@@ -1407,7 +1407,7 @@ XXX
           default_pattern, conv = search(:atype, o) unless default_pattern
         end
         ldesc << "--[no-]#{q}"
-        (o = q.downcase).tr!('_', '-')
+        o = q.downcase.tr('_', '-')
         long << o
         not_pattern, not_conv = search(:atype, FalseClass) unless not_style
         not_style = Switch::NoArgument

--- a/stdlib/optparse.rb
+++ b/stdlib/optparse.rb
@@ -1793,10 +1793,14 @@ XXX
   #
   def complete(typ, opt, icase = false, *pat) # :nodoc:
     if pat.empty?
-      search(typ, opt) { |sw| return [sw, opt] } # exact match or...
+      retval = nil
+      search(typ, opt) { |sw| retval = [sw, opt]; break } # exact match or...
+      return retval if retval
     end
     ambiguous = catch(:ambiguous) do
-      visit(:complete, typ, opt, icase, *pat) { |o, *sw| return sw }
+      retval = nil
+      visit(:complete, typ, opt, icase, *pat) { |o, *sw| retval = sw; break }
+      return retval if retval
     end
     exc = ambiguous ? AmbiguousOption : InvalidOption
     raise exc.new(opt, additional: method(:additional_message).curry[typ])

--- a/stdlib/optparse.rb
+++ b/stdlib/optparse.rb
@@ -1,0 +1,2275 @@
+# frozen_string_literal: true
+#
+# optparse.rb - command-line option analysis with the OptionParser class.
+#
+# Author:: Nobu Nakada
+# Documentation:: Nobu Nakada and Gavin Sinclair.
+#
+# See OptionParser for documentation.
+#
+
+
+#--
+# == Developer Documentation (not for RDoc output)
+#
+# === Class tree
+#
+# - OptionParser:: front end
+# - OptionParser::Switch:: each switches
+# - OptionParser::List:: options list
+# - OptionParser::ParseError:: errors on parsing
+#   - OptionParser::AmbiguousOption
+#   - OptionParser::NeedlessArgument
+#   - OptionParser::MissingArgument
+#   - OptionParser::InvalidOption
+#   - OptionParser::InvalidArgument
+#     - OptionParser::AmbiguousArgument
+#
+# === Object relationship diagram
+#
+#   +--------------+
+#   | OptionParser |<>-----+
+#   +--------------+       |                      +--------+
+#                          |                    ,-| Switch |
+#        on_head -------->+---------------+    /  +--------+
+#        accept/reject -->| List          |<|>-
+#                         |               |<|>-  +----------+
+#        on ------------->+---------------+    `-| argument |
+#                           :           :        |  class   |
+#                         +---------------+      |==========|
+#        on_tail -------->|               |      |pattern   |
+#                         +---------------+      |----------|
+#   OptionParser.accept ->| DefaultList   |      |converter |
+#                reject   |(shared between|      +----------+
+#                         | all instances)|
+#                         +---------------+
+#
+#++
+#
+# == OptionParser
+#
+# === New to \OptionParser?
+#
+# See the {Tutorial}[./doc/optparse/tutorial_rdoc.html].
+#
+# === Introduction
+#
+# OptionParser is a class for command-line option analysis.  It is much more
+# advanced, yet also easier to use, than GetoptLong, and is a more Ruby-oriented
+# solution.
+#
+# === Features
+#
+# 1. The argument specification and the code to handle it are written in the
+#    same place.
+# 2. It can output an option summary; you don't need to maintain this string
+#    separately.
+# 3. Optional and mandatory arguments are specified very gracefully.
+# 4. Arguments can be automatically converted to a specified class.
+# 5. Arguments can be restricted to a certain set.
+#
+# All of these features are demonstrated in the examples below.  See
+# #make_switch for full documentation.
+#
+# === Minimal example
+#
+#   require 'optparse'
+#
+#   options = {}
+#   OptionParser.new do |parser|
+#     parser.banner = "Usage: example.rb [options]"
+#
+#     parser.on("-v", "--[no-]verbose", "Run verbosely") do |v|
+#       options[:verbose] = v
+#     end
+#   end.parse!
+#
+#   p options
+#   p ARGV
+#
+# === Generating Help
+#
+# OptionParser can be used to automatically generate help for the commands you
+# write:
+#
+#   require 'optparse'
+#
+#   Options = Struct.new(:name)
+#
+#   class Parser
+#     def self.parse(options)
+#       args = Options.new("world")
+#
+#       opt_parser = OptionParser.new do |parser|
+#         parser.banner = "Usage: example.rb [options]"
+#
+#         parser.on("-nNAME", "--name=NAME", "Name to say hello to") do |n|
+#           args.name = n
+#         end
+#
+#         parser.on("-h", "--help", "Prints this help") do
+#           puts parser
+#           exit
+#         end
+#       end
+#
+#       opt_parser.parse!(options)
+#       return args
+#     end
+#   end
+#   options = Parser.parse %w[--help]
+#
+#   #=>
+#      # Usage: example.rb [options]
+#      #     -n, --name=NAME                  Name to say hello to
+#      #     -h, --help                       Prints this help
+#
+# === Required Arguments
+#
+# For options that require an argument, option specification strings may include an
+# option name in all caps. If an option is used without the required argument,
+# an exception will be raised.
+#
+#   require 'optparse'
+#
+#   options = {}
+#   OptionParser.new do |parser|
+#     parser.on("-r", "--require LIBRARY",
+#               "Require the LIBRARY before executing your script") do |lib|
+#       puts "You required #{lib}!"
+#     end
+#   end.parse!
+#
+# Used:
+#
+#   $ ruby optparse-test.rb -r
+#   optparse-test.rb:9:in `<main>': missing argument: -r (OptionParser::MissingArgument)
+#   $ ruby optparse-test.rb -r my-library
+#   You required my-library!
+#
+# === Type Coercion
+#
+# OptionParser supports the ability to coerce command line arguments
+# into objects for us.
+#
+# OptionParser comes with a few ready-to-use kinds of  type
+# coercion. They are:
+#
+# - Date  -- Anything accepted by +Date.parse+
+# - DateTime -- Anything accepted by +DateTime.parse+
+# - Time -- Anything accepted by +Time.httpdate+ or +Time.parse+
+# - URI  -- Anything accepted by +URI.parse+
+# - Shellwords -- Anything accepted by +Shellwords.shellwords+
+# - String -- Any non-empty string
+# - Integer -- Any integer. Will convert octal. (e.g. 124, -3, 040)
+# - Float -- Any float. (e.g. 10, 3.14, -100E+13)
+# - Numeric -- Any integer, float, or rational (1, 3.4, 1/3)
+# - DecimalInteger -- Like +Integer+, but no octal format.
+# - OctalInteger -- Like +Integer+, but no decimal format.
+# - DecimalNumeric -- Decimal integer or float.
+# - TrueClass --  Accepts '+, yes, true, -, no, false' and
+#   defaults as +true+
+# - FalseClass -- Same as +TrueClass+, but defaults to +false+
+# - Array -- Strings separated by ',' (e.g. 1,2,3)
+# - Regexp -- Regular expressions. Also includes options.
+#
+# We can also add our own coercions, which we will cover below.
+#
+# ==== Using Built-in Conversions
+#
+# As an example, the built-in +Time+ conversion is used. The other built-in
+# conversions behave in the same way.
+# OptionParser will attempt to parse the argument
+# as a +Time+. If it succeeds, that time will be passed to the
+# handler block. Otherwise, an exception will be raised.
+#
+#   require 'optparse'
+#   require 'optparse/time'
+#   OptionParser.new do |parser|
+#     parser.on("-t", "--time [TIME]", Time, "Begin execution at given time") do |time|
+#       p time
+#     end
+#   end.parse!
+#
+# Used:
+#
+#   $ ruby optparse-test.rb  -t nonsense
+#   ... invalid argument: -t nonsense (OptionParser::InvalidArgument)
+#   $ ruby optparse-test.rb  -t 10-11-12
+#   2010-11-12 00:00:00 -0500
+#   $ ruby optparse-test.rb  -t 9:30
+#   2014-08-13 09:30:00 -0400
+#
+# ==== Creating Custom Conversions
+#
+# The +accept+ method on OptionParser may be used to create converters.
+# It specifies which conversion block to call whenever a class is specified.
+# The example below uses it to fetch a +User+ object before the +on+ handler receives it.
+#
+#   require 'optparse'
+#
+#   User = Struct.new(:id, :name)
+#
+#   def find_user id
+#     not_found = ->{ raise "No User Found for id #{id}" }
+#     [ User.new(1, "Sam"),
+#       User.new(2, "Gandalf") ].find(not_found) do |u|
+#       u.id == id
+#     end
+#   end
+#
+#   op = OptionParser.new
+#   op.accept(User) do |user_id|
+#     find_user user_id.to_i
+#   end
+#
+#   op.on("--user ID", User) do |user|
+#     puts user
+#   end
+#
+#   op.parse!
+#
+# Used:
+#
+#   $ ruby optparse-test.rb --user 1
+#   #<struct User id=1, name="Sam">
+#   $ ruby optparse-test.rb --user 2
+#   #<struct User id=2, name="Gandalf">
+#   $ ruby optparse-test.rb --user 3
+#   optparse-test.rb:15:in `block in find_user': No User Found for id 3 (RuntimeError)
+#
+# === Store options to a Hash
+#
+# The +into+ option of +order+, +parse+ and so on methods stores command line options into a Hash.
+#
+#   require 'optparse'
+#
+#   options = {}
+#   OptionParser.new do |parser|
+#     parser.on('-a')
+#     parser.on('-b NUM', Integer)
+#     parser.on('-v', '--verbose')
+#   end.parse!(into: options)
+#
+#   p options
+#
+# Used:
+#
+#   $ ruby optparse-test.rb -a
+#   {:a=>true}
+#   $ ruby optparse-test.rb -a -v
+#   {:a=>true, :verbose=>true}
+#   $ ruby optparse-test.rb -a -b 100
+#   {:a=>true, :b=>100}
+#
+# === Complete example
+#
+# The following example is a complete Ruby program.  You can run it and see the
+# effect of specifying various options.  This is probably the best way to learn
+# the features of +optparse+.
+#
+#   require 'optparse'
+#   require 'optparse/time'
+#   require 'ostruct'
+#   require 'pp'
+#
+#   class OptparseExample
+#     Version = '1.0.0'
+#
+#     CODES = %w[iso-2022-jp shift_jis euc-jp utf8 binary]
+#     CODE_ALIASES = { "jis" => "iso-2022-jp", "sjis" => "shift_jis" }
+#
+#     class ScriptOptions
+#       attr_accessor :library, :inplace, :encoding, :transfer_type,
+#                     :verbose, :extension, :delay, :time, :record_separator,
+#                     :list
+#
+#       def initialize
+#         self.library = []
+#         self.inplace = false
+#         self.encoding = "utf8"
+#         self.transfer_type = :auto
+#         self.verbose = false
+#       end
+#
+#       def define_options(parser)
+#         parser.banner = "Usage: example.rb [options]"
+#         parser.separator ""
+#         parser.separator "Specific options:"
+#
+#         # add additional options
+#         perform_inplace_option(parser)
+#         delay_execution_option(parser)
+#         execute_at_time_option(parser)
+#         specify_record_separator_option(parser)
+#         list_example_option(parser)
+#         specify_encoding_option(parser)
+#         optional_option_argument_with_keyword_completion_option(parser)
+#         boolean_verbose_option(parser)
+#
+#         parser.separator ""
+#         parser.separator "Common options:"
+#         # No argument, shows at tail.  This will print an options summary.
+#         # Try it and see!
+#         parser.on_tail("-h", "--help", "Show this message") do
+#           puts parser
+#           exit
+#         end
+#         # Another typical switch to print the version.
+#         parser.on_tail("--version", "Show version") do
+#           puts Version
+#           exit
+#         end
+#       end
+#
+#       def perform_inplace_option(parser)
+#         # Specifies an optional option argument
+#         parser.on("-i", "--inplace [EXTENSION]",
+#                   "Edit ARGV files in place",
+#                   "(make backup if EXTENSION supplied)") do |ext|
+#           self.inplace = true
+#           self.extension = ext || ''
+#           self.extension.sub!(/\A\.?(?=.)/, ".")  # Ensure extension begins with dot.
+#         end
+#       end
+#
+#       def delay_execution_option(parser)
+#         # Cast 'delay' argument to a Float.
+#         parser.on("--delay N", Float, "Delay N seconds before executing") do |n|
+#           self.delay = n
+#         end
+#       end
+#
+#       def execute_at_time_option(parser)
+#         # Cast 'time' argument to a Time object.
+#         parser.on("-t", "--time [TIME]", Time, "Begin execution at given time") do |time|
+#           self.time = time
+#         end
+#       end
+#
+#       def specify_record_separator_option(parser)
+#         # Cast to octal integer.
+#         parser.on("-F", "--irs [OCTAL]", OptionParser::OctalInteger,
+#                   "Specify record separator (default \\0)") do |rs|
+#           self.record_separator = rs
+#         end
+#       end
+#
+#       def list_example_option(parser)
+#         # List of arguments.
+#         parser.on("--list x,y,z", Array, "Example 'list' of arguments") do |list|
+#           self.list = list
+#         end
+#       end
+#
+#       def specify_encoding_option(parser)
+#         # Keyword completion.  We are specifying a specific set of arguments (CODES
+#         # and CODE_ALIASES - notice the latter is a Hash), and the user may provide
+#         # the shortest unambiguous text.
+#         code_list = (CODE_ALIASES.keys + CODES).join(', ')
+#         parser.on("--code CODE", CODES, CODE_ALIASES, "Select encoding",
+#                   "(#{code_list})") do |encoding|
+#           self.encoding = encoding
+#         end
+#       end
+#
+#       def optional_option_argument_with_keyword_completion_option(parser)
+#         # Optional '--type' option argument with keyword completion.
+#         parser.on("--type [TYPE]", [:text, :binary, :auto],
+#                   "Select transfer type (text, binary, auto)") do |t|
+#           self.transfer_type = t
+#         end
+#       end
+#
+#       def boolean_verbose_option(parser)
+#         # Boolean switch.
+#         parser.on("-v", "--[no-]verbose", "Run verbosely") do |v|
+#           self.verbose = v
+#         end
+#       end
+#     end
+#
+#     #
+#     # Return a structure describing the options.
+#     #
+#     def parse(args)
+#       # The options specified on the command line will be collected in
+#       # *options*.
+#
+#       @options = ScriptOptions.new
+#       @args = OptionParser.new do |parser|
+#         @options.define_options(parser)
+#         parser.parse!(args)
+#       end
+#       @options
+#     end
+#
+#     attr_reader :parser, :options
+#   end  # class OptparseExample
+#
+#   example = OptparseExample.new
+#   options = example.parse(ARGV)
+#   pp options # example.options
+#   pp ARGV
+#
+# === Shell Completion
+#
+# For modern shells (e.g. bash, zsh, etc.), you can use shell
+# completion for command line options.
+#
+# === Further documentation
+#
+# The above examples, along with the accompanying
+# {Tutorial}[./doc/optparse/tutorial_rdoc.html],
+# should be enough to learn how to use this class.
+# If you have any questions, file a ticket at http://bugs.ruby-lang.org.
+#
+class OptionParser
+  OptionParser::Version = '0.1.1'
+
+  # :stopdoc:
+  NoArgument = [NO_ARGUMENT = :NONE, nil].freeze
+  RequiredArgument = [REQUIRED_ARGUMENT = :REQUIRED, true].freeze
+  OptionalArgument = [OPTIONAL_ARGUMENT = :OPTIONAL, false].freeze
+  # :startdoc:
+
+  #
+  # Keyword completion module.  This allows partial arguments to be specified
+  # and resolved against a list of acceptable values.
+  #
+  module Completion
+    def self.regexp(key, icase)
+      Regexp.new('\A' + Regexp.quote(key).gsub(/\w+\b/, '\&\w*'), icase)
+    end
+
+    def self.candidate(key, icase = false, pat = nil, &block)
+      pat ||= Completion.regexp(key, icase)
+      candidates = []
+      block.call do |k, *v|
+        (if Regexp === k
+           kn = ''
+           k === key
+         else
+           kn = defined?(k.id2name) ? k.id2name : k
+           pat === kn
+         end) || next
+        v << k if v.empty?
+        candidates << [k, v, kn]
+      end
+      candidates
+    end
+
+    def candidate(key, icase = false, pat = nil)
+      Completion.candidate(key, icase, pat, &method(:each))
+    end
+
+    public
+
+    def complete(key, icase = false, pat = nil)
+      candidates = candidate(key, icase, pat, &method(:each)).sort_by { |k, v, kn| kn.size }
+      if candidates.size == 1
+        canon, sw, * = candidates[0]
+      elsif candidates.size > 1
+        canon, sw, cn = candidates.shift
+        candidates.each do |k, v, kn|
+          next if sw == v
+          if (String === cn) && (String === kn)
+            if cn.rindex(kn, 0)
+              canon, sw, cn = k, v, kn
+              next
+            elsif kn.rindex(cn, 0)
+              next
+            end
+          end
+          throw :ambiguous, key
+        end
+      end
+      if canon
+        block_given? || (return key, *sw)
+        yield(key, *sw)
+      end
+    end
+
+    def convert(opt = nil, val = nil, *)
+      val
+    end
+  end
+
+
+  #
+  # Map from option/keyword string to object with completion.
+  #
+  class OptionMap < Hash
+    include Completion
+  end
+
+
+  #
+  # Individual switch class.  Not important to the user.
+  #
+  # Defined within Switch are several Switch-derived classes: NoArgument,
+  # RequiredArgument, etc.
+  #
+  class Switch
+    attr_reader :pattern, :conv, :short, :long, :arg, :desc, :block
+
+    #
+    # Guesses argument style from +arg+.  Returns corresponding
+    # OptionParser::Switch class (OptionalArgument, etc.).
+    #
+    def self.guess(arg)
+      case arg
+      when ''
+        t = self
+      when /\A=?\[/
+        t = Switch::OptionalArgument
+      when /\A\s+\[/
+        t = Switch::PlacedArgument
+      else
+        t = Switch::RequiredArgument
+      end
+      (self >= t) || incompatible_argument_styles(arg, t)
+      t
+    end
+
+    def self.incompatible_argument_styles(arg, t)
+      raise(ArgumentError, "#{arg}: incompatible argument styles\n  #{self}, #{t}",
+        ParseError.filter_backtrace(caller(2))
+      )
+    end
+
+    def self.pattern
+      NilClass
+    end
+
+    def initialize(pattern = nil, conv = nil,
+      short = nil, long = nil, arg = nil,
+      desc = ([] if short || long), block = nil, &_block)
+      raise if Array === pattern
+      block ||= _block
+      @pattern, @conv, @short, @long, @arg, @desc, @block =
+        pattern, conv, short, long, arg, desc, block
+    end
+
+    #
+    # Parses +arg+ and returns rest of +arg+ and matched portion to the
+    # argument pattern. Yields when the pattern doesn't match substring.
+    #
+    def parse_arg(arg) # :nodoc:
+      pattern || (return nil, [arg])
+      unless m = pattern.match(arg)
+        yield(InvalidArgument, arg)
+        return arg, []
+      end
+      if String === m
+        m = [s = m]
+      else
+        m = m.to_a
+        s = m[0]
+        return nil, m unless String === s
+      end
+      raise InvalidArgument, arg unless arg.rindex(s, 0)
+      return nil, m if s.length == arg.length
+      yield(InvalidArgument, arg) # didn't match whole arg
+      [arg[s.length..-1], m]
+    end
+    private :parse_arg
+
+    #
+    # Parses argument, converts and returns +arg+, +block+ and result of
+    # conversion. Yields at semi-error condition instead of raising an
+    # exception.
+    #
+    def conv_arg(arg, val = []) # :nodoc:
+      if conv
+        val = conv.call(*val)
+      else
+        val = proc { |v| v }.call(*val)
+      end
+      [arg, block, val]
+    end
+    private :conv_arg
+
+    #
+    # Produces the summary text. Each line of the summary is yielded to the
+    # block (without newline).
+    #
+    # +sdone+::  Already summarized short style options keyed hash.
+    # +ldone+::  Already summarized long style options keyed hash.
+    # +width+::  Width of left side (option part). In other words, the right
+    #            side (description part) starts after +width+ columns.
+    # +max+::    Maximum width of left side -> the options are filled within
+    #            +max+ columns.
+    # +indent+:: Prefix string indents all summarized lines.
+    #
+    def summarize(sdone = {}, ldone = {}, width = 1, max = width - 1, indent = '')
+      sopts, lopts = [], [], nil
+      @short.each { |s| sdone.fetch(s) { sopts << s }; sdone[s] = true } if @short
+      @long.each { |s| ldone.fetch(s) { lopts << s }; ldone[s] = true } if @long
+      return if sopts.empty? && lopts.empty? # completely hidden
+
+      left = [sopts.join(', ')]
+      right = desc.dup
+
+      while s = lopts.shift
+        l = left[-1].length + s.length
+        l += arg.length if left.size == 1 && arg
+        (l < max) || sopts.empty? || left << +''
+        left[-1] += (left[-1].empty? ? ' ' * 4 : ', ') + s
+      end
+
+      if arg
+        left[0] += (left[1] ? arg.sub(/\A(\[?)=/, '\1') + ',' : arg)
+      end
+      mlen = left.collect(&:length).max.to_i
+      while (mlen > width) && (l = left.shift)
+        mlen = left.collect(&:length).max.to_i if l.length == mlen
+        if (l.length < width) && (r = right[0]) && !r.empty?
+          l = l.to_s.ljust(width) + ' ' + r
+          right.shift
+        end
+        yield(indent + l)
+      end
+
+      while begin l = left.shift; r = right.shift; l || r end
+        l = l.to_s.ljust(width) + ' ' + r if r && !r.empty?
+        yield(indent + l)
+      end
+
+      self
+    end
+
+    def add_banner(to) # :nodoc:
+      unless @short || @long
+        s = desc.join
+        to << ' [' + s + ']...' unless s.empty?
+      end
+      to
+    end
+
+    def match_nonswitch?(str) # :nodoc:
+      @pattern =~ str unless @short || @long
+    end
+
+    #
+    # Main name of the switch.
+    #
+    def switch_name
+      (long.first || short.first).sub(/\A-+(?:\[no-\])?/, '')
+    end
+
+    def compsys(sdone, ldone) # :nodoc:
+      sopts, lopts = [], []
+      @short.each { |s| sdone.fetch(s) { sopts << s }; sdone[s] = true } if @short
+      @long.each { |s| ldone.fetch(s) { lopts << s }; ldone[s] = true } if @long
+      return if sopts.empty? && lopts.empty? # completely hidden
+
+      (sopts + lopts).each do |opt|
+        # "(-x -c -r)-l[left justify]"
+        if /^--\[no-\](.+)$/ =~ opt
+          o = Regexp.last_match(1)
+          yield("--#{o}", desc.join(''))
+          yield("--no-#{o}", desc.join(''))
+        else
+          yield(opt.to_s, desc.join(''))
+        end
+      end
+    end
+
+    #
+    # Switch that takes no arguments.
+    #
+    class NoArgument < self
+      #
+      # Raises an exception if any arguments given.
+      #
+      def parse(arg, argv)
+        yield(NeedlessArgument, arg) if arg
+        conv_arg(arg)
+      end
+
+      def self.incompatible_argument_styles(*)
+      end
+
+      def self.pattern
+        Object
+      end
+    end
+
+    #
+    # Switch that takes an argument.
+    #
+    class RequiredArgument < self
+      #
+      # Raises an exception if argument is not present.
+      #
+      def parse(arg, argv)
+        unless arg
+          raise MissingArgument if argv.empty?
+          arg = argv.shift
+        end
+        conv_arg(*parse_arg(arg, &method(:raise)))
+      end
+    end
+
+    #
+    # Switch that can omit argument.
+    #
+    class OptionalArgument < self
+      #
+      # Parses argument if given, or uses default value.
+      #
+      def parse(arg, argv, &error)
+        if arg
+          conv_arg(*parse_arg(arg, &error))
+        else
+          conv_arg(arg)
+        end
+      end
+    end
+
+    #
+    # Switch that takes an argument, which does not begin with '-'.
+    #
+    class PlacedArgument < self
+      #
+      # Returns nil if argument is not present or begins with '-'.
+      #
+      def parse(arg, argv, &error)
+        if !(val = arg) && (argv.empty? || /\A-/ =~ (val = argv[0]))
+          return nil, block, nil
+        end
+        opt = (val = parse_arg(val, &error))[1]
+        val = conv_arg(*val)
+        if opt && !arg
+          argv.shift
+        else
+          val[0] = nil
+        end
+        val
+      end
+    end
+  end
+
+  #
+  # Simple option list providing mapping from short and/or long option
+  # string to OptionParser::Switch and mapping from acceptable argument to
+  # matching pattern and converter pair. Also provides summary feature.
+  #
+  class List
+    # Map from acceptable argument types to pattern and converter pairs.
+    attr_reader :atype
+
+    # Map from short style option switches to actual switch objects.
+    attr_reader :short
+
+    # Map from long style option switches to actual switch objects.
+    attr_reader :long
+
+    # List of all switches and summary string.
+    attr_reader :list
+
+    #
+    # Just initializes all instance variables.
+    #
+    def initialize
+      @atype = {}
+      @short = OptionMap.new
+      @long = OptionMap.new
+      @list = []
+    end
+
+    #
+    # See OptionParser.accept.
+    #
+    def accept(t, pat = /.*/m, &block)
+      if pat
+        pat.respond_to?(:match) ||
+          raise(TypeError, "has no `match'", ParseError.filter_backtrace(caller(2)))
+      else
+        pat = t if t.respond_to?(:match)
+      end
+      unless block
+        block = pat.method(:convert).to_proc if pat.respond_to?(:convert)
+      end
+      @atype[t] = [pat, block]
+    end
+
+    #
+    # See OptionParser.reject.
+    #
+    def reject(t)
+      @atype.delete(t)
+    end
+
+    #
+    # Adds +sw+ according to +sopts+, +lopts+ and +nlopts+.
+    #
+    # +sw+::     OptionParser::Switch instance to be added.
+    # +sopts+::  Short style option list.
+    # +lopts+::  Long style option list.
+    # +nlopts+:: Negated long style options list.
+    #
+    def update(sw, sopts, lopts, nsw = nil, nlopts = nil) # :nodoc:
+      sopts.each { |o| @short[o] = sw } if sopts
+      lopts.each { |o| @long[o] = sw } if lopts
+      nlopts.each { |o| @long[o] = nsw } if nsw && nlopts
+      used = @short.invert.update(@long.invert)
+      @list.delete_if { |o| (Switch === o) && !used[o] }
+    end
+    private :update
+
+    #
+    # Inserts +switch+ at the head of the list, and associates short, long
+    # and negated long options. Arguments are:
+    #
+    # +switch+::      OptionParser::Switch instance to be inserted.
+    # +short_opts+::  List of short style options.
+    # +long_opts+::   List of long style options.
+    # +nolong_opts+:: List of long style options with "no-" prefix.
+    #
+    #   prepend(switch, short_opts, long_opts, nolong_opts)
+    #
+    def prepend(*args)
+      update(*args)
+      @list.unshift(args[0])
+    end
+
+    #
+    # Appends +switch+ at the tail of the list, and associates short, long
+    # and negated long options. Arguments are:
+    #
+    # +switch+::      OptionParser::Switch instance to be inserted.
+    # +short_opts+::  List of short style options.
+    # +long_opts+::   List of long style options.
+    # +nolong_opts+:: List of long style options with "no-" prefix.
+    #
+    #   append(switch, short_opts, long_opts, nolong_opts)
+    #
+    def append(*args)
+      update(*args)
+      @list.push(args[0])
+    end
+
+    #
+    # Searches +key+ in +id+ list. The result is returned or yielded if a
+    # block is given. If it isn't found, nil is returned.
+    #
+    def search(id, key)
+      if list = __send__(id)
+        val = list.fetch(key) { return nil }
+        block_given? ? yield(val) : val
+      end
+    end
+
+    #
+    # Searches list +id+ for +opt+ and the optional patterns for completion
+    # +pat+. If +icase+ is true, the search is case insensitive. The result
+    # is returned or yielded if a block is given. If it isn't found, nil is
+    # returned.
+    #
+    def complete(id, opt, icase = false, *pat, &block)
+      __send__(id).complete(opt, icase, *pat, &block)
+    end
+
+    def get_candidates(id)
+      yield __send__(id).keys
+    end
+
+    #
+    # Iterates over each option, passing the option to the +block+.
+    #
+    def each_option(&block)
+      list.each(&block)
+    end
+
+    #
+    # Creates the summary table, passing each line to the +block+ (without
+    # newline). The arguments +args+ are passed along to the summarize
+    # method which is called on every option.
+    #
+    def summarize(*args, &block)
+      sum = []
+      list.reverse_each do |opt|
+        if opt.respond_to?(:summarize) # perhaps OptionParser::Switch
+          s = []
+          opt.summarize(*args) { |l| s << l }
+          sum.concat(s.reverse)
+        elsif !opt || opt.empty?
+          sum << ''
+        elsif opt.respond_to?(:each_line)
+          sum.concat([*opt.each_line].reverse)
+        else
+          sum.concat([*opt.each].reverse)
+        end
+      end
+      sum.reverse_each(&block)
+    end
+
+    def add_banner(to) # :nodoc:
+      list.each do |opt|
+        if opt.respond_to?(:add_banner)
+          opt.add_banner(to)
+        end
+      end
+      to
+    end
+
+    def compsys(*args, &block) # :nodoc:
+      list.each do |opt|
+        if opt.respond_to?(:compsys)
+          opt.compsys(*args, &block)
+        end
+      end
+    end
+  end
+
+  #
+  # Hash with completion search feature. See OptionParser::Completion.
+  #
+  class CompletingHash < Hash
+    include Completion
+
+    #
+    # Completion for hash key.
+    #
+    def match(key)
+      *values = fetch(key) do
+        raise AmbiguousArgument, catch(:ambiguous) { return complete(key) }
+      end
+      [key, *values]
+    end
+  end
+
+  # :stopdoc:
+
+  #
+  # Enumeration of acceptable argument styles. Possible values are:
+  #
+  # NO_ARGUMENT::       The switch takes no arguments. (:NONE)
+  # REQUIRED_ARGUMENT:: The switch requires an argument. (:REQUIRED)
+  # OPTIONAL_ARGUMENT:: The switch requires an optional argument. (:OPTIONAL)
+  #
+  # Use like --switch=argument (long style) or -Xargument (short style). For
+  # short style, only portion matched to argument pattern is treated as
+  # argument.
+  #
+  ArgumentStyle = {}
+  NoArgument.each { |el| ArgumentStyle[el] = Switch::NoArgument }
+  RequiredArgument.each { |el| ArgumentStyle[el] = Switch::RequiredArgument }
+  OptionalArgument.each { |el| ArgumentStyle[el] = Switch::OptionalArgument }
+  ArgumentStyle.freeze
+
+  #
+  # Switches common used such as '--', and also provides default
+  # argument classes
+  #
+  DefaultList = List.new
+  DefaultList.short['-'] = Switch::NoArgument.new {}
+  DefaultList.long[''] = Switch::NoArgument.new { throw :terminate }
+
+
+  COMPSYS_HEADER = <<'XXX'      # :nodoc:
+
+typeset -A opt_args
+local context state line
+
+_arguments -s -S \
+XXX
+
+  def compsys(to, name = File.basename($0)) # :nodoc:
+    to << "#compdef #{name}\n"
+    to << COMPSYS_HEADER
+    visit(:compsys, {}, {}) do |o, d|
+      to << %[  "#{o}[#{d.gsub(/[\"\[\]]/, '\\\\\&')}]" \\\n]
+    end
+    to << "  '*:file:_files' && return 0\n"
+  end
+
+  #
+  # Default options for ARGV, which never appear in option summary.
+  #
+  Officious = {}
+
+  #
+  # --help
+  # Shows option summary.
+  #
+  Officious['help'] = proc do |parser|
+    Switch::NoArgument.new do |arg|
+      puts parser.help
+      exit
+    end
+  end
+
+  #
+  # --*-completion-bash=WORD
+  # Shows candidates for command line completion.
+  #
+  Officious['*-completion-bash'] = proc do |parser|
+    Switch::RequiredArgument.new do |arg|
+      puts parser.candidate(arg)
+      exit
+    end
+  end
+
+  #
+  # --*-completion-zsh[=NAME:FILE]
+  # Creates zsh completion file.
+  #
+  Officious['*-completion-zsh'] = proc do |parser|
+    Switch::OptionalArgument.new do |arg|
+      parser.compsys(STDOUT, arg)
+      exit
+    end
+  end
+
+  #
+  # --version
+  # Shows version string if Version is defined.
+  #
+  Officious['version'] = proc do |parser|
+    Switch::OptionalArgument.new do |pkg|
+      if pkg
+        begin
+          require 'optparse/version'
+        rescue LoadError
+        else
+          show_version(*pkg.split(/,/)) ||
+            abort("#{parser.program_name}: no version found in package #{pkg}")
+          exit
+        end
+      end
+      (v = parser.ver) || abort("#{parser.program_name}: version unknown")
+      puts v
+      exit
+    end
+  end
+
+  # :startdoc:
+
+  #
+  # Class methods
+  #
+
+  #
+  # Initializes a new instance and evaluates the optional block in context
+  # of the instance. Arguments +args+ are passed to #new, see there for
+  # description of parameters.
+  #
+  # This method is *deprecated*, its behavior corresponds to the older #new
+  # method.
+  #
+  def self.with(*args, &block)
+    opts = new(*args)
+    opts.instance_eval(&block)
+    opts
+  end
+
+  #
+  # Returns an incremented value of +default+ according to +arg+.
+  #
+  def self.inc(arg, default = nil)
+    case arg
+    when Integer
+      arg.nonzero?
+    when nil
+      default.to_i + 1
+    end
+  end
+
+  def inc(*args)
+    self.class.inc(*args)
+  end
+
+  #
+  # Initializes the instance and yields itself if called with a block.
+  #
+  # +banner+:: Banner message.
+  # +width+::  Summary width.
+  # +indent+:: Summary indent.
+  #
+  def initialize(banner = nil, width = 32, indent = ' ' * 4)
+    @stack = [DefaultList, List.new, List.new]
+    @program_name = nil
+    @banner = banner
+    @summary_width = width
+    @summary_indent = indent
+    @default_argv = ARGV
+    @require_exact = false
+    add_officious
+    yield self if block_given?
+  end
+
+  def add_officious # :nodoc:
+    list = base
+    Officious.each do |opt, block|
+      list.long[opt] ||= block.call(self)
+    end
+  end
+
+  #
+  # Terminates option parsing. Optional parameter +arg+ is a string pushed
+  # back to be the first non-option argument.
+  #
+  def terminate(arg = nil)
+    self.class.terminate(arg)
+  end
+
+  def self.terminate(arg = nil)
+    throw :terminate, arg
+  end
+
+  @stack = [DefaultList]
+  def self.top
+    DefaultList
+  end
+
+  #
+  # Directs to accept specified class +t+. The argument string is passed to
+  # the block in which it should be converted to the desired class.
+  #
+  # +t+::   Argument class specifier, any object including Class.
+  # +pat+:: Pattern for argument, defaults to +t+ if it responds to match.
+  #
+  #   accept(t, pat, &block)
+  #
+  def accept(*args, &blk)
+    top.accept(*args, &blk)
+  end
+
+  #
+  # See #accept.
+  #
+  def self.accept(*args, &blk)
+    top.accept(*args, &blk)
+  end
+
+  #
+  # Directs to reject specified class argument.
+  #
+  # +t+:: Argument class specifier, any object including Class.
+  #
+  #   reject(t)
+  #
+  def reject(*args, &blk)
+    top.reject(*args, &blk)
+  end
+
+  #
+  # See #reject.
+  #
+  def self.reject(*args, &blk)
+    top.reject(*args, &blk)
+  end
+
+  #
+  # Instance methods
+  #
+
+  # Heading banner preceding summary.
+  attr_writer :banner
+
+  # Program name to be emitted in error message and default banner,
+  # defaults to $0.
+  attr_writer :program_name
+
+  # Width for option list portion of summary. Must be Numeric.
+  attr_accessor :summary_width
+
+  # Indentation for summary. Must be String (or have + String method).
+  attr_accessor :summary_indent
+
+  # Strings to be parsed in default.
+  attr_accessor :default_argv
+
+  # Whether to require that options match exactly (disallows providing
+  # abbreviated long option as short option).
+  attr_accessor :require_exact
+
+  #
+  # Heading banner preceding summary.
+  #
+  def banner
+    unless @banner
+      @banner = +"Usage: #{program_name} [options]"
+      visit(:add_banner, @banner)
+    end
+    @banner
+  end
+
+  #
+  # Program name to be emitted in error message and default banner, defaults
+  # to $0.
+  #
+  def program_name
+    @program_name || File.basename($0, '.*')
+  end
+
+  # for experimental cascading :-)
+  alias set_banner banner=
+  alias set_program_name program_name=
+  alias set_summary_width summary_width=
+  alias set_summary_indent summary_indent=
+
+  # Version
+  attr_writer :version
+  # Release code
+  attr_writer :release
+
+  #
+  # Version
+  #
+  def version
+    (defined?(@version) && @version) || (defined?(::Version) && ::Version)
+  end
+
+  #
+  # Release code
+  #
+  def release
+    (defined?(@release) && @release) || (defined?(::Release) && ::Release) || (defined?(::RELEASE) && ::RELEASE)
+  end
+
+  #
+  # Returns version string from program_name, version and release.
+  #
+  def ver
+    if v = version
+      str = +"#{program_name} #{[v].join('.')}"
+      str << " (#{v})" if v = release
+      str
+    end
+  end
+
+  def warn(mesg = $!)
+    super("#{program_name}: #{mesg}")
+  end
+
+  def abort(mesg = $!)
+    super("#{program_name}: #{mesg}")
+  end
+
+  #
+  # Subject of #on / #on_head, #accept / #reject
+  #
+  def top
+    @stack[-1]
+  end
+
+  #
+  # Subject of #on_tail.
+  #
+  def base
+    @stack[1]
+  end
+
+  #
+  # Pushes a new List.
+  #
+  def new
+    @stack.push(List.new)
+    if block_given?
+      yield self
+    else
+      self
+    end
+  end
+
+  #
+  # Removes the last List.
+  #
+  def remove
+    @stack.pop
+  end
+
+  #
+  # Puts option summary into +to+ and returns +to+. Yields each line if
+  # a block is given.
+  #
+  # +to+:: Output destination, which must have method <<. Defaults to [].
+  # +width+:: Width of left side, defaults to @summary_width.
+  # +max+:: Maximum length allowed for left side, defaults to +width+ - 1.
+  # +indent+:: Indentation, defaults to @summary_indent.
+  #
+  def summarize(to = [], width = @summary_width, max = width - 1, indent = @summary_indent, &blk)
+    nl = "\n"
+    blk ||= proc { |l| to << (l.index(nl, -1) ? l : l + nl) }
+    visit(:summarize, {}, {}, width, max, indent, &blk)
+    to
+  end
+
+  #
+  # Returns option summary string.
+  #
+  def help
+    summarize([banner.to_s.sub(/\n?\z/, "\n")]).join
+  end
+  alias to_s help
+
+  #
+  # Returns option summary list.
+  #
+  def to_a
+    summarize([banner.to_s.split(/^/)]).join
+  end
+
+  #
+  # Checks if an argument is given twice, in which case an ArgumentError is
+  # raised. Called from OptionParser#switch only.
+  #
+  # +obj+:: New argument.
+  # +prv+:: Previously specified argument.
+  # +msg+:: Exception message.
+  #
+  def notwice(obj, prv, msg) # :nodoc:
+    unless !prv || (prv == obj)
+      raise(ArgumentError, "argument #{msg} given twice: #{obj}",
+        ParseError.filter_backtrace(caller(2))
+      )
+    end
+    obj
+  end
+  private :notwice
+
+  SPLAT_PROC = proc { |*a| a.length <= 1 ? a.first : a } # :nodoc:
+
+  # :call-seq:
+  #   make_switch(params, block = nil)
+  #
+  # :include: ../doc/optparse/creates_option.rdoc
+  #
+  def make_switch(opts, block = nil)
+    short, long, nolong, style, pattern, conv, not_pattern, not_conv, not_style = [], [], []
+    ldesc, sdesc, desc, arg = [], [], []
+    default_style = Switch::NoArgument
+    default_pattern = nil
+    klass = nil
+    q, a = nil
+    has_arg = false
+
+    opts.each do |o|
+      # argument class
+      next if search(:atype, o) do |pat, c|
+        klass = notwice(o, klass, 'type')
+        if not_style && (not_style != Switch::NoArgument)
+          not_pattern, not_conv = pat, c
+        else
+          default_pattern, conv = pat, c
+        end
+      end
+
+      # directly specified pattern(any object possible to match)
+      if !(String === o || Symbol === o) && o.respond_to?(:match)
+        pattern = notwice(o, pattern, 'pattern')
+        if pattern.respond_to?(:convert)
+          conv = pattern.method(:convert).to_proc
+        else
+          conv = SPLAT_PROC
+        end
+        next
+      end
+
+      # anything others
+      case o
+      when Proc, Method
+        block = notwice(o, block, 'block')
+      when Array, Hash
+        case pattern
+        when CompletingHash
+        when nil
+          pattern = CompletingHash.new
+          conv = pattern.method(:convert).to_proc if pattern.respond_to?(:convert)
+        else
+          raise ArgumentError, 'argument pattern given twice'
+        end
+        o.each { |pat, *v| pattern[pat] = v.fetch(0) { pat } }
+      when Module
+        raise ArgumentError, "unsupported argument type: #{o}", ParseError.filter_backtrace(caller(4))
+      when *ArgumentStyle.keys
+        style = notwice(ArgumentStyle[o], style, 'style')
+      when /^--no-([^\[\]=\s]*)(.+)?/
+        q, a = Regexp.last_match(1), Regexp.last_match(2)
+        o = notwice(a ? Object : TrueClass, klass, 'type')
+        not_pattern, not_conv = search(:atype, o) unless not_style
+        not_style = (not_style || default_style).guess(arg = a) if a
+        default_style = Switch::NoArgument
+        default_pattern, conv = search(:atype, FalseClass) unless default_pattern
+        ldesc << "--no-#{q}"
+        q = q.downcase.tr('_', '-')
+        long << "no-#{q}"
+        nolong << q
+      when /^--\[no-\]([^\[\]=\s]*)(.+)?/
+        q, a = Regexp.last_match(1), Regexp.last_match(2)
+        o = notwice(a ? Object : TrueClass, klass, 'type')
+        if a
+          default_style = default_style.guess(arg = a)
+          default_pattern, conv = search(:atype, o) unless default_pattern
+        end
+        ldesc << "--[no-]#{q}"
+        (o = q.downcase).tr!('_', '-')
+        long << o
+        not_pattern, not_conv = search(:atype, FalseClass) unless not_style
+        not_style = Switch::NoArgument
+        nolong << "no-#{o}"
+      when /^--([^\[\]=\s]*)(.+)?/
+        q, a = Regexp.last_match(1), Regexp.last_match(2)
+        if a
+          o = notwice(NilClass, klass, 'type')
+          default_style = default_style.guess(arg = a)
+          default_pattern, conv = search(:atype, o) unless default_pattern
+        end
+        ldesc << "--#{q}"
+        # Opal patch:
+        o = q.downcase.tr('_', '-')
+        long << o
+      when /^-(\[\^?\]?(?:[^\\\]]|\\.)*\])(.+)?/
+        q, a = Regexp.last_match(1), Regexp.last_match(2)
+        o = notwice(Object, klass, 'type')
+        if a
+          default_style = default_style.guess(arg = a)
+          default_pattern, conv = search(:atype, o) unless default_pattern
+        else
+          has_arg = true
+        end
+        sdesc << "-#{q}"
+        short << Regexp.new(q)
+      when /^-(.)(.+)?/
+        q, a = Regexp.last_match(1), Regexp.last_match(2)
+        if a
+          o = notwice(NilClass, klass, 'type')
+          default_style = default_style.guess(arg = a)
+          default_pattern, conv = search(:atype, o) unless default_pattern
+        end
+        sdesc << "-#{q}"
+        short << q
+      when /^=/
+        style = notwice(default_style.guess(arg = o), style, 'style')
+        default_pattern, conv = search(:atype, Object) unless default_pattern
+      else
+        desc.push(o)
+      end
+    end
+
+    default_pattern, conv = search(:atype, default_style.pattern) unless default_pattern
+    if !(short.empty? && long.empty?)
+      if has_arg && (default_style == Switch::NoArgument)
+        default_style = Switch::RequiredArgument
+      end
+      s = (style || default_style).new(pattern || default_pattern,
+        conv, sdesc, ldesc, arg, desc, block
+      )
+    elsif !block
+      if style || pattern
+        raise ArgumentError, 'no switch given', ParseError.filter_backtrace(caller)
+      end
+      s = desc
+    else
+      short << pattern
+      s = (style || default_style).new(pattern,
+        conv, nil, nil, arg, desc, block
+      )
+    end
+    [s, short, long,
+     (not_style.new(not_pattern, not_conv, sdesc, ldesc, nil, desc, block) if not_style),
+     nolong]
+  end
+
+  # :call-seq:
+  #   define(*params, &block)
+  #
+  # :include: ../doc/optparse/creates_option.rdoc
+  #
+  def define(*opts, &block)
+    top.append(*(sw = make_switch(opts, block)))
+    sw[0]
+  end
+
+  # :call-seq:
+  #   on(*params, &block)
+  #
+  # :include: ../doc/optparse/creates_option.rdoc
+  #
+  def on(*opts, &block)
+    define(*opts, &block)
+    self
+  end
+  alias def_option define
+
+  # :call-seq:
+  #   define_head(*params, &block)
+  #
+  # :include: ../doc/optparse/creates_option.rdoc
+  #
+  def define_head(*opts, &block)
+    top.prepend(*(sw = make_switch(opts, block)))
+    sw[0]
+  end
+
+  # :call-seq:
+  #   on_head(*params, &block)
+  #
+  # :include: ../doc/optparse/creates_option.rdoc
+  #
+  # The new option is added at the head of the summary.
+  #
+  def on_head(*opts, &block)
+    define_head(*opts, &block)
+    self
+  end
+  alias def_head_option define_head
+
+  # :call-seq:
+  #   define_tail(*params, &block)
+  #
+  # :include: ../doc/optparse/creates_option.rdoc
+  #
+  def define_tail(*opts, &block)
+    base.append(*(sw = make_switch(opts, block)))
+    sw[0]
+  end
+
+  #
+  # :call-seq:
+  #   on_tail(*params, &block)
+  #
+  # :include: ../doc/optparse/creates_option.rdoc
+  #
+  # The new option is added at the tail of the summary.
+  #
+  def on_tail(*opts, &block)
+    define_tail(*opts, &block)
+    self
+  end
+  alias def_tail_option define_tail
+
+  #
+  # Add separator in summary.
+  #
+  def separator(string)
+    top.append(string, nil, nil)
+  end
+
+  #
+  # Parses command line arguments +argv+ in order. When a block is given,
+  # each non-option argument is yielded. When optional +into+ keyword
+  # argument is provided, the parsed option values are stored there via
+  # <code>[]=</code> method (so it can be Hash, or OpenStruct, or other
+  # similar object).
+  #
+  # Returns the rest of +argv+ left unparsed.
+  #
+  def order(*argv, into: nil, &nonopt)
+    argv = argv[0].dup if (argv.size == 1) && (Array === argv[0])
+    order!(argv, into: into, &nonopt)
+  end
+
+  #
+  # Same as #order, but removes switches destructively.
+  # Non-option arguments remain in +argv+.
+  #
+  def order!(argv = default_argv, into: nil, &nonopt)
+    setter = ->(name, val) { into[name.to_sym] = val } if into
+    parse_in_order(argv, setter, &nonopt)
+  end
+
+  def parse_in_order(argv = default_argv, setter = nil, &nonopt) # :nodoc:
+    opt, arg, val, rest = nil
+    nonopt ||= proc { |a| throw :terminate, a }
+    argv.unshift(arg) if arg = catch(:terminate) do
+      while arg = argv.shift
+        case arg
+        # long option
+        when /\A--([^=]*)(?:=(.*))?/m
+          opt, rest = Regexp.last_match(1), Regexp.last_match(2)
+          opt = opt.tr('_', '-')
+          begin
+            sw, = complete(:long, opt, true)
+            if require_exact && !sw.long.include?(arg)
+              raise InvalidOption, arg
+            end
+          rescue ParseError
+            raise $!.set_option(arg, true)
+          end
+          begin
+            opt, cb, val = sw.parse(rest, argv) { |*exc| raise(*exc) }
+            val = cb.call(val) if cb
+            setter.call(sw.switch_name, val) if setter
+          rescue ParseError
+            raise $!.set_option(arg, rest)
+          end
+
+        # short option
+        when /\A-(.)((=).*|.+)?/m
+          eq, rest, opt = Regexp.last_match(3), Regexp.last_match(2), Regexp.last_match(1)
+          has_arg, val = eq, rest
+          begin
+            sw, = search(:short, opt)
+            unless sw
+              begin
+                sw, = complete(:short, opt)
+                # short option matched.
+                val = arg.delete_prefix('-')
+                has_arg = true
+              rescue InvalidOption
+                raise if require_exact
+                # if no short options match, try completion with long
+                # options.
+                sw, = complete(:long, opt)
+                eq ||= !rest
+              end
+            end
+          rescue ParseError
+            raise $!.set_option(arg, true)
+          end
+          begin
+            opt, cb, val = sw.parse(val, argv) { |*exc| raise(*exc) if eq }
+          rescue ParseError
+            raise $!.set_option(arg, arg.length > 2)
+          else
+            raise InvalidOption, arg if has_arg && !eq && (arg == "-#{opt}")
+          end
+          begin
+            argv.unshift(opt) if opt && (!rest || ((opt = opt.sub(/\A-*/, '-')) != '-'))
+            val = cb.call(val) if cb
+            setter.call(sw.switch_name, val) if setter
+          rescue ParseError
+            raise $!.set_option(arg, arg.length > 2)
+          end
+
+        # non-option argument
+        else
+          catch(:prune) do
+            visit(:each_option) do |sw0|
+              sw = sw0
+              sw.block.call(arg) if (Switch === sw) && sw.match_nonswitch?(arg)
+            end
+            nonopt.call(arg)
+          end
+        end
+      end
+
+      nil
+    end
+
+    visit(:search, :short, nil) { |sw| sw.block.call(*argv) unless sw.pattern }
+
+    argv
+  end
+  private :parse_in_order
+
+  #
+  # Parses command line arguments +argv+ in permutation mode and returns
+  # list of non-option arguments. When optional +into+ keyword
+  # argument is provided, the parsed option values are stored there via
+  # <code>[]=</code> method (so it can be Hash, or OpenStruct, or other
+  # similar object).
+  #
+  def permute(*argv, into: nil)
+    argv = argv[0].dup if (argv.size == 1) && (Array === argv[0])
+    permute!(argv, into: into)
+  end
+
+  #
+  # Same as #permute, but removes switches destructively.
+  # Non-option arguments remain in +argv+.
+  #
+  def permute!(argv = default_argv, into: nil)
+    nonopts = []
+    order!(argv, into: into, &nonopts.method(:<<))
+    argv[0, 0] = nonopts
+    argv
+  end
+
+  #
+  # Parses command line arguments +argv+ in order when environment variable
+  # POSIXLY_CORRECT is set, and in permutation mode otherwise.
+  # When optional +into+ keyword argument is provided, the parsed option
+  # values are stored there via <code>[]=</code> method (so it can be Hash,
+  # or OpenStruct, or other similar object).
+  #
+  def parse(*argv, into: nil)
+    argv = argv[0].dup if (argv.size == 1) && (Array === argv[0])
+    parse!(argv, into: into)
+  end
+
+  #
+  # Same as #parse, but removes switches destructively.
+  # Non-option arguments remain in +argv+.
+  #
+  def parse!(argv = default_argv, into: nil)
+    if ENV.include?('POSIXLY_CORRECT')
+      order!(argv, into: into)
+    else
+      permute!(argv, into: into)
+    end
+  end
+
+  #
+  # Wrapper method for getopts.rb.
+  #
+  #   params = ARGV.getopts("ab:", "foo", "bar:", "zot:Z;zot option")
+  #   # params["a"] = true   # -a
+  #   # params["b"] = "1"    # -b1
+  #   # params["foo"] = "1"  # --foo
+  #   # params["bar"] = "x"  # --bar x
+  #   # params["zot"] = "z"  # --zot Z
+  #
+  def getopts(*args)
+    argv = Array === args.first ? args.shift : default_argv
+    single_options, *long_options = *args
+
+    result = {}
+
+    if single_options
+      single_options.scan(/(.)(:)?/) do |opt, val|
+        if val
+          result[opt] = nil
+          define("-#{opt} VAL")
+        else
+          result[opt] = false
+          define("-#{opt}")
+        end
+      end
+    end
+
+    long_options.each do |arg|
+      arg, desc = arg.split(';', 2)
+      opt, val = arg.split(':', 2)
+      if val
+        result[opt] = val.empty? ? nil : val
+        define("--#{opt}=#{result[opt] || 'VAL'}", *[desc].compact)
+      else
+        result[opt] = false
+        define("--#{opt}", *[desc].compact)
+      end
+    end
+
+    parse_in_order(argv, result.method(:[]=))
+    result
+  end
+
+  #
+  # See #getopts.
+  #
+  def self.getopts(*args)
+    new.getopts(*args)
+  end
+
+  #
+  # Traverses @stack, sending each element method +id+ with +args+ and
+  # +block+.
+  #
+  def visit(id, *args, &block) # :nodoc:
+    @stack.reverse_each do |el|
+      el.__send__(id, *args, &block)
+    end
+    nil
+  end
+  private :visit
+
+  #
+  # Searches +key+ in @stack for +id+ hash and returns or yields the result.
+  #
+  def search(id, key) # :nodoc:
+    block_given = block_given?
+    retval = nil
+    visit(:search, id, key) do |k|
+      retval = block_given ? yield(k) : k
+      break
+    end
+    retval
+  end
+  private :search
+
+  #
+  # Completes shortened long style option switch and returns pair of
+  # canonical switch and switch descriptor OptionParser::Switch.
+  #
+  # +typ+::   Searching table.
+  # +opt+::   Searching key.
+  # +icase+:: Search case insensitive if true.
+  # +pat+::   Optional pattern for completion.
+  #
+  def complete(typ, opt, icase = false, *pat) # :nodoc:
+    if pat.empty?
+      search(typ, opt) { |sw| return [sw, opt] } # exact match or...
+    end
+    ambiguous = catch(:ambiguous) do
+      visit(:complete, typ, opt, icase, *pat) { |o, *sw| return sw }
+    end
+    exc = ambiguous ? AmbiguousOption : InvalidOption
+    raise exc.new(opt, additional: method(:additional_message).curry[typ])
+  end
+  private :complete
+
+  #
+  # Returns additional info.
+  #
+  def additional_message(typ, opt)
+    return unless typ && opt && defined?(DidYouMean::SpellChecker)
+    all_candidates = []
+    visit(:get_candidates, typ) do |candidates|
+      all_candidates.concat(candidates)
+    end
+    all_candidates.select! { |cand| cand.is_a?(String) }
+    checker = DidYouMean::SpellChecker.new(dictionary: all_candidates)
+    DidYouMean.formatter.message_for(all_candidates & checker.correct(opt))
+  end
+
+  def candidate(word)
+    list = []
+    case word
+    when '-'
+      long = short = true
+    when /\A--/
+      word, arg = word.split(/=/, 2)
+      argpat = Completion.regexp(arg, false) if arg && !arg.empty?
+      long = true
+    when /\A-/
+      short = true
+    end
+    pat = Completion.regexp(word, long)
+    visit(:each_option) do |opt|
+      next unless Switch === opt
+      opts = (long ? opt.long : []) + (short ? opt.short : [])
+      opts = Completion.candidate(word, true, pat, &opts.method(:each)).map(&:first) if pat
+      if /\A=/ =~ opt.arg
+        opts.map! { |sw| sw + '=' }
+        if arg && (CompletingHash === opt.pattern)
+          if opts = opt.pattern.candidate(arg, false, argpat)
+            opts.map!(&:last)
+          end
+        end
+      end
+      list.concat(opts)
+    end
+    list
+  end
+
+  #
+  # Loads options from file names as +filename+. Does nothing when the file
+  # is not present. Returns whether successfully loaded.
+  #
+  # +filename+ defaults to basename of the program without suffix in a
+  # directory ~/.options, then the basename with '.options' suffix
+  # under XDG and Haiku standard places.
+  #
+  def load(filename = nil)
+    unless filename
+      basename = File.basename($0, '.*')
+      begin
+        return true if load(File.expand_path(basename, '~/.options'))
+      rescue
+        nil
+      end
+      basename << '.options'
+      return [
+        # XDG
+        ENV['XDG_CONFIG_HOME'],
+        '~/.config',
+        *ENV['XDG_CONFIG_DIRS']&.split(File::PATH_SEPARATOR),
+
+        # Haiku
+        '~/config/settings',
+      ].any? do |dir|
+        next if !dir || dir.empty?
+        begin
+          load(File.expand_path(basename, dir))
+        rescue
+          nil
+        end
+      end
+    end
+    begin
+      parse(*IO.readlines(filename).each(&:chomp!))
+      true
+    rescue Errno::ENOENT, Errno::ENOTDIR
+      false
+    end
+  end
+
+  #
+  # Parses environment variable +env+ or its uppercase with splitting like a
+  # shell.
+  #
+  # +env+ defaults to the basename of the program.
+  #
+  def environment(env = File.basename($0, '.*'))
+    (env = ENV[env] || ENV[env.upcase]) || return
+    require 'shellwords'
+    parse(*Shellwords.shellwords(env))
+  end
+
+  #
+  # Acceptable argument classes
+  #
+
+  #
+  # Any string and no conversion. This is fall-back.
+  #
+  accept(Object) { |s,| s || s.nil? }
+
+  accept(NilClass) { |s,| s }
+
+  #
+  # Any non-empty string, and no conversion.
+  #
+  accept(String, /.+/m) { |s, *| s }
+
+  #
+  # Ruby/C-like integer, octal for 0-7 sequence, binary for 0b, hexadecimal
+  # for 0x, and decimal for others; with optional sign prefix. Converts to
+  # Integer.
+  #
+  decimal = '\d+(?:_\d+)*'
+  binary = 'b[01]+(?:_[01]+)*'
+  hex = 'x[\da-f]+(?:_[\da-f]+)*'
+  octal = "0(?:[0-7]+(?:_[0-7]+)*|#{binary}|#{hex})?"
+  integer = "#{octal}|#{decimal}"
+
+  accept(Integer, %r"\A[-+]?(?:#{integer})\z"io) do |s,|
+    if s
+      begin
+        Integer(s)
+      rescue ArgumentError
+        raise OptionParser::InvalidArgument, s
+      end
+    end
+  end
+
+  #
+  # Float number format, and converts to Float.
+  #
+  float = "(?:#{decimal}(?=(.)?)(?:\\.(?:#{decimal})?)?|\\.#{decimal})(?:E[-+]?#{decimal})?"
+  floatpat = %r"\A[-+]?#{float}\z"io
+  accept(Float, floatpat) { |s,| s.to_f if s }
+
+  #
+  # Generic numeric format, converts to Integer for integer format, Float
+  # for float format, and Rational for rational format.
+  #
+  real = "[-+]?(?:#{octal}|#{float})"
+  accept(Numeric, /\A(#{real})(?:\/(#{real}))?\z/io) do |s, d, f, n,|
+    if n
+      Rational(d, n)
+    elsif f
+      Float(s)
+    else
+      Integer(s)
+    end
+  end
+
+  #
+  # Decimal integer format, to be converted to Integer.
+  #
+  DecimalInteger = /\A[-+]?#{decimal}\z/io
+  accept(DecimalInteger, DecimalInteger) do |s,|
+    if s
+      begin
+        Integer(s, 10)
+      rescue ArgumentError
+        raise OptionParser::InvalidArgument, s
+      end
+    end
+  end
+
+  #
+  # Ruby/C like octal/hexadecimal/binary integer format, to be converted to
+  # Integer.
+  #
+  OctalInteger = /\A[-+]?(?:[0-7]+(?:_[0-7]+)*|0(?:#{binary}|#{hex}))\z/io
+  accept(OctalInteger, OctalInteger) do |s,|
+    if s
+      begin
+        Integer(s, 8)
+      rescue ArgumentError
+        raise OptionParser::InvalidArgument, s
+      end
+    end
+  end
+
+  #
+  # Decimal integer/float number format, to be converted to Integer for
+  # integer format, Float for float format.
+  #
+  DecimalNumeric = floatpat # decimal integer is allowed as float also.
+  accept(DecimalNumeric, floatpat) do |s, f|
+    if s
+      begin
+        if f
+          Float(s)
+        else
+          Integer(s)
+        end
+      rescue ArgumentError
+        raise OptionParser::InvalidArgument, s
+      end
+    end
+  end
+
+  #
+  # Boolean switch, which means whether it is present or not, whether it is
+  # absent or not with prefix no-, or it takes an argument
+  # yes/no/true/false/+/-.
+  #
+  yesno = CompletingHash.new
+  %w[- no false].each { |el| yesno[el] = false }
+  %w[+ yes true].each { |el| yesno[el] = true }
+  yesno['nil'] = false # should be nil?
+  accept(TrueClass, yesno) { |arg, val| val.nil? || val }
+  #
+  # Similar to TrueClass, but defaults to false.
+  #
+  accept(FalseClass, yesno) { |arg, val| !val.nil? && val }
+
+  #
+  # List of strings separated by ",".
+  #
+  accept(Array) do |s,|
+    if s
+      s = s.split(',').collect { |ss| ss unless ss.empty? }
+    end
+    s
+  end
+
+  #
+  # Regular expression with options.
+  #
+  accept(Regexp, %r"\A/((?:\\.|[^\\])*)/([[:alpha:]]+)?\z|.*") do |all, s, o|
+    f = 0
+    if o
+      f |= Regexp::IGNORECASE if /i/ =~ o
+      f |= Regexp::MULTILINE if /m/ =~ o
+      f |= Regexp::EXTENDED if /x/ =~ o
+      k = o.delete('imx')
+      k = nil if k.empty?
+    end
+    Regexp.new(s || all, f, k)
+  end
+
+  #
+  # Exceptions
+  #
+
+  #
+  # Base class of exceptions from OptionParser.
+  #
+  class ParseError < RuntimeError
+    # Reason which caused the error.
+    Reason = 'parse error'
+
+    def initialize(*args, additional: nil)
+      @additional = additional
+      @arg0, = args
+      @args = args
+      @reason = nil
+    end
+
+    attr_reader :args
+    attr_writer :reason
+    attr_accessor :additional
+
+    #
+    # Pushes back erred argument(s) to +argv+.
+    #
+    def recover(argv)
+      argv[0, 0] = @args
+      argv
+    end
+
+    def self.filter_backtrace(array)
+      unless $DEBUG
+        array.delete_if(&%r"\A#{Regexp.quote(__FILE__)}:"o.method(:=~))
+      end
+      array
+    end
+
+    def set_backtrace(array)
+      super(self.class.filter_backtrace(array))
+    end
+
+    def set_option(opt, eq)
+      if eq
+        @args[0] = opt
+      else
+        @args.unshift(opt)
+      end
+      self
+    end
+
+    #
+    # Returns error reason. Override this for I18N.
+    #
+    def reason
+      @reason || self.class::Reason
+    end
+
+    def inspect
+      "#<#{self.class}: #{args.join(' ')}>"
+    end
+
+    #
+    # Default stringizing method to emit standard error message.
+    #
+    def message
+      "#{reason}: #{args.join(' ')}#{additional[@arg0] if additional}"
+    end
+
+    alias to_s message
+  end
+
+  #
+  # Raises when ambiguously completable string is encountered.
+  #
+  class AmbiguousOption < ParseError
+    const_set(:Reason, 'ambiguous option')
+  end
+
+  #
+  # Raises when there is an argument for a switch which takes no argument.
+  #
+  class NeedlessArgument < ParseError
+    const_set(:Reason, 'needless argument')
+  end
+
+  #
+  # Raises when a switch with mandatory argument has no argument.
+  #
+  class MissingArgument < ParseError
+    const_set(:Reason, 'missing argument')
+  end
+
+  #
+  # Raises when switch is undefined.
+  #
+  class InvalidOption < ParseError
+    const_set(:Reason, 'invalid option')
+  end
+
+  #
+  # Raises when the given argument does not match required format.
+  #
+  class InvalidArgument < ParseError
+    const_set(:Reason, 'invalid argument')
+  end
+
+  #
+  # Raises when the given argument word can't be completed uniquely.
+  #
+  class AmbiguousArgument < InvalidArgument
+    const_set(:Reason, 'ambiguous argument')
+  end
+
+  #
+  # Miscellaneous
+  #
+
+  #
+  # Extends command line arguments array (ARGV) to parse itself.
+  #
+  module Arguable
+    #
+    # Sets OptionParser object, when +opt+ is +false+ or +nil+, methods
+    # OptionParser::Arguable#options and OptionParser::Arguable#options= are
+    # undefined. Thus, there is no ways to access the OptionParser object
+    # via the receiver object.
+    #
+    def options=(opt)
+      unless @optparse = opt
+        class << self
+          undef_method(:options)
+          undef_method(:options=)
+        end
+      end
+    end
+
+    #
+    # Actual OptionParser object, automatically created if nonexistent.
+    #
+    # If called with a block, yields the OptionParser object and returns the
+    # result of the block. If an OptionParser::ParseError exception occurs
+    # in the block, it is rescued, a error message printed to STDERR and
+    # +nil+ returned.
+    #
+    def options
+      @optparse ||= OptionParser.new
+      @optparse.default_argv = self
+      block_given? || (return @optparse)
+      begin
+        yield @optparse
+      rescue ParseError
+        @optparse.warn $!
+        nil
+      end
+    end
+
+    #
+    # Parses +self+ destructively in order and returns +self+ containing the
+    # rest arguments left unparsed.
+    #
+    def order!(&blk)
+      options.order!(self, &blk)
+    end
+
+    #
+    # Parses +self+ destructively in permutation mode and returns +self+
+    # containing the rest arguments left unparsed.
+    #
+    def permute!
+      options.permute!(self)
+    end
+
+    #
+    # Parses +self+ destructively and returns +self+ containing the
+    # rest arguments left unparsed.
+    #
+    def parse!
+      options.parse!(self)
+    end
+
+    #
+    # Substitution of getopts is possible as follows. Also see
+    # OptionParser#getopts.
+    #
+    #   def getopts(*args)
+    #     ($OPT = ARGV.getopts(*args)).each do |opt, val|
+    #       eval "$OPT_#{opt.gsub(/[^A-Za-z0-9_]/, '_')} = val"
+    #     end
+    #   rescue OptionParser::ParseError
+    #   end
+    #
+    def getopts(*args)
+      options.getopts(self, *args)
+    end
+
+    #
+    # Initializes instance variable.
+    #
+    def self.extend_object(obj)
+      super
+      obj.instance_eval { @optparse = nil }
+    end
+
+    def initialize(*args)
+      super
+      @optparse = nil
+    end
+  end
+
+  #
+  # Acceptable argument classes. Now contains DecimalInteger, OctalInteger
+  # and DecimalNumeric. See Acceptable argument classes (in source code).
+  #
+  module Acceptables
+    const_set(:DecimalInteger, OptionParser::DecimalInteger)
+    const_set(:OctalInteger, OptionParser::OctalInteger)
+    const_set(:DecimalNumeric, OptionParser::DecimalNumeric)
+  end
+end
+
+# ARGV is arguable by OptionParser
+ARGV.extend(OptionParser::Arguable)
+
+# An alias for OptionParser.
+OptParse = OptionParser # :nodoc:

--- a/stdlib/optparse/ac.rb
+++ b/stdlib/optparse/ac.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: false
+require 'optparse'
+
+class OptionParser::AC < OptionParser
+  private
+
+  def _check_ac_args(name, block)
+    unless /\A\w[-\w]*\z/ =~ name
+      raise ArgumentError, name
+    end
+    unless block
+      raise ArgumentError, 'no block given', ParseError.filter_backtrace(caller)
+    end
+  end
+
+  ARG_CONV = proc { |val| val.nil? ? true : val }
+
+  def _ac_arg_enable(prefix, name, help_string, block)
+    _check_ac_args(name, block)
+
+    sdesc = []
+    ldesc = ["--#{prefix}-#{name}"]
+    desc = [help_string]
+    q = name.downcase
+    ac_block = proc { |val| block.call(ARG_CONV.call(val)) }
+    enable = Switch::PlacedArgument.new(nil, ARG_CONV, sdesc, ldesc, nil, desc, ac_block)
+    disable = Switch::NoArgument.new(nil, proc { false }, sdesc, ldesc, nil, desc, ac_block)
+    top.append(enable, [], ['enable-' + q], disable, ['disable-' + q])
+    enable
+  end
+
+  public
+
+  def ac_arg_enable(name, help_string, &block)
+    _ac_arg_enable('enable', name, help_string, block)
+  end
+
+  def ac_arg_disable(name, help_string, &block)
+    _ac_arg_enable('disable', name, help_string, block)
+  end
+
+  def ac_arg_with(name, help_string, &block)
+    _check_ac_args(name, block)
+
+    sdesc = []
+    ldesc = ["--with-#{name}"]
+    desc = [help_string]
+    q = name.downcase
+    with = Switch::PlacedArgument.new(*search(:atype, String), sdesc, ldesc, nil, desc, block)
+    without = Switch::NoArgument.new(nil, proc {}, sdesc, ldesc, nil, desc, block)
+    top.append(with, [], ['with-' + q], without, ['without-' + q])
+    with
+  end
+end

--- a/stdlib/optparse/date.rb
+++ b/stdlib/optparse/date.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: false
+require 'optparse'
+require 'date'
+
+OptionParser.accept(DateTime) do |s,|
+  DateTime.parse(s) if s
+rescue ArgumentError
+  raise OptionParser::InvalidArgument, s
+end
+OptionParser.accept(Date) do |s,|
+  Date.parse(s) if s
+rescue ArgumentError
+  raise OptionParser::InvalidArgument, s
+end

--- a/stdlib/optparse/kwargs.rb
+++ b/stdlib/optparse/kwargs.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require 'optparse'
+
+class OptionParser
+  # :call-seq:
+  #   define_by_keywords(options, method, **params)
+  #
+  # :include: ../../doc/optparse/creates_option.rdoc
+  #
+  def define_by_keywords(options, meth, **opts)
+    meth.parameters.each do |type, name|
+      case type
+      when :key, :keyreq
+        op, cl = *(type == :key ? %w"[ ]" : ['', ''])
+        define("--#{name}=#{op}#{name.upcase}#{cl}", *opts[name]) do |o|
+          options[name] = o
+        end
+      end
+    end
+    options
+  end
+end

--- a/stdlib/optparse/shellwords.rb
+++ b/stdlib/optparse/shellwords.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: false
+# -*- ruby -*-
+
+require 'shellwords'
+require 'optparse'
+
+OptionParser.accept(Shellwords) { |s,| Shellwords.shellwords(s) }

--- a/stdlib/optparse/time.rb
+++ b/stdlib/optparse/time.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: false
+require 'optparse'
+require 'time'
+
+OptionParser.accept(Time) do |s,|
+  if s
+    (begin
+       Time.httpdate(s)
+     rescue
+       Time.parse(s)
+     end)
+  end
+rescue
+  raise OptionParser::InvalidArgument, s
+end

--- a/stdlib/optparse/uri.rb
+++ b/stdlib/optparse/uri.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: false
+# -*- ruby -*-
+
+require 'optparse'
+require 'uri'
+
+OptionParser.accept(URI) { |s,| URI.parse(s) if s }

--- a/stdlib/optparse/version.rb
+++ b/stdlib/optparse/version.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: false
+# OptionParser internal utility
+
+class << OptionParser
+  def show_version(*pkgs)
+    progname = ARGV.options.program_name
+    result = false
+    show = proc do |klass, cname, version|
+      str = progname.to_s
+      unless (klass == ::Object) && (cname == :VERSION)
+        version = version.join('.') if Array === version
+        str << ": #{klass}" unless klass == Object
+        str << " version #{version}"
+      end
+      %i[Release RELEASE].find do |rel|
+        if klass.const_defined?(rel)
+          str << " (#{klass.const_get(rel)})"
+        end
+      end
+      puts str
+      result = true
+    end
+    if (pkgs.size == 1) && (pkgs[0] == 'all')
+      search_const(::Object, /\AV(?:ERSION|ersion)\z/) do |klass, cname, version|
+        unless (cname[1] == 'e') && klass.const_defined?(:Version)
+          show.call(klass, cname.intern, version)
+        end
+      end
+    else
+      pkgs.each do |pkg|
+        pkg = pkg.split(/::|\//).inject(::Object) { |m, c| m.const_get(c) }
+        v = case
+            when pkg.const_defined?(:Version)
+              pkg.const_get(n = :Version)
+            when pkg.const_defined?(:VERSION)
+              pkg.const_get(n = :VERSION)
+            else
+              n = nil
+              'unknown'
+            end
+        show.call(pkg, n, v)
+      rescue NameError
+      end
+    end
+    result
+  end
+
+  def each_const(path, base = ::Object)
+    path.split(/::|\//).inject(base) do |klass, name|
+      raise NameError, path unless Module === klass
+      klass.constants.grep(/#{name}/i) do |c|
+        klass.const_defined?(c) || next
+        klass.const_get(c)
+      end
+    end
+  end
+
+  def search_const(klass, name)
+    klasses = [klass]
+    while klass = klasses.shift
+      klass.constants.each do |cname|
+        klass.const_defined?(cname) || next
+        const = klass.const_get(cname)
+        yield klass, cname, const if name === cname
+        klasses << const if (Module === const) && (const != ::Object)
+      end
+    end
+  end
+end

--- a/stdlib/shellwords.rb
+++ b/stdlib/shellwords.rb
@@ -86,9 +86,10 @@ module Shellwords
   #   argv = 'here are "two words"'.shellsplit
   #   argv #=> ["here", "are", "two words"]
   def shellsplit(line)
+    line += " " # Somehow this is needed for the JS regexp engine
     words = []
     field = String.new
-    line.scan(/\G\s*(?>([^\s\\\'\"]+)|'([^\']*)'|"((?:[^\"\\]|\\.)*)"|(\\.?)|(\S))(\s|\z)?/m) do |word, sq, dq, esc, garbage, sep|
+    line.scan(/\s*(?:([^\s\\\'\"]+)|'([^\']*)'|"((?:[^\"\\]|\\.)*)"|(\\.?)|(\S))(\r?\n?\Z|\s)?/m) do |(word, sq, dq, esc, garbage, sep)|
       raise ArgumentError, "Unmatched quote: #{line.inspect}" if garbage
       # 2.2.3 Double-Quotes:
       #
@@ -97,7 +98,7 @@ module Shellwords
       #   characters when considered special:
       #
       #   $ ` " \ <newline>
-      field << (word || sq || (dq && dq.gsub(/\\([$`"\\\n])/, '\\1')) || esc.gsub(/\\(.)/, '\\1'))
+      field += (word || sq || (dq && dq.gsub(/\\([$`"\\\n])/, '\\1')) || esc.gsub(/\\(.)/, '\\1'))
       if sep
         words << field
         field = String.new
@@ -155,11 +156,11 @@ module Shellwords
     # Treat multibyte characters as is.  It is the caller's responsibility
     # to encode the string in the right encoding for the shell
     # environment.
-    str.gsub!(/[^A-Za-z0-9_\-.,:+\/@\n]/, '\\\\\\&')
+    str = str.gsub(/[^A-Za-z0-9_\-.,:+\/@\n]/, '\\\\\\&')
 
     # A LF cannot be escaped with a backslash because a backslash + LF
     # combo is regarded as a line continuation and simply ignored.
-    str.gsub!(/\n/, "'\n'")
+    str = str.gsub(/\n/, "'\n'")
 
     str
   end

--- a/stdlib/shellwords.rb
+++ b/stdlib/shellwords.rb
@@ -1,0 +1,239 @@
+# frozen-string-literal: true
+##
+# == Manipulates strings like the UNIX Bourne shell
+#
+# This module manipulates strings according to the word parsing rules
+# of the UNIX Bourne shell.
+#
+# The shellwords() function was originally a port of shellwords.pl,
+# but modified to conform to the Shell & Utilities volume of the IEEE
+# Std 1003.1-2008, 2016 Edition [1].
+#
+# === Usage
+#
+# You can use Shellwords to parse a string into a Bourne shell friendly Array.
+#
+#   require 'shellwords'
+#
+#   argv = Shellwords.split('three blind "mice"')
+#   argv #=> ["three", "blind", "mice"]
+#
+# Once you've required Shellwords, you can use the #split alias
+# String#shellsplit.
+#
+#   argv = "see how they run".shellsplit
+#   argv #=> ["see", "how", "they", "run"]
+#
+# They treat quotes as special characters, so an unmatched quote will
+# cause an ArgumentError.
+#
+#   argv = "they all ran after the farmer's wife".shellsplit
+#        #=> ArgumentError: Unmatched quote: ...
+#
+# Shellwords also provides methods that do the opposite.
+# Shellwords.escape, or its alias, String#shellescape, escapes
+# shell metacharacters in a string for use in a command line.
+#
+#   filename = "special's.txt"
+#
+#   system("cat -- #{filename.shellescape}")
+#   # runs "cat -- special\\'s.txt"
+#
+# Note the '--'.  Without it, cat(1) will treat the following argument
+# as a command line option if it starts with '-'.  It is guaranteed
+# that Shellwords.escape converts a string to a form that a Bourne
+# shell will parse back to the original string, but it is the
+# programmer's responsibility to make sure that passing an arbitrary
+# argument to a command does no harm.
+#
+# Shellwords also comes with a core extension for Array, Array#shelljoin.
+#
+#   dir = "Funny GIFs"
+#   argv = %W[ls -lta -- #{dir}]
+#   system(argv.shelljoin + " | less")
+#   # runs "ls -lta -- Funny\\ GIFs | less"
+#
+# You can use this method to build a complete command line out of an
+# array of arguments.
+#
+# === Authors
+# * Wakou Aoyama
+# * Akinori MUSHA <knu@iDaemons.org>
+#
+# === Contact
+# * Akinori MUSHA <knu@iDaemons.org> (current maintainer)
+#
+# === Resources
+#
+# 1: {IEEE Std 1003.1-2008, 2016 Edition, the Shell & Utilities volume}[http://pubs.opengroup.org/onlinepubs/9699919799/utilities/contents.html]
+
+module Shellwords
+  # Splits a string into an array of tokens in the same way the UNIX
+  # Bourne shell does.
+  #
+  #   argv = Shellwords.split('here are "two words"')
+  #   argv #=> ["here", "are", "two words"]
+  #
+  # Note, however, that this is not a command line parser.  Shell
+  # metacharacters except for the single and double quotes and
+  # backslash are not treated as such.
+  #
+  #   argv = Shellwords.split('ruby my_prog.rb | less')
+  #   argv #=> ["ruby", "my_prog.rb", "|", "less"]
+  #
+  # String#shellsplit is a shortcut for this function.
+  #
+  #   argv = 'here are "two words"'.shellsplit
+  #   argv #=> ["here", "are", "two words"]
+  def shellsplit(line)
+    words = []
+    field = String.new
+    line.scan(/\G\s*(?>([^\s\\\'\"]+)|'([^\']*)'|"((?:[^\"\\]|\\.)*)"|(\\.?)|(\S))(\s|\z)?/m) do |word, sq, dq, esc, garbage, sep|
+      raise ArgumentError, "Unmatched quote: #{line.inspect}" if garbage
+      # 2.2.3 Double-Quotes:
+      #
+      #   The <backslash> shall retain its special meaning as an
+      #   escape character only when followed by one of the following
+      #   characters when considered special:
+      #
+      #   $ ` " \ <newline>
+      field << (word || sq || (dq && dq.gsub(/\\([$`"\\\n])/, '\\1')) || esc.gsub(/\\(.)/, '\\1'))
+      if sep
+        words << field
+        field = String.new
+      end
+    end
+    words
+  end
+
+  alias shellwords shellsplit
+
+  module_function :shellsplit, :shellwords
+
+  class << self
+    alias split shellsplit
+  end
+
+  # Escapes a string so that it can be safely used in a Bourne shell
+  # command line.  +str+ can be a non-string object that responds to
+  # +to_s+.
+  #
+  # Note that a resulted string should be used unquoted and is not
+  # intended for use in double quotes nor in single quotes.
+  #
+  #   argv = Shellwords.escape("It's better to give than to receive")
+  #   argv #=> "It\\'s\\ better\\ to\\ give\\ than\\ to\\ receive"
+  #
+  # String#shellescape is a shorthand for this function.
+  #
+  #   argv = "It's better to give than to receive".shellescape
+  #   argv #=> "It\\'s\\ better\\ to\\ give\\ than\\ to\\ receive"
+  #
+  #   # Search files in lib for method definitions
+  #   pattern = "^[ \t]*def "
+  #   open("| grep -Ern -e #{pattern.shellescape} lib") { |grep|
+  #     grep.each_line { |line|
+  #       file, lineno, matched_line = line.split(':', 3)
+  #       # ...
+  #     }
+  #   }
+  #
+  # It is the caller's responsibility to encode the string in the right
+  # encoding for the shell environment where this string is used.
+  #
+  # Multibyte characters are treated as multibyte characters, not as bytes.
+  #
+  # Returns an empty quoted String if +str+ has a length of zero.
+  def shellescape(str)
+    str = str.to_s
+
+    # An empty argument will be skipped, so return empty quotes.
+    return "''".dup if str.empty?
+
+    str = str.dup
+
+    # Treat multibyte characters as is.  It is the caller's responsibility
+    # to encode the string in the right encoding for the shell
+    # environment.
+    str.gsub!(/[^A-Za-z0-9_\-.,:+\/@\n]/, '\\\\\\&')
+
+    # A LF cannot be escaped with a backslash because a backslash + LF
+    # combo is regarded as a line continuation and simply ignored.
+    str.gsub!(/\n/, "'\n'")
+
+    str
+  end
+
+  module_function :shellescape
+
+  class << self
+    alias escape shellescape
+  end
+
+  # Builds a command line string from an argument list, +array+.
+  #
+  # All elements are joined into a single string with fields separated by a
+  # space, where each element is escaped for the Bourne shell and stringified
+  # using +to_s+.
+  #
+  #   ary = ["There's", "a", "time", "and", "place", "for", "everything"]
+  #   argv = Shellwords.join(ary)
+  #   argv #=> "There\\'s a time and place for everything"
+  #
+  # Array#shelljoin is a shortcut for this function.
+  #
+  #   ary = ["Don't", "rock", "the", "boat"]
+  #   argv = ary.shelljoin
+  #   argv #=> "Don\\'t rock the boat"
+  #
+  # You can also mix non-string objects in the elements as allowed in Array#join.
+  #
+  #   output = `#{['ps', '-p', $$].shelljoin}`
+  #
+  def shelljoin(array)
+    array.map { |arg| shellescape(arg) }.join(' ')
+  end
+
+  module_function :shelljoin
+
+  class << self
+    alias join shelljoin
+  end
+end
+
+class String
+  # call-seq:
+  #   str.shellsplit => array
+  #
+  # Splits +str+ into an array of tokens in the same way the UNIX
+  # Bourne shell does.
+  #
+  # See Shellwords.shellsplit for details.
+  def shellsplit
+    Shellwords.split(self)
+  end
+
+  # call-seq:
+  #   str.shellescape => string
+  #
+  # Escapes +str+ so that it can be safely used in a Bourne shell
+  # command line.
+  #
+  # See Shellwords.shellescape for details.
+  def shellescape
+    Shellwords.escape(self)
+  end
+end
+
+class Array
+  # call-seq:
+  #   array.shelljoin => string
+  #
+  # Builds a command line string from an argument list +array+ joining
+  # all elements escaped for the Bourne shell and separated by a space.
+  #
+  # See Shellwords.shelljoin for details.
+  def shelljoin
+    Shellwords.join(self)
+  end
+end

--- a/stdlib/shellwords.rb
+++ b/stdlib/shellwords.rb
@@ -86,7 +86,7 @@ module Shellwords
   #   argv = 'here are "two words"'.shellsplit
   #   argv #=> ["here", "are", "two words"]
   def shellsplit(line)
-    line += " " # Somehow this is needed for the JS regexp engine
+    line += ' ' # Somehow this is needed for the JS regexp engine
     words = []
     field = String.new
     line.scan(/\s*(?:([^\s\\\'\"]+)|'([^\']*)'|"((?:[^\"\\]|\\.)*)"|(\\.?)|(\S))(\r?\n?\Z|\s)?/m) do |(word, sq, dq, esc, garbage, sep)|


### PR DESCRIPTION
This works:

```ruby
[user@localhost opal]# bin/opal -s readline -rnodejs -rcorelib/string/unpack -Ilib -popal/cli_runners/compiler exe/opal -- -Oce 'p 5'
warning: Skipping the 'o' Regexp flag as it's not widely supported by JavaScript vendors. -- ./optparse.rb:
warning: Skipping the 'o' Regexp flag as it's not widely supported by JavaScript vendors. -- ./optparse.rb:
warning: Skipping the 'o' Regexp flag as it's not widely supported by JavaScript vendors. -- ./optparse.rb:
warning: Skipping the 'o' Regexp flag as it's not widely supported by JavaScript vendors. -- ./optparse.rb:
warning: Skipping the 'o' Regexp flag as it's not widely supported by JavaScript vendors. -- ./optparse.rb:
warning: Skipping the 'o' Regexp flag as it's not widely supported by JavaScript vendors. -- ./optparse.rb:
Object freezing is not supported by Opal
Opal.queue(function(Opal) {/* Generated by Opal 1.3.0.alpha1 */
  var self = Opal.top, $nesting = [], nil = Opal.nil, $$$ = Opal.$$$, $$ = Opal.$$;

  Opal.add_stubs(['$p']);
  return self.$p(5)
});

Opal.queue(function(Opal) {/* Generated by Opal 1.3.0.alpha1 */
  var self = Opal.top, $nesting = [], nil = Opal.nil, $$$ = Opal.$$$, $$ = Opal.$$;

  Opal.add_stubs(['$exit']);
  return $$($nesting, 'Kernel').$exit()
});

//# sourceMappingURL=data:application/json;(...)
[user@localhost opal]# 
```

Solved problems in this branch:
- [x] optparse doesn't recognize long option names
- [x] require "opal" doesn't work (-O is a must)
  - this is related to a problem with `__FILE__`, can be hacked around with -Iopal -Istdlib -Ilib
- [x] run tests in opal-in-opal
  - [x] pass: bundle exec rake minitest_cruby_opalopal_nodejs
  - [ ] pass: bundle exec rake minitest_node_opalopal_nodejs
  - [ ] run: bundle exec rake mspec_opal_opalopal_nodejs
  - [ ] run: bundle exec rake mspec_ruby_opalopal_nodejs
- [x] other runners than compiler (backport some work from #2313)
- [ ] source map support