### PR TITLE
DCE for methods

### DIFF
--- a/lib/opal/builder.rb
+++ b/lib/opal/builder.rb
@@ -95,6 +95,21 @@ module Opal
 
     def build_str(source, rel_path, options = {})
       return if source.nil?
+
+      if options[:get_method_defs] != true && ENV['DCE']
+
+        options[:allowed_method_defs] = []
+
+        dup.build_str(source, rel_path, options.merge(get_method_defs: true)).processed.each do |asset|
+          # p [asset.class, asset.filename] => asset.method_calls.to_a.sort
+          options[:allowed_method_defs].push(*asset.method_calls)
+        end
+        options[:allowed_method_defs].uniq!
+        # p :allowed_method_defs
+        # puts options[:allowed_method_defs].to_a.sort
+        # exit 1
+      end
+
       abs_path = expand_path(rel_path)
       rel_path = expand_ext(rel_path)
       asset = processor_for(source, rel_path, abs_path, false, options)

--- a/lib/opal/builder_processors.rb
+++ b/lib/opal/builder_processors.rb
@@ -14,7 +14,7 @@ module Opal
         @required_trees = []
         @autoloads = []
       end
-      attr_reader :source, :filename, :options, :requires, :required_trees, :autoloads
+      attr_reader :source, :filename, :options, :requires, :required_trees, :autoloads, :method_calls
 
       def to_s
         source.to_s
@@ -106,6 +106,10 @@ module Opal
 
       def autoloads
         compiled.autoloads
+      end
+
+      def method_calls
+        compiled.method_calls
       end
 
       # Also catch a files with missing extensions and nil.

--- a/lib/opal/cli.rb
+++ b/lib/opal/cli.rb
@@ -125,7 +125,7 @@ module Opal
       builder.build_str '$DEBUG = true', '(flags)' if debug
 
       # --eval / stdin / file
-      evals_or_file { |source, filename| builder.build_str(source, filename) }
+      evals_or_file { |source, filename| p source; builder.build_str(source, filename) }
 
       # --no-exit
       builder.build_str '::Kernel.exit', '(exit)' unless no_exit

--- a/lib/opal/compiler.rb
+++ b/lib/opal/compiler.rb
@@ -196,6 +196,8 @@ module Opal
     # # await: *await*, sleep, gets
     compiler_option :await, default: false, as: :async_await, magic_comment: true
 
+    compiler_option :allowed_method_defs, default: nil
+
     # @return [String] The compiled ruby code
     attr_reader :result
 

--- a/lib/opal/nodes/def.rb
+++ b/lib/opal/nodes/def.rb
@@ -10,6 +10,13 @@ module Opal
       children :mid, :inline_args, :stmts
 
       def compile
+        if compiler.allowed_method_defs && !compiler.allowed_method_defs.include?(mid.to_sym)
+          # push "(/* DCE: #{mid} */ Opal.add_stub(", mid.to_s, '), ', process(@sexp.updated(:str, [mid.to_s])), ')'
+          push "/* DCE: #{mid} */ "
+          push process(@sexp.updated(:alias, [s(:sym, mid.to_s), s(:sym, 'raise')]))
+          return
+        end
+
         inline_params = nil
         scope_name = nil
 

--- a/opal/corelib/array.rb
+++ b/opal/corelib/array.rb
@@ -1433,10 +1433,6 @@ class ::Array < `Array`
     `self.length`
   end
 
-  alias map collect
-
-  alias map! collect!
-
   def max(n = undefined, &block)
     each.max(n, &block)
   end
@@ -1634,8 +1630,6 @@ class ::Array < `Array`
 
     self
   end
-
-  alias append push
 
   def rassoc(object)
     %x{
@@ -1938,9 +1932,6 @@ class ::Array < `Array`
     }
   end
 
-  alias filter select
-  alias filter! select!
-
   def shift(count = undefined)
     if `count === undefined`
       return if `self.length === 0`
@@ -1957,8 +1948,6 @@ class ::Array < `Array`
 
     `self.splice(0, count)`
   end
-
-  alias size length
 
   def shuffle(rng = undefined)
     dup.to_a.shuffle!(rng)
@@ -2004,8 +1993,6 @@ class ::Array < `Array`
       return self;
     }
   end
-
-  alias slice []
 
   def slice!(index, length = undefined)
     result = nil
@@ -2209,8 +2196,6 @@ class ::Array < `Array`
     }
   end
 
-  alias to_s inspect
-
   def transpose
     return [] if empty?
 
@@ -2312,8 +2297,6 @@ class ::Array < `Array`
     }
   end
 
-  alias prepend unshift
-
   def values_at(*args)
     out = []
 
@@ -2410,10 +2393,20 @@ class ::Array < `Array`
     super.reject { |ivar| `/^@\d+$/.test(#{ivar})` || ivar == '@length' }
   end
 
-  ::Opal.pristine singleton_class, :allocate
-  ::Opal.pristine self, :copy_instance_variables, :initialize_dup
-
   def pack(*args)
     ::Kernel.raise "To use Array#pack, you must first require 'corelib/array/pack'."
   end
+
+  alias append push
+  alias filter select
+  alias filter! select!
+  alias map collect
+  alias map! collect!
+  alias prepend unshift
+  alias size length
+  alias slice []
+  alias to_s inspect
+
+  ::Opal.pristine singleton_class, :allocate
+  ::Opal.pristine self, :copy_instance_variables, :initialize_dup
 end

--- a/opal/corelib/array.rb
+++ b/opal/corelib/array.rb
@@ -905,6 +905,8 @@ class ::Array < `Array`
 
   def drop(number)
     %x{
+      number = $coerce_to(number, #{::Integer}, 'to_int');
+
       if (number < 0) {
         #{::Kernel.raise ::ArgumentError}
       }

--- a/opal/corelib/boolean.rb
+++ b/opal/corelib/boolean.rb
@@ -39,8 +39,6 @@ class ::Boolean < `Boolean`
     `self.valueOf() ? 2 : 0`
   end
 
-  alias object_id __id__
-
   def !
     `self != true`
   end
@@ -61,9 +59,6 @@ class ::Boolean < `Boolean`
     `(self == true) === other.valueOf()`
   end
 
-  alias equal? ==
-  alias eql? ==
-
   def singleton_class
     `self.$$meta`
   end
@@ -71,8 +66,6 @@ class ::Boolean < `Boolean`
   def to_s
     `(self == true) ? 'true' : 'false'`
   end
-
-  alias inspect to_s
 
   def dup
     self
@@ -104,6 +97,11 @@ class ::Boolean < `Boolean`
     `var body = self.$$class.$$prototype['$' + #{method}]`
     `typeof body !== 'undefined' && !body.$$stub`
   end
+
+  alias eql? ==
+  alias equal? ==
+  alias inspect to_s
+  alias object_id __id__
 end
 
 class ::TrueClass < ::Boolean; end

--- a/opal/corelib/complex.rb
+++ b/opal/corelib/complex.rb
@@ -10,10 +10,6 @@ class ::Complex < ::Numeric
     new(real, imag)
   end
 
-  class << self
-    alias rectangular rect
-  end
-
   def self.polar(r, theta = 0)
     unless ::Numeric === r && r.real? && ::Numeric === theta && theta.real?
       ::Kernel.raise ::TypeError, 'not a real'
@@ -156,19 +152,13 @@ class ::Complex < ::Numeric
     ::Math.atan2(@imag, @real)
   end
 
-  alias arg angle
-
   def conj
     ::Kernel.Complex(@real, -@imag)
   end
 
-  alias conjugate conj
-
   def denominator
     @real.denominator.lcm(@imag.denominator)
   end
-
-  alias divide /
 
   def eql?(other)
     Complex === other && @real.class == @imag.class && self == other
@@ -190,8 +180,6 @@ class ::Complex < ::Numeric
     "Complex:#{@real}:#{@imag}"
   end
 
-  alias imaginary imag
-
   def infinite?
     @real.infinite? || @imag.infinite?
   end
@@ -199,10 +187,6 @@ class ::Complex < ::Numeric
   def inspect
     "(#{self})"
   end
-
-  alias magnitude abs
-
-  undef negative?
 
   def numerator
     d = denominator
@@ -212,15 +196,9 @@ class ::Complex < ::Numeric
     )
   end
 
-  alias phase arg
-
   def polar
     [abs, arg]
   end
-
-  undef positive?
-
-  alias quo /
 
   def rationalize(eps = undefined)
     %x{
@@ -243,10 +221,6 @@ class ::Complex < ::Numeric
   def rect
     [@real, @imag]
   end
-
-  alias rectangular rect
-
-  undef step
 
   def to_f
     unless @imag == 0
@@ -370,4 +344,21 @@ class ::Complex < ::Numeric
       }
     }
   end
+
+  class << self
+    alias rectangular rect
+  end
+
+  alias arg angle
+  alias conjugate conj
+  alias divide /
+  alias imaginary imag
+  alias magnitude abs
+  alias phase arg
+  alias quo /
+  alias rectangular rect
+
+  undef negative?
+  undef positive?
+  undef step
 end

--- a/opal/corelib/dir.rb
+++ b/opal/corelib/dir.rb
@@ -11,10 +11,10 @@ class ::Dir
     def pwd
       `Opal.current_dir || '.'`
     end
-    alias getwd pwd
-
     def home
       ::ENV['HOME'] || '.'
     end
+
+    alias getwd pwd
   end
 end

--- a/opal/corelib/enumerable.rb
+++ b/opal/corelib/enumerable.rb
@@ -437,8 +437,6 @@ module ::Enumerable
     map(&block).select(&:itself)
   end
 
-  alias find detect
-
   def find_all(&block)
     return enum_for(:find_all) { enumerator_size } unless block_given?
 
@@ -459,8 +457,6 @@ module ::Enumerable
       return result;
     }
   end
-
-  alias filter find_all
 
   def find_index(object = undefined, &block)
     return enum_for :find_index if `object === undefined && block === nil`
@@ -524,8 +520,6 @@ module ::Enumerable
       result
     end
   end
-
-  alias flat_map collect_concat
 
   def grep(pattern, &block)
     result = []
@@ -656,8 +650,6 @@ module ::Enumerable
     respond_to?(:size) ? size : nil
   end
 
-  alias map collect
-
   def max(n = undefined, &block)
     %x{
       if (n === undefined || n === nil) {
@@ -733,8 +725,6 @@ module ::Enumerable
       return result === undefined ? nil : result;
     }
   end
-
-  alias member? include?
 
   def min(n = nil, &block)
     unless n.nil?
@@ -967,8 +957,6 @@ module ::Enumerable
     }
   end
 
-  alias reduce inject
-
   def reject(&block)
     return enum_for(:reject) { enumerator_size } unless block_given?
 
@@ -1009,8 +997,6 @@ module ::Enumerable
       return result;
     }
   end
-
-  alias select find_all
 
   def slice_before(pattern = undefined, &block)
     if `pattern === undefined && block === nil`
@@ -1233,8 +1219,6 @@ module ::Enumerable
     group_by(&:itself).transform_values(&:count)
   end
 
-  alias to_a entries
-
   def to_h(*args, &block)
     return map(&block).to_h(*args) if block_given?
 
@@ -1265,4 +1249,13 @@ module ::Enumerable
   def zip(*others, &block)
     to_a.zip(*others)
   end
+
+  alias find detect
+  alias filter find_all
+  alias flat_map collect_concat
+  alias map collect
+  alias member? include?
+  alias reduce inject
+  alias select find_all
+  alias to_a entries
 end

--- a/opal/corelib/enumerator.rb
+++ b/opal/corelib/enumerator.rb
@@ -77,8 +77,6 @@ class ::Enumerator
     }
   end
 
-  alias with_object each_with_object
-
   def each_with_index(&block)
     return enum_for(:each_with_index) { size } unless block_given?
 
@@ -95,6 +93,8 @@ class ::Enumerator
 
     result + '>'
   end
+
+  alias with_object each_with_object
 
   class Generator
     include ::Enumerable
@@ -174,8 +174,6 @@ class ::Enumerator
         nil
       end
     end
-
-    alias force to_a
 
     def lazy
       self
@@ -272,8 +270,6 @@ class ::Enumerator
       self.class.for(self, method, *args, &block)
     end
 
-    alias filter find_all
-
     def find_all(&block)
       unless block
         ::Kernel.raise ::ArgumentError, 'tried to call lazy select without a block'
@@ -290,7 +286,29 @@ class ::Enumerator
       end
     end
 
-    alias flat_map collect_concat
+    def detect(ifnone = undefined, &block)
+      return enum_for :detect, ifnone unless block_given?
+
+      each do |*args|
+        value = ::Opal.destructure(args)
+        p value: value
+        if yield(value)
+          return value
+        end
+      end
+
+      %x{
+        if (ifnone !== undefined) {
+          if (typeof(ifnone) === 'function') {
+            return ifnone();
+          } else {
+            return ifnone;
+          }
+        }
+      }
+
+      nil
+    end
 
     def grep(pattern, &block)
       if block
@@ -319,10 +337,6 @@ class ::Enumerator
         end
       end
     end
-
-    alias map collect
-
-    alias select find_all
 
     def reject(&block)
       unless block
@@ -384,11 +398,16 @@ class ::Enumerator
       end
     end
 
-    alias to_enum enum_for
-
     def inspect
       "#<#{self.class}: #{@enumerator.inspect}>"
     end
+
+    alias force to_a
+    alias flat_map collect_concat
+    alias filter find_all
+    alias map collect
+    alias select find_all
+    alias to_enum enum_for
   end
 
   class self::ArithmeticSequence < self

--- a/opal/corelib/file.rb
+++ b/opal/corelib/file.rb
@@ -74,7 +74,6 @@ class ::File < ::IO
       end
       absolute_path(path, basedir)
     end
-    alias realpath expand_path
 
     %x{
       // Coerce a given path to a path string using #to_path and #to_str
@@ -156,7 +155,6 @@ class ::File < ::IO
     def exist?(path)
       `Opal.modules[#{path}] != null`
     end
-    alias exists? exist?
 
     def directory?(path)
       files = []
@@ -206,5 +204,8 @@ class ::File < ::IO
     def split(path)
       path.split(SEPARATOR)
     end
+
+    alias realpath expand_path
+    alias exists? exist?
   end
 end

--- a/opal/corelib/hash.rb
+++ b/opal/corelib/hash.rb
@@ -403,8 +403,6 @@ class ::Hash
     }
   end
 
-  alias dup clone
-
   def dig(key, *keys)
     item = self[key]
 
@@ -456,8 +454,6 @@ class ::Hash
     }
   end
 
-  alias each_pair each
-
   def each_value(&block)
     return enum_for(:each_value) { size } unless block
 
@@ -475,8 +471,6 @@ class ::Hash
   def empty?
     `self.$$keys.length === 0`
   end
-
-  alias eql? ==
 
   def except(*keys)
     dup.except!(*keys)
@@ -609,8 +603,6 @@ class ::Hash
     }
   end
 
-  alias include? has_key?
-
   def index(object)
     %x{
       for (var i = 0, keys = self.$$keys, length = keys.length, key, value; i < length; i++) {
@@ -651,8 +643,6 @@ class ::Hash
       return result;
     }
   end
-
-  alias indices indexes
 
   `var inspect_ids`
 
@@ -745,10 +735,6 @@ class ::Hash
     }
   end
 
-  alias key index
-
-  alias key? has_key?
-
   def keys
     %x{
       var result = [];
@@ -770,8 +756,6 @@ class ::Hash
   def length
     `self.$$keys.length`
   end
-
-  alias member? has_key?
 
   def merge(*others, &block)
     dup.merge!(*others, &block)
@@ -997,9 +981,6 @@ class ::Hash
     }
   end
 
-  alias filter select
-  alias filter! select!
-
   def shift
     %x{
       var keys = self.$$keys,
@@ -1017,8 +998,6 @@ class ::Hash
     }
   end
 
-  alias size length
-
   def slice(*keys)
     %x{
       var result = $hash();
@@ -1034,8 +1013,6 @@ class ::Hash
       return result;
     }
   end
-
-  alias store []=
 
   def to_a
     %x{
@@ -1090,8 +1067,6 @@ class ::Hash
       self[key]
     end
   end
-
-  alias to_s inspect
 
   def transform_keys(&block)
     return enum_for(:transform_keys) { size } unless block
@@ -1193,12 +1168,6 @@ class ::Hash
     }
   end
 
-  alias update merge!
-
-  alias value? has_value?
-
-  alias values_at indexes
-
   def values
     %x{
       var result = [];
@@ -1216,4 +1185,21 @@ class ::Hash
       return result;
     }
   end
+
+  alias dup clone
+  alias each_pair each
+  alias eql? ==
+  alias filter select
+  alias filter! select!
+  alias include? has_key?
+  alias indices indexes
+  alias key index
+  alias key? has_key?
+  alias member? has_key?
+  alias size length
+  alias store []=
+  alias to_s inspect
+  alias update merge!
+  alias value? has_value?
+  alias values_at indexes
 end

--- a/opal/corelib/io.rb
+++ b/opal/corelib/io.rb
@@ -8,6 +8,10 @@ class ::IO
   self::READABLE = 1
   self::WRITABLE = 4
 
+  attr_reader :eof
+
+  attr_accessor :read_proc,  :sync, :tty, :write_proc
+
   def initialize(fd, flags = 'r')
     @fd = fd
     @flags = flags
@@ -28,18 +32,10 @@ class ::IO
     `self.tty == true`
   end
 
-  attr_accessor :write_proc
-  attr_accessor :read_proc
-
   def write(string)
     `self.write_proc(string)`
     string.size
   end
-
-  attr_accessor :sync, :tty
-
-  attr_reader :eof
-  alias eof? eof
 
   def flush
     # noop
@@ -216,8 +212,6 @@ class ::IO
     self
   end
 
-  alias each_line each
-
   def each_byte(&block)
     return enum_for :each_byte unless block_given?
 
@@ -285,6 +279,9 @@ class ::IO
       ::Kernel.raise ::IOError, 'not opened for reading'
     end
   end
+
+  alias each_line each
+  alias eof? eof
 end
 
 ::STDIN  = $stdin  = ::IO.new(0, 'r')

--- a/opal/corelib/kernel.rb
+++ b/opal/corelib/kernel.rb
@@ -192,8 +192,6 @@ module ::Kernel
     ::Enumerator.for(self, method, *args, &block)
   end
 
-  alias to_enum enum_for
-
   def equal?(other)
     `self === other`
   end
@@ -467,8 +465,6 @@ module ::Kernel
     self
   end
 
-  alias kind_of? is_a?
-
   def lambda(&block)
     `Opal.lambda(block)`
   end
@@ -495,8 +491,6 @@ module ::Kernel
   def nil?
     false
   end
-
-  alias object_id __id__
 
   def printf(*args)
     if args.any?
@@ -581,8 +575,6 @@ module ::Kernel
       throw exception;
     }
   end
-
-  alias fail raise
 
   def rand(max = undefined)
     %x{
@@ -669,9 +661,6 @@ module ::Kernel
     }
   end
 
-  alias send        __send__
-  alias public_send __send__
-
   def singleton_class
     `Opal.get_singleton_class(self)`
   end
@@ -741,7 +730,13 @@ module ::Kernel
     yield self
   end
 
+  alias fail raise
+  alias kind_of? is_a?
+  alias object_id __id__
+  alias public_send __send__
+  alias send __send__
   alias then yield_self
+  alias to_enum enum_for
 
   ::Opal.pristine(self, :method_missing)
 end

--- a/opal/corelib/method.rb
+++ b/opal/corelib/method.rb
@@ -36,9 +36,6 @@ class ::Method
     @method.curry(arity)
   end
 
-  alias [] call
-  alias === call
-
   def >>(other)
     @method >> other
   end
@@ -65,6 +62,9 @@ class ::Method
   def inspect
     "#<#{self.class}: #{@receiver.class}##{@name} (defined in #{@owner} in #{source_location.join(':')})>"
   end
+
+  alias [] call
+  alias === call
 end
 
 class ::UnboundMethod

--- a/opal/corelib/module.rb
+++ b/opal/corelib/module.rb
@@ -542,8 +542,6 @@ class ::Module
     }
   end
 
-  alias class_eval module_eval
-
   def module_exec(*args, &block)
     %x{
       if (block === nil) {
@@ -559,8 +557,6 @@ class ::Module
       return result;
     }
   end
-
-  alias class_exec module_exec
 
   def method_defined?(method)
     %x{
@@ -660,8 +656,6 @@ class ::Module
     `Opal.Module.$name.call(self)` || "#<#{`self.$$is_module ? 'Module' : 'Class'`}:0x#{__id__.to_s(16)}>"
   end
 
-  alias inspect to_s
-
   def undef_method(*names)
     %x{
       for (var i = 0, length = names.length; i < length; i++) {
@@ -737,4 +731,8 @@ class ::Module
   def using(mod)
     ::Kernel.raise 'Module#using is not permitted in methods'
   end
+
+  alias class_eval module_eval
+  alias class_exec module_exec
+  alias inspect to_s
 end

--- a/opal/corelib/nil.rb
+++ b/opal/corelib/nil.rb
@@ -61,8 +61,6 @@ class ::NilClass
     0
   end
 
-  alias to_f to_i
-
   def to_s
     ''
   end
@@ -83,6 +81,8 @@ class ::NilClass
   def instance_variables
     []
   end
+
+  alias to_f to_i
 end
 
 ::NIL = nil

--- a/opal/corelib/number.rb
+++ b/opal/corelib/number.rb
@@ -37,8 +37,6 @@ class ::Number < ::Numeric
     `(self * 2) + 1`
   end
 
-  alias object_id __id__
-
   def +(other)
     %x{
       if (other.$$is_number) {
@@ -82,8 +80,6 @@ class ::Number < ::Numeric
       }
     }
   end
-
-  alias fdiv /
 
   def %(other)
     %x{
@@ -334,9 +330,6 @@ class ::Number < ::Numeric
     }
   end
 
-  alias arg angle
-  alias phase angle
-
   def bit_length
     unless ::Integer === self
       ::Kernel.raise ::NoMethodError.new("undefined method `bit_length` for #{self}:Float", 'bit_length')
@@ -410,8 +403,6 @@ class ::Number < ::Numeric
     self
   end
 
-  alias eql? ==
-
   def equal?(other)
     self == other || `isNaN(self) && isNaN(other)`
   end
@@ -475,8 +466,6 @@ class ::Number < ::Numeric
     super
   end
 
-  alias kind_of? is_a?
-
   def instance_of?(klass)
     return true if klass == ::Integer && ::Integer === self
     return true if klass == ::Integer && ::Integer === self
@@ -499,10 +488,6 @@ class ::Number < ::Numeric
       }
     }
   end
-
-  alias magnitude abs
-
-  alias modulo %
 
   def next
     `self + 1`
@@ -668,8 +653,6 @@ class ::Number < ::Numeric
     end
   end
 
-  alias succ next
-
   def times(&block)
     return enum_for(:times) { self } unless block
 
@@ -689,8 +672,6 @@ class ::Number < ::Numeric
   def to_i
     `self < 0 ? Math.ceil(self) : Math.floor(self)`
   end
-
-  alias to_int to_i
 
   def to_r
     if ::Integer === self
@@ -737,8 +718,6 @@ class ::Number < ::Numeric
       return result;
     }
   end
-
-  alias inspect to_s
 
   def digits(base = 10)
     if self < 0
@@ -837,6 +816,18 @@ class ::Number < ::Numeric
   def negative?
     `self == -Infinity || 1 / self < 0`
   end
+
+  alias arg angle
+  alias eql? ==
+  alias fdiv /
+  alias inspect to_s
+  alias kind_of? is_a?
+  alias magnitude abs
+  alias modulo %
+  alias object_id __id__
+  alias phase angle
+  alias succ next
+  alias to_int to_i
 end
 
 ::Fixnum = ::Number

--- a/opal/corelib/numeric.rb
+++ b/opal/corelib/numeric.rb
@@ -57,8 +57,6 @@ class ::Numeric
     self < 0 ? ::Math::PI : 0
   end
 
-  alias arg angle
-
   def ceil(ndigits = 0)
     to_f.ceil(ndigits)
   end
@@ -66,8 +64,6 @@ class ::Numeric
   def conj
     self
   end
-
-  alias conjugate conj
 
   def denominator
     to_r.denominator
@@ -99,15 +95,9 @@ class ::Numeric
     0
   end
 
-  alias imaginary imag
-
   def integer?
     false
   end
-
-  alias magnitude abs
-
-  alias modulo %
 
   def nonzero?
     zero? ? nil : self
@@ -116,8 +106,6 @@ class ::Numeric
   def numerator
     to_r.numerator
   end
-
-  alias phase arg
 
   def polar
     [abs, arg]
@@ -138,8 +126,6 @@ class ::Numeric
   def rect
     [self, 0]
   end
-
-  alias rectangular rect
 
   def round(digits = undefined)
     to_f.round(digits)
@@ -340,4 +326,12 @@ class ::Numeric
   def infinite?
     nil
   end
+
+  alias arg angle
+  alias conjugate conj
+  alias imaginary imag
+  alias magnitude abs
+  alias modulo %
+  alias phase arg
+  alias rectangular rect
 end

--- a/opal/corelib/object_space.rb
+++ b/opal/corelib/object_space.rb
@@ -90,13 +90,14 @@ module ::ObjectSpace
         return #{@weak_map}.has(p1);
       }
     end
-    alias member? include?
-    alias key? include?
 
     %i[each each_key each_value each_pair keys values size length].each do |i|
       define_method i do |*|
         ::Kernel.raise ::NotImplementedError, "##{i} can't be implemented on top of JS interfaces"
       end
     end
+
+    alias member? include?
+    alias key? include?
   end
 end

--- a/opal/corelib/proc.rb
+++ b/opal/corelib/proc.rb
@@ -50,10 +50,6 @@ class ::Proc < `Function`
     }
   end
 
-  alias [] call
-  alias === call
-  alias yield call
-
   def >>(other)
     ::Kernel.proc do |*args, &block|
       out = call(*args, &block)
@@ -188,5 +184,8 @@ class ::Proc < `Function`
     }
   end
 
+  alias === call
   alias clone dup
+  alias yield call
+  alias [] call
 end

--- a/opal/corelib/range.rb
+++ b/opal/corelib/range.rb
@@ -101,8 +101,6 @@ class ::Range
       @end.eql?(other.end)
   end
 
-  alias == eql?
-
   def exclude_end?
     @excl
   end
@@ -112,8 +110,6 @@ class ::Range
     return @begin if `n == null`
     super
   end
-
-  alias include? cover?
 
   def last(n = undefined)
     ::Kernel.raise ::RangeError, 'cannot get the maximum of endless range' if @end.nil?
@@ -134,8 +130,6 @@ class ::Range
       `#{@excl} ? #{@end} - 1 : #{@end}`
     end
   end
-
-  alias member? cover?
 
   def min
     if @begin.nil?
@@ -283,4 +277,8 @@ class ::Range
   def hash
     [@begin, @end, @excl].hash
   end
+
+  alias == eql?
+  alias include? cover?
+  alias member? cover?
 end

--- a/opal/corelib/rational.rb
+++ b/opal/corelib/rational.rb
@@ -232,8 +232,6 @@ class ::Rational < ::Numeric
     end
   end
 
-  alias divide /
-
   def floor(precision = 0)
     if precision == 0
       (-(-@num / @den)).floor
@@ -249,8 +247,6 @@ class ::Rational < ::Numeric
   def inspect
     "(#{self})"
   end
-
-  alias quo /
 
   def rationalize(eps = undefined)
     %x{
@@ -391,4 +387,7 @@ class ::Rational < ::Numeric
       }
     }
   end
+
+  alias divide /
+  alias quo /
 end

--- a/opal/corelib/regexp.rb
+++ b/opal/corelib/regexp.rb
@@ -28,8 +28,6 @@ class ::Regexp < `RegExp`
       end
     end
 
-    alias quote escape
-
     def union(*parts)
       %x{
         var is_first_part_array, quoted_validated, part, options, each_part_options;
@@ -104,6 +102,7 @@ class ::Regexp < `RegExp`
     end
 
     alias compile new
+    alias quote escape
   end
 
   def ==(other)
@@ -117,8 +116,6 @@ class ::Regexp < `RegExp`
   def =~(string)
     match(string) && $~.begin(0)
   end
-
-  alias eql? ==
 
   def inspect
     # Use a regexp to extract the regular expression and the optional mode modifiers from the string.
@@ -288,6 +285,7 @@ class ::Regexp < `RegExp`
     `self.ignoreCase`
   end
 
+  alias eql? ==
   alias to_s source
 end
 
@@ -350,8 +348,6 @@ class MatchData
       `self.begin == other.begin`
   end
 
-  alias eql? ==
-
   def begin(n)
     %x{
       if (n !== 0) {
@@ -410,8 +406,6 @@ class MatchData
     `#{@matches}.length`
   end
 
-  alias size length
-
   def to_a
     @matches
   end
@@ -448,4 +442,7 @@ class MatchData
       return values;
     }
   end
+
+  alias eql? ==
+  alias size length
 end

--- a/opal/corelib/string.rb
+++ b/opal/corelib/string.rb
@@ -23,8 +23,6 @@ class ::String < `String`
     `self.toString()`
   end
 
-  alias object_id __id__
-
   def self.try_convert(what)
     ::Opal.coerce_to?(what, ::String, :to_str)
   end
@@ -141,8 +139,6 @@ class ::String < `String`
     }
   end
 
-  alias eql? ==
-  alias === ==
 
   def =~(other)
     %x{
@@ -251,8 +247,6 @@ class ::String < `String`
       return self.$$cast(self.substr(index, length));
     }
   end
-
-  alias byteslice []
 
   def b
     `new String(#{self})`.force_encoding('binary')
@@ -490,8 +484,6 @@ class ::String < `String`
 
     false
   end
-
-  alias equal? ===
 
   def gsub(pattern, replacement = undefined, &block)
     %x{
@@ -1028,8 +1020,6 @@ class ::String < `String`
     }
   end
 
-  alias slice []
-
   def split(pattern = undefined, limit = undefined)
     %x{
       if (self.length === 0) {
@@ -1229,8 +1219,6 @@ class ::String < `String`
     }
   end
 
-  alias succ next
-
   def sum(n = 16)
     %x{
       n = $coerce_to(n, #{::Integer}, 'to_int');
@@ -1376,10 +1364,6 @@ class ::String < `String`
   def to_s
     `self.toString()`
   end
-
-  alias to_str to_s
-
-  alias to_sym intern
 
   def tr(from, to)
     %x{
@@ -1866,8 +1850,6 @@ class ::String < `String`
     }
   end
 
-  alias +@ dup
-
   def -@
     %x{
       if (typeof self === 'string') return self;
@@ -1880,6 +1862,17 @@ class ::String < `String`
   def frozen?
     `typeof self === 'string' || self.$$frozen === true`
   end
+
+  alias +@ dup
+  alias === ==
+  alias byteslice []
+  alias eql? ==
+  alias equal? ===
+  alias object_id __id__
+  alias slice []
+  alias succ next
+  alias to_str to_s
+  alias to_sym intern
 
   ::Opal.pristine self, :initialize
 end

--- a/opal/corelib/struct.rb
+++ b/opal/corelib/struct.rb
@@ -253,13 +253,9 @@ class ::Struct
     self.class.members.length
   end
 
-  alias size length
-
   def to_a
     self.class.members.map { |name| self[name] }
   end
-
-  alias values to_a
 
   def inspect
     result = '#<struct '
@@ -276,8 +272,6 @@ class ::Struct
 
     result
   end
-
-  alias to_s inspect
 
   def to_h(&block)
     return map(&block).to_h(*args) if block_given?
@@ -316,4 +310,8 @@ class ::Struct
 
     item.dig(*keys)
   end
+
+  alias size length
+  alias to_s inspect
+  alias values to_a
 end

--- a/opal/corelib/time.rb
+++ b/opal/corelib/time.rb
@@ -224,11 +224,6 @@ class ::Time < `Date`
     }
   end
 
-  class << self
-    alias mktime local
-    alias utc gm
-  end
-
   def self.now
     new
   end
@@ -288,8 +283,6 @@ class ::Time < `Date`
     strftime '%a %b %e %H:%M:%S %Y'
   end
 
-  alias ctime asctime
-
   def day
     `self.is_utc ? self.getUTCDate() : self.getDate()`
   end
@@ -312,8 +305,6 @@ class ::Time < `Date`
       return self.getTimezoneOffset() < Math.max(jan.getTimezoneOffset(), jul.getTimezoneOffset());
     }
   end
-
-  alias dst? isdst
 
   def dup
     copy = `new Date(self.getTime())`
@@ -348,8 +339,6 @@ class ::Time < `Date`
     end
   end
 
-  alias mday day
-
   def min
     `self.is_utc ? self.getUTCMinutes() : self.getMinutes()`
   end
@@ -361,8 +350,6 @@ class ::Time < `Date`
   def monday?
     `#{wday} == 1`
   end
-
-  alias month mon
 
   def saturday?
     `#{wday} == 6`
@@ -413,16 +400,12 @@ class ::Time < `Date`
     }
   end
 
-  alias getutc getgm
-
   def gmtime
     %x{
       self.is_utc = true;
       return self;
     }
   end
-
-  alias utc gmtime
 
   def gmt?
     `self.is_utc === true`
@@ -692,20 +675,10 @@ class ::Time < `Date`
     `parseInt(self.getTime() / 1000, 10)`
   end
 
-  alias to_s inspect
-
   def tuesday?
     `#{wday} == 2`
   end
 
-  alias tv_sec to_i
-
-  alias tv_usec usec
-
-  alias utc? gmt?
-
-  alias gmtoff gmt_offset
-  alias utc_offset gmt_offset
 
   def wday
     `self.is_utc ? self.getUTCDay() : self.getDay()`
@@ -750,4 +723,22 @@ class ::Time < `Date`
 
     [week, year]
   end
+
+  class << self
+    alias mktime local
+    alias utc gm
+  end
+
+  alias ctime asctime
+  alias dst? isdst
+  alias getutc getgm
+  alias gmtoff gmt_offset
+  alias mday day
+  alias month mon
+  alias to_s inspect
+  alias tv_sec to_i
+  alias tv_usec usec
+  alias utc gmtime
+  alias utc? gmt?
+  alias utc_offset gmt_offset
 end

--- a/opal/corelib/unsupported.rb
+++ b/opal/corelib/unsupported.rb
@@ -82,17 +82,9 @@ class ::Module
     }
   end
 
-  alias private public
-
-  alias protected public
-
-  alias nesting public
-
   def private_class_method(*)
     self
   end
-
-  alias public_class_method private_class_method
 
   def private_method_defined?(obj)
     false
@@ -101,12 +93,13 @@ class ::Module
   def private_constant(*)
   end
 
+  alias nesting public
+  alias private public
+  alias protected public
   alias protected_method_defined? private_method_defined?
-
-  alias public_instance_methods instance_methods
-
+  alias public_class_method private_class_method
   alias public_instance_method instance_method
-
+  alias public_instance_methods instance_methods
   alias public_method_defined? method_defined?
 end
 

--- a/spec/filters/bugs/array.rb
+++ b/spec/filters/bugs/array.rb
@@ -19,7 +19,6 @@ opal_filter "Array" do
   fails "Array#[]= with [m..] just sets the section defined by range to nil if m and n < 0 and the rhs is nil" # Opal::SyntaxError: undefined method `type' for nil
   fails "Array#[]= with [m..] replaces the section defined by range" # Opal::SyntaxError: undefined method `type' for nil
   fails "Array#[]= with [m..] replaces the section if m and n < 0" # Opal::SyntaxError: undefined method `type' for nil
-  fails "Array#drop raises a TypeError when the passed argument can't be coerced to Integer" # Expected TypeError but no exception was raised ([1, 2] was returned)
   fails "Array#drop raises a TypeError when the passed argument isn't an integer and #to_int returns non-Integer" # Expected TypeError but no exception was raised ([1, 2] was returned)
   fails "Array#drop tries to convert the passed argument to an Integer using #to_int" # Expected [1, 2, 3] == [3] to be truthy but was false
   fails "Array#each does not yield elements deleted from the end of the array" # Expected [2, 3, nil] to equal [2, 3]

--- a/stdlib/bigdecimal.rb
+++ b/stdlib/bigdecimal.rb
@@ -67,8 +67,6 @@ class BigDecimal < Numeric
     end
   end
 
-  alias === ==
-
   def <=>(other)
     result = case other
              when self.class
@@ -122,8 +120,6 @@ class BigDecimal < Numeric
 
     self.class.new(result)
   end
-
-  alias + add
 
   def ceil(n = nil)
     unless bignumber.JS.isFinite
@@ -188,8 +184,6 @@ class BigDecimal < Numeric
     self.class.new(bignumber.JS.minus(other.bignumber))
   end
 
-  alias - minus
-
   def mult(other, digits = nil)
     other, _ = coerce(other)
 
@@ -200,8 +194,6 @@ class BigDecimal < Numeric
     self.class.new(bignumber.JS.times(other.bignumber).JS.round(digits, self.class.mode(ROUND_MODE)))
   end
 
-  alias * mult
-
   def nan?
     bignumber.JS.isNaN
   end
@@ -210,8 +202,6 @@ class BigDecimal < Numeric
     other, _ = coerce(other)
     self.class.new(bignumber.JS.dividedBy(other.bignumber))
   end
-
-  alias / quo
 
   def sign
     if bignumber.JS.isNaN
@@ -234,9 +224,15 @@ class BigDecimal < Numeric
   def to_s(s = '')
     bignumber.JS.toString
   end
-  alias inspect to_s
 
   def zero?
     bignumber.JS.isZero
   end
+
+  alias === ==
+  alias + add
+  alias - minus
+  alias * mult
+  alias / quo
+  alias inspect to_s
 end

--- a/stdlib/buffer.rb
+++ b/stdlib/buffer.rb
@@ -30,8 +30,6 @@ class Buffer
     `#{@native}.byteLength`
   end
 
-  alias size length
-
   def to_a(bits = 8, type = :unsigned)
     Array.new(self, bits, type)
   end
@@ -43,4 +41,6 @@ class Buffer
   def to_s
     to_a.to_a.pack('c*')
   end
+
+  alias size length
 end

--- a/stdlib/buffer/view.rb
+++ b/stdlib/buffer/view.rb
@@ -27,8 +27,6 @@ class Buffer
       `#{@native}.byteLength`
     end
 
-    alias size length
-
     def get(offset, bits = 8, type = :unsigned, little = false)
       `#{@native}["get" + #{Buffer.name_for bits, type}](offset, little)`
     end
@@ -104,5 +102,7 @@ class Buffer
     def set_float64(offset, value, little = false)
       `#{@native}.setFloat64(offset, value, little)`
     end
+
+    alias size length
   end
 end

--- a/stdlib/date.rb
+++ b/stdlib/date.rb
@@ -83,8 +83,6 @@ class Date
   ABBR_DAYNAMES   = %w[Sun Mon Tue Wed Thu Fri Sat]
 
   class << self
-    alias civil new
-
     def wrap(native)
       instance = allocate
       `#{instance}.date = #{native}`
@@ -344,6 +342,8 @@ class Date
     def gregorian_leap?(year)
       `(new Date(#{year}, 1, 29).getMonth()-1) === 0`
     end
+
+    alias civil new
   end
 
   def initialize(year = -4712, month = 1, day = 1, start = ITALY)
@@ -472,8 +472,6 @@ class Date
     }
   end
 
-  alias eql? ==
-
   def clone
     Date.wrap(`new Date(#{@date}.getTime())`)
   end
@@ -588,8 +586,6 @@ class Date
     }
   end
 
-  alias succ next
-
   def sunday?
     wday == 0
   end
@@ -680,4 +676,7 @@ class Date
       return [31, (leap ? 29 : 28), 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month]
     }
   }
+
+  alias eql? ==
+  alias succ next
 end

--- a/stdlib/erb.rb
+++ b/stdlib/erb.rb
@@ -10,6 +10,7 @@ class ERB
     end
 
     alias h html_escape
+
     module_function :h
     module_function :html_escape
   end

--- a/stdlib/js.rb
+++ b/stdlib/js.rb
@@ -58,11 +58,12 @@ module JS
     args << block if block
     g.JS[func].JS.apply(g, args)
   end
-  alias method_missing call
 
   def [](name)
     `Opal.global[#{name}]`
   end
+
+  alias method_missing call
 
   extend self
 end

--- a/stdlib/native.rb
+++ b/stdlib/native.rb
@@ -261,10 +261,6 @@ class Native::Object < BasicObject
     `Opal.hasOwnProperty.call(#{@native}, #{name})`
   end
 
-  alias key? has_key?
-  alias include? has_key?
-  alias member? has_key?
-
   def each(*args)
     if block_given?
       %x{
@@ -341,8 +337,6 @@ class Native::Object < BasicObject
     `Opal.is_a(self, klass)`
   end
 
-  alias kind_of? is_a?
-
   def instance_of?(klass)
     `self.$$class === klass`
   end
@@ -358,6 +352,11 @@ class Native::Object < BasicObject
   def inspect
     "#<Native:#{`String(#{@native})`}>"
   end
+
+  alias include? has_key?
+  alias key? has_key?
+  alias kind_of? is_a?
+  alias member? has_key?
 end
 
 class Native::Array
@@ -435,11 +434,11 @@ class Native::Array
     `#{@native}[#{@length}]`
   end
 
-  alias to_ary to_a
-
   def inspect
     to_a.inspect
   end
+
+  alias to_ary to_a
 end
 
 class Numeric

--- a/stdlib/nodejs/argf.rb
+++ b/stdlib/nodejs/argf.rb
@@ -99,12 +99,12 @@ class << ARGF
     file.eof?
   end
 
-  alias to_io file
-  alias to_i fileno
-  alias skip close
-  alias path filename
   alias each_line each
   alias eof eof?
+  alias path filename
+  alias skip close
+  alias to_i fileno
+  alias to_io file
 end
 
 ARGF.lineno = 1

--- a/stdlib/nodejs/env.rb
+++ b/stdlib/nodejs/env.rb
@@ -13,11 +13,6 @@ class << ENV
     `process.env.hasOwnProperty(#{name})`
   end
 
-  # alias
-  alias has_key? key?
-  alias include? key?
-  alias member? key?
-
   def empty?
     `Object.keys(process.env).length === 0`
   end
@@ -45,15 +40,17 @@ class << ENV
     'ENV'
   end
 
-  alias inspect to_s
-
   def to_h
     keys.to_h { |k| [k, self[k]] }
   end
 
-  alias to_hash to_h
-
   def merge(keys)
     to_h.merge(keys)
   end
+
+  alias has_key? key?
+  alias include? key?
+  alias inspect to_s
+  alias member? key?
+  alias to_hash to_h
 end

--- a/stdlib/nodejs/fileutils.rb
+++ b/stdlib/nodejs/fileutils.rb
@@ -23,11 +23,11 @@ module FileUtils
     `__fs__.mkdirSync(#{path})`
   end
 
-  alias mkpath mkdir_p
-  alias makedirs mkdir_p
-
   def mv(source, target)
     target = File.join(target, File.basename(source)) if File.directory? target
     `__fs__.renameSync(source, target)`
   end
+
+  alias mkpath mkdir_p
+  alias makedirs mkdir_p
 end

--- a/stdlib/pathname.rb
+++ b/stdlib/pathname.rb
@@ -165,12 +165,6 @@ class Pathname
     path <=> other.path
   end
 
-  alias eql? ==
-  alias === ==
-
-  alias to_str to_path
-  alias to_s to_path
-
   SAME_PATHS = if File::FNM_SYSCASE.nonzero?
                  # Avoid #zero? here because #casecmp can return nil.
                  proc { |a, b| a.casecmp(b) == 0 }
@@ -217,6 +211,11 @@ class Pathname
   def entries
     Dir.entries(@path).map { |f| self.class.new(f) }
   end
+
+  alias === ==
+  alias eql? ==
+  alias to_s to_path
+  alias to_str to_path
 end
 
 module Kernel

--- a/stdlib/promise.rb
+++ b/stdlib/promise.rb
@@ -275,9 +275,6 @@ class Promise
     self.then(&block)
   end
 
-  alias do then
-  alias do! then!
-
   def fail(&block)
     self ^ Promise.new(failure: block)
   end
@@ -287,11 +284,6 @@ class Promise
     fail(&block)
   end
 
-  alias rescue fail
-  alias catch fail
-  alias rescue! fail!
-  alias catch! fail!
-
   def always(&block)
     self ^ Promise.new(always: block)
   end
@@ -300,11 +292,6 @@ class Promise
     there_can_be_only_one!
     always(&block)
   end
-
-  alias finally always
-  alias ensure always
-  alias finally! always!
-  alias ensure! always!
 
   def trace(depth = nil, &block)
     self ^ Trace.new(depth, block)
@@ -337,8 +324,6 @@ class Promise
     result
   end
 
-  alias to_v1 itself
-
   def to_v2
     v2 = PromiseV2.new
 
@@ -347,7 +332,18 @@ class Promise
     v2
   end
 
+  alias catch fail
+  alias catch! fail!
+  alias do then
+  alias do! then!
+  alias ensure always
+  alias ensure! always!
+  alias finally always
+  alias finally! always!
+  alias rescue fail
+  alias rescue! fail!
   alias to_n to_v2
+  alias to_v1 itself
 
   class Trace < self
     def self.it(promise)
@@ -414,10 +410,6 @@ class Promise
       end
     end
 
-    alias map collect
-
-    alias reduce inject
-
     def wait(promise)
       unless Promise === promise
         promise = Promise.value(promise)
@@ -436,8 +428,6 @@ class Promise
       self
     end
 
-    alias and wait
-
     def >>(*)
       super.tap do
         try
@@ -454,6 +444,10 @@ class Promise
         end
       end
     end
+
+    alias map collect
+    alias reduce inject
+    alias and wait
   end
 end
 

--- a/stdlib/promise/v2.rb
+++ b/stdlib/promise/v2.rb
@@ -124,8 +124,6 @@ class PromiseV2 < `Promise`
       end
     end
 
-    alias all when
-
     def all_resolved(*promises)
       promises = Array(promises.length == 1 ? promises.first : promises)
       `Promise.allResolved(#{promises})`.tap do |prom|
@@ -154,7 +152,6 @@ class PromiseV2 < `Promise`
         prom.instance_variable_set(:@value, value)
       end
     end
-    alias value resolve
 
     def reject(value = nil)
       `Promise.reject(#{value})`.tap do |prom|
@@ -163,7 +160,10 @@ class PromiseV2 < `Promise`
         prom.instance_variable_set(:@value, value)
       end
     end
+
+    alias all when
     alias error reject
+    alias value resolve
   end
 
   attr_reader :prev, :next
@@ -209,7 +209,6 @@ class PromiseV2 < `Promise`
     @resolve_proc.call(value)
     self
   end
-  alias resolve! resolve
 
   def reject(value = nil)
     nativity_check!
@@ -219,7 +218,6 @@ class PromiseV2 < `Promise`
     @reject_proc.call(value)
     self
   end
-  alias reject! reject
 
   def then(&block)
     prom = nil
@@ -239,9 +237,6 @@ class PromiseV2 < `Promise`
     self.then(&block)
   end
 
-  alias do then
-  alias do! then!
-
   def fail(&block)
     prom = nil
     blk = gen_tracing_proc(block) do |val|
@@ -260,11 +255,6 @@ class PromiseV2 < `Promise`
     fail(&block)
   end
 
-  alias rescue fail
-  alias catch fail
-  alias rescue! fail!
-  alias catch! fail!
-
   def always(&block)
     prom = nil
     blk = gen_tracing_proc(block) do |val|
@@ -282,11 +272,6 @@ class PromiseV2 < `Promise`
     there_can_be_only_one!
     always(&block)
   end
-
-  alias finally always
-  alias ensure always
-  alias finally! always!
-  alias ensure! always!
 
   def trace(depth = nil, &block)
     prom = self.then do
@@ -362,8 +347,6 @@ class PromiseV2 < `Promise`
     yield self if block_given?
   end
 
-  alias to_v2 itself
-
   def to_v1
     v1 = PromiseV1.new
 
@@ -371,8 +354,6 @@ class PromiseV2 < `Promise`
 
     v1
   end
-
-  alias to_n itself
 
   def inspect
     result = "#<#{self.class}"
@@ -395,4 +376,19 @@ class PromiseV2 < `Promise`
 
     result
   end
+
+  alias catch fail
+  alias catch! fail!
+  alias do then
+  alias do! then!
+  alias ensure always
+  alias ensure! always!
+  alias finally always
+  alias finally! always!
+  alias reject! reject
+  alias rescue fail
+  alias rescue! fail!
+  alias resolve! resolve
+  alias to_n itself
+  alias to_v2 itself
 end

--- a/stdlib/set.rb
+++ b/stdlib/set.rb
@@ -31,7 +31,6 @@ class ::Set
 
     dup.subtract(enum)
   end
-  alias difference -
 
   def inspect
     "#<Set: {#{to_a.join(',')}}>"
@@ -53,7 +52,6 @@ class ::Set
     @hash[o] = true
     self
   end
-  alias << add
 
   def classify(&block)
     return enum_for(:classify) unless block_given?
@@ -71,7 +69,6 @@ class ::Set
     each { |item| result << yield(item) }
     replace result
   end
-  alias map! collect!
 
   def delete(o)
     @hash.delete(o)
@@ -113,8 +110,6 @@ class ::Set
     size == before ? nil : self
   end
 
-  alias filter! select!
-
   def add?(o)
     if include?(o)
       nil
@@ -145,8 +140,6 @@ class ::Set
   def include?(o)
     @hash.include?(o)
   end
-  alias member? include?
-
   def merge(enum)
     enum.each { |item| add item }
     self
@@ -162,8 +155,6 @@ class ::Set
   def size
     @hash.size
   end
-  alias length size
-
   def subtract(enum)
     enum.each { |item| delete item }
     self
@@ -188,15 +179,11 @@ class ::Set
     set.all? { |o| include?(o) }
   end
 
-  alias >= superset?
-
   def proper_superset?(set)
     `is_set(set)`
     return false if size <= set.size
     set.all? { |o| include?(o) }
   end
-
-  alias > proper_superset?
 
   def subset?(set)
     `is_set(set)`
@@ -204,15 +191,11 @@ class ::Set
     all? { |o| set.include?(o) }
   end
 
-  alias <= subset?
-
   def proper_subset?(set)
     `is_set(set)`
     return false if set.size <= size
     all? { |o| set.include?(o) }
   end
-
-  alias < proper_subset?
 
   def intersect?(set)
     `is_set(set)`
@@ -227,12 +210,22 @@ class ::Set
     !intersect?(set)
   end
 
-  alias + |
-  alias union |
-
   def to_a
     @hash.keys
   end
+
+  alias + |
+  alias < proper_subset?
+  alias << add
+  alias <= subset?
+  alias > proper_superset?
+  alias >= superset?
+  alias difference -
+  alias filter! select!
+  alias length size
+  alias map! collect!
+  alias member? include?
+  alias union |
 end
 
 module ::Enumerable

--- a/stdlib/stringio.rb
+++ b/stdlib/stringio.rb
@@ -22,8 +22,6 @@ class StringIO < IO
     @position == @string.length
   end
 
-  alias eof eof?
-
   def seek(pos, whence = IO::SEEK_SET)
     # Let's reset the read buffer, because it will be most likely wrong
     @read_buffer = ''
@@ -55,10 +53,6 @@ class StringIO < IO
   def tell
     @position
   end
-
-  alias pos tell
-
-  alias pos= seek
 
   def rewind
     seek 0
@@ -113,5 +107,8 @@ class StringIO < IO
     read(length)
   end
 
+  alias eof eof?
+  alias pos tell
+  alias pos= seek
   alias readpartial read
 end

--- a/stdlib/strscan.rb
+++ b/stdlib/strscan.rb
@@ -1,6 +1,5 @@
 class StringScanner
-  attr_reader :pos
-  attr_reader :matched
+  attr_reader :pos, :matched
 
   def initialize(string)
     @string  = string
@@ -15,8 +14,6 @@ class StringScanner
   def beginning_of_line?
     `#{@pos} === 0 || #{@string}.charAt(#{@pos} - 1) === "\n"`
   end
-
-  alias bol? beginning_of_line?
 
   def scan(pattern)
     pattern = anchor(pattern)
@@ -227,9 +224,6 @@ class StringScanner
     }
   end
 
-  # not exactly, but for now...
-  alias getch get_byte
-
   def match?(pattern)
     pattern = anchor(pattern)
 
@@ -318,6 +312,9 @@ class StringScanner
 
     self
   end
+
+  alias bol? beginning_of_line?
+  alias getch get_byte # not exactly the same, but for now...
 
   private
 

--- a/stdlib/template.rb
+++ b/stdlib/template.rb
@@ -36,10 +36,10 @@ class Template
       @buffer << str
     end
 
-    alias append= append
-
     def join
       @buffer.join
     end
+
+    alias append= append
   end
 end

--- a/stdlib/thread.rb
+++ b/stdlib/thread.rb
@@ -86,8 +86,6 @@ class Thread
       @storage.size
     end
 
-    alias length size
-
     def pop(non_block = false)
       if empty?
         raise ThreadError, 'Queue empty' if non_block
@@ -97,19 +95,19 @@ class Thread
       @storage.shift
     end
 
-    alias shift pop
-    alias deq   pop
-
     def push(value)
       @storage.push(value)
     end
 
-    alias <<  push
-    alias enq push
-
     def each(&block)
       @storage.each(&block)
     end
+
+    alias << push
+    alias deq pop
+    alias enq push
+    alias length size
+    alias shift pop
   end
 
   class Backtrace


### PR DESCRIPTION
This is a reprise of some older attempts at DCE, still WIP, but promising.

Any method definition for a method name that's not called anywhere is replaced with an alias to raise and a `/* DCE: foo */` comment.

```
opal:master * ⤑ bin/opal -ce "def foo; end; (1..100).maxmin"|wc -c
 1856900
opal:master * ⤑ env DCE=1 bin/opal -ce "def foo; end; (1..100).maxmin"|wc -c
 1058296
```

Right now it scrapes out 43% of the size.
