### PR TITLE
Stop interpreting falsey values as a missing constant in `Module#const_get`

### DIFF
--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -244,7 +244,7 @@
         throw e;
       }
       cref.$$autoload[name].required = true;
-      if (cref.$$const[name]) {
+      if (cref.$$const[name] != null) {
         cref.$$autoload[name].success = true;
         return cref.$$const[name];
       }
@@ -268,7 +268,7 @@
   // Get the constant in the scope of the current cref
   function const_get_name(cref, name) {
     if (cref) {
-      if (cref.$$const[name]) { return cref.$$const[name]; }
+      if (cref.$$const[name] != null) { return cref.$$const[name]; }
       if (cref.$$autoload && cref.$$autoload[name]) {
         return handle_autoload(cref, name);
       }

--- a/spec/opal/core/language_spec.rb
+++ b/spec/opal/core/language_spec.rb
@@ -27,3 +27,17 @@ describe "Bridging" do
     `typeof(String.call)`.should == "function"
   end
 end
+
+describe "Constants" do
+  it "doesn't raise error when a JS falsey constant is referenced" do
+    z = Class.new {
+      C1 = 0
+      C2 = nil
+      C3 = false
+      C4 = ''
+      C5 = C3
+    }
+
+    [z::C1, z::C2, z::C3, z::C4, z::C5].should == [0, nil, false, '', false]
+  end
+end


### PR DESCRIPTION
This commit fixes a regression introduced by 9d3a43d. In runtime,
const_get_name had a check like: `if(cref.$$const[name])` which
broke if the const was `0`.

This fixes #2351