### PR TITLE
resolves #2348 preserve UNC path prefix on File#join (Node.js impl)

### DIFF
--- a/stdlib/nodejs/file.rb
+++ b/stdlib/nodejs/file.rb
@@ -176,7 +176,10 @@ class File < IO
   end
 
   def self.join(*paths)
-    `__path__.posix.join.apply(__path__, #{paths})`
+    # by itself, `path.posix.join` normalizes leading // to /.
+    # restore the leading / on UNC paths (i.e., paths starting with //).
+    prefix = paths.first&.start_with?('//') ? '/' : ''
+    `#{prefix} + __path__.posix.join.apply(__path__, #{paths})`
   end
 
   def self.directory?(path)

--- a/test/nodejs/test_file.rb
+++ b/test/nodejs/test_file.rb
@@ -202,5 +202,16 @@ class TestNodejsFile < Test::Unit::TestCase
 
   def test_join
     assert_equal('usr/bin', File.join('usr', 'bin'))
+    assert_equal('//a/b', File.join('//a', 'b'))
+  end
+
+  def test_join_supports_any_number_of_arguments
+    assert_equal("a/b/c/d", File.join("a", "b", "c", "d"))
+  end
+
+  def test_join_handles_leading_parts_edge_cases
+    assert_equal("/bin", File.join("/bin"))
+    assert_equal("/bin", File.join("/", "bin"))
+    assert_equal("/bin", File.join("/", "/bin"))
   end
 end


### PR DESCRIPTION
resolves #2348 