### PR TITLE
Do not modify `$~` when calling `String#scan` from internal methods

### DIFF
--- a/opal/corelib/regexp.rb
+++ b/opal/corelib/regexp.rb
@@ -245,16 +245,16 @@ class Regexp < `RegExp`
   end
 
   def names
-    source.scan(/\(?<(\w+)>/).map(&:first).uniq
+    source.scan(/\(?<(\w+)>/, no_matchdata: true).map(&:first).uniq
   end
 
   def named_captures
-    source.scan(/\(?<(\w+)>/)        # Scan for capture groups
-          .map(&:first)              # Get the first regexp match (\w+)
-          .each_with_index           # Add index to an iterator
-          .group_by(&:first)         # Group by the capture group names
-          .transform_values do |i|   # Convert hash values
-            i.map { |j| j.last + 1 } # Drop the capture group names; increase indexes by 1
+    source.scan(/\(?<(\w+)>/, no_matchdata: true) # Scan for capture groups
+          .map(&:first)                           # Get the first regexp match (\w+)
+          .each_with_index                        # Add index to an iterator
+          .group_by(&:first)                      # Group by the capture group names
+          .transform_values do |i|                # Convert hash values
+            i.map { |j| j.last + 1 }              # Drop the capture group names; increase indexes by 1
           end
   end
 

--- a/opal/corelib/string.rb
+++ b/opal/corelib/string.rb
@@ -992,7 +992,7 @@ class String < `String`
     `self.replace(/[\s\u0000]*$/, '')`
   end
 
-  def scan(pattern, &block)
+  def scan(pattern, no_matchdata: false, &block)
     %x{
       var result = [],
           match_data = nil,
@@ -1017,7 +1017,7 @@ class String < `String`
         }
       }
 
-      #{$~ = `match_data`}
+      if (!no_matchdata) #{$~ = `match_data`};
 
       return (block !== nil ? self : result);
     }

--- a/spec/opal/core/string/gsub_spec.rb
+++ b/spec/opal/core/string/gsub_spec.rb
@@ -23,6 +23,14 @@ describe 'String' do
       expect("test".gsub(/$/, '2')).to eq "test2"
       expect("test".gsub(/\b/, '2')).to eq "2test2"
     end
+
+    it "doesn't override $~ when it's inspected" do
+      'a:b'.gsub(/([a-z]):([a-z])/) do
+        $~.inspect
+        target, content = $1, $2
+        expect([target, content]).to eq(['a', 'b'])
+      end
+    end
   end
 
   describe '#sub' do


### PR DESCRIPTION
Allow `String#scan` to be called with a private kwarg `no_matchdata`,
which ensures that `$~` isn't set. Then, ensure that matchdata methods
on searching for named captures use this.

This fixes #2352