### PR TITLE
Improve tidy_up_cache performance

### DIFF
--- a/lib/opal/cache/file_cache.rb
+++ b/lib/opal/cache/file_cache.rb
@@ -42,8 +42,9 @@ module Opal
       # were used least recently.
       private def tidy_up_cache
         entries = Dir[@dir + '/*.rbm.gz']
+        entries_stats = entries.map { |entry| [entry, File.stat(entry)] }
 
-        size_sum = entries.map { |i| File.size(i) }.sum
+        size_sum = entries_stats.map { |_entry, stat| stat.size }.sum
         return unless size_sum > @max_size
 
         # First, we try to get the oldest files first.
@@ -51,13 +52,13 @@ module Opal
         # recently used files first. Filesystems with relatime or noatime
         # will get this wrong, but it doesn't matter that much, because
         # the previous sort got things "maybe right".
-        entries = entries.sort_by { |i| [File.mtime(i), File.atime(i)] }
+        entries_stats = entries_stats.sort_by { |_entry, stat| [stat.mtime, stat.atime] }
 
-        entries.each do |i|
-          size_sum -= File.size(i)
-          File.unlink(i)
+        entries_stats.each do |entry, stat|
+          size_sum -= stat.size
+          File.unlink(entry)
 
-          # We don't need to work this out anymore - we reached out goal.
+          # We don't need to work this out anymore - we reached our goal.
           break unless size_sum > @max_size
         end
       rescue Errno::ENOENT


### PR DESCRIPTION
This patch is reducing file system calls.
tidy_up_cache run with ~60mb:
before: ~4.1s
after: ~1.8s
(measured on Windows)