### PR TITLE
Fix multiline x-string in a case assignment

### DIFF
--- a/lib/opal/nodes/if.rb
+++ b/lib/opal/nodes/if.rb
@@ -147,6 +147,10 @@ module Opal
           case body.type
           when :return, :js_return, :break, :next, :redo, :retry
             false
+          when :xstr
+            XStringNode.single_line?(
+              XStringNode.strip_empty_children(body.children)
+            )
           else
             body.children.all? { |i| simple?(i) }
           end

--- a/spec/opal/core/language/xstring_spec.rb
+++ b/spec/opal/core/language/xstring_spec.rb
@@ -1,0 +1,13 @@
+describe "The x-string expression" do
+  it "works with multiline, case and assignment" do
+    a = case 1
+        when 1
+          %x{
+            var b = 5;
+            return b;
+          }
+        end
+    
+    a.should == 5
+  end
+end


### PR DESCRIPTION
Correct a regression that I tried to fix in Opal-Browser with this:

https://github.com/opal/opal-browser/commit/5856297c22c81fcd801432f89218375a30538350