### PR TITLE
Implement Proc#binding correctly

### DIFF
--- a/lib/opal/nodes/call.rb
+++ b/lib/opal/nodes/call.rb
@@ -385,7 +385,7 @@ module Opal
         push ')' if push_nesting
       end
 
-      # This can be refactored in terms of binding, but it would 'corelib/binding'
+      # This can be refactored in terms of binding, but it would need 'corelib/binding'
       # to be required in existing code.
       add_special :eval do |compile_default|
         next compile_default.call if arglist.children.length != 1 || ![s(:self), nil].include?(recvr)
@@ -399,7 +399,9 @@ module Opal
         push "self.$eval(#{temp}))"
       end
 
-      add_special :binding do
+      add_special :binding do |compile_default|
+        next compile_default.call unless recvr.nil?
+
         push "Opal.Binding.$new("
         push "  function($code, $value) {"
         push "    if (typeof $value === 'undefined') {"

--- a/opal/corelib/binding.rb
+++ b/opal/corelib/binding.rb
@@ -6,7 +6,11 @@ class Binding
   end
 
   def js_eval(*args)
-    @jseval.call(*args)
+    if @jseval
+      @jseval.call(*args)
+    else
+      raise 'Evaluation on a Proc#binding is not supported'
+    end
   end
 
   def local_variable_get(symbol)

--- a/opal/corelib/proc.rb
+++ b/opal/corelib/proc.rb
@@ -95,7 +95,10 @@ class Proc < `Function`
 
   def binding
     `if (self.$$is_curried) { #{raise ArgumentError, "Can't create Binding"} }`
-    nil
+
+    if defined? Binding
+      Binding.new(nil, [], `self.$$s`, source_location)
+    end
   end
 
   def parameters

--- a/spec/filters/bugs/kernel.rb
+++ b/spec/filters/bugs/kernel.rb
@@ -70,7 +70,9 @@ opal_filter "Kernel" do
   fails "Kernel#eval activates refinements from the binding" # NoMethodError: undefined method `refine' for #<Module:0x1ad8>
   fails "Kernel#eval activates refinements from the eval scope" # NoMethodError: undefined method `refine' for #<Module:0x20d4>
   fails "Kernel#eval allows a binding to be captured inside an eval"
+  fails "Kernel#eval allows creating a new class in a binding" # RuntimeError: Evaluation on a Proc#binding is not supported
   fails "Kernel#eval can be aliased"
+  fails "Kernel#eval does not make Proc locals visible to evaluated code" # Expected NameError but got: RuntimeError (Evaluation on a Proc#binding is not supported)
   fails "Kernel#eval does not share locals across eval scopes"
   fails "Kernel#eval doesn't accept a Proc object as a binding"
   fails "Kernel#eval evaluates string with given filename and negative linenumber" # NameError: uninitialized constant TOPLEVEL_BINDING


### PR DESCRIPTION
The mistake in the previous implementation was that `Proc#binding` was equivalent to `Kernel#binding`. `Proc#binding` returns a binding where a Proc was defined, which is how Ruby works internally to handle scopes. In our case implementing this would cause a performance problem (each block would need to be amended with its binding - which if not performance killing itself, it also involves JS `eval` which isn't what JITs like). So, this is a limited implementation that at least allows you to access block's self via either `my_proc.binding.receiver` or `my_proc.binding.eval('self')` (the second is apparently compatible with earlier Rubies, I saw this code in the wild; we make a shortpath for `'self'` and don't need a parser in this particular case).

This fixes #2340