### PR TITLE
added URI.decode_www_form

### DIFF
--- a/stdlib/uri.rb
+++ b/stdlib/uri.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module URI
+	def self.decode_www_form(str, separator: '&', isindex: false)
+		%x{
+			var str = #{str};
+			var ary = [];
+			if (str.length == 0) {
+				return ary;
+			}
+			var parts = str.split(#{separator});
+			for (var i = 0; i < parts.length; i++) {
+				var string = parts[i];
+				var comps = string.split('=');
+				var key = comps[0];
+				var val = comps[1];
+				if (#{isindex}) {
+					if (comps.length < 2) {
+						val = key;
+						key = '';
+					}
+				}
+
+				key = decodeURIComponent(key.replace(/\+/g, ' '));
+				if (val) {
+					val = decodeURIComponent(val.replace(/\+/g, ' '));
+				} else {
+					val = '';
+				}
+				ary.push([key, val]);
+			}
+			return ary;
+		}
+	end
+end

--- a/stdlib/uri.rb
+++ b/stdlib/uri.rb
@@ -1,23 +1,35 @@
 # frozen_string_literal: true
 
 module URI
-  def self.decode_www_form(str, separator: '&', isindex: false)
+  def self.decode_www_form(str, enc = undefined, separator: '&', use__charset_: false, isindex: false)
+    raise ArgumentError, "the input of #{name}.#{__method__} must be ASCII only string" unless str.ascii_only?
+
     %x{
-      var ary = [];
-      if (str.length == 0) {
+      var ary = [], key, val;
+      if (str.length == 0)
         return ary;
-      }
+      if (enc)
+        #{enc = Encoding.find(enc)};
+
       var parts = str.split(#{separator});
       for (var i = 0; i < parts.length; i++) {
         var string = parts[i];
-        var comps = string.split('=');
-        var key = comps[0];
-        var val = comps[1];
-        if (#{isindex}) {
-          if (comps.length < 2) {
-            val = key;
+        var splitIndex = string.indexOf('=')
+
+        if (splitIndex >= 0) {
+          key = string.substr(0, splitIndex);
+          val = string.substr(splitIndex + 1);
+        } else {
+          key = string;
+          val = '';
+        }
+
+        if (isindex) {
+          if (splitIndex < 0) {
             key = '';
+            val = string;
           }
+          isindex = false;
         }
 
         key = decodeURIComponent(key.replace(/\+/g, ' '));
@@ -26,8 +38,15 @@ module URI
         } else {
           val = '';
         }
+
+        if (enc) {
+          key = #{`key`.force_encoding(enc)}
+          val = #{`val`.force_encoding(enc)}
+        }
+
         ary.push([key, val]);
       }
+
       return ary;
     }
   end

--- a/stdlib/uri.rb
+++ b/stdlib/uri.rb
@@ -1,35 +1,35 @@
 # frozen_string_literal: true
 
 module URI
-	def self.decode_www_form(str, separator: '&', isindex: false)
-		%x{
-			var str = #{str};
-			var ary = [];
-			if (str.length == 0) {
-				return ary;
-			}
-			var parts = str.split(#{separator});
-			for (var i = 0; i < parts.length; i++) {
-				var string = parts[i];
-				var comps = string.split('=');
-				var key = comps[0];
-				var val = comps[1];
-				if (#{isindex}) {
-					if (comps.length < 2) {
-						val = key;
-						key = '';
-					}
-				}
+  def self.decode_www_form(str, separator: '&', isindex: false)
+    %x{
+      var str = #{str};
+      var ary = [];
+      if (str.length == 0) {
+        return ary;
+      }
+      var parts = str.split(#{separator});
+      for (var i = 0; i < parts.length; i++) {
+        var string = parts[i];
+        var comps = string.split('=');
+        var key = comps[0];
+        var val = comps[1];
+        if (#{isindex}) {
+          if (comps.length < 2) {
+            val = key;
+            key = '';
+          }
+        }
 
-				key = decodeURIComponent(key.replace(/\+/g, ' '));
-				if (val) {
-					val = decodeURIComponent(val.replace(/\+/g, ' '));
-				} else {
-					val = '';
-				}
-				ary.push([key, val]);
-			}
-			return ary;
-		}
-	end
+        key = decodeURIComponent(key.replace(/\+/g, ' '));
+        if (val) {
+          val = decodeURIComponent(val.replace(/\+/g, ' '));
+        } else {
+          val = '';
+        }
+        ary.push([key, val]);
+      }
+      return ary;
+    }
+  end
 end

--- a/stdlib/uri.rb
+++ b/stdlib/uri.rb
@@ -3,7 +3,6 @@
 module URI
   def self.decode_www_form(str, separator: '&', isindex: false)
     %x{
-      var str = #{str};
       var ary = [];
       if (str.length == 0) {
         return ary;

--- a/tasks/testing.rake
+++ b/tasks/testing.rake
@@ -337,6 +337,7 @@ platforms.each do |platform|
           opal/test_keyword.rb
           opal/test_base64.rb
           opal/test_openuri.rb
+          opal/test_uri.rb
           opal/unsupported_and_bugs.rb
           opal/test_matrix.rb
           opal/promisev2/test_always.rb

--- a/test/opal/test_uri.rb
+++ b/test/opal/test_uri.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: false
+
+require 'uri'
+
+module URI
+  class TestCommon < Test::Unit::TestCase
+    def test_decode_www_form
+      assert_equal([%w[a 1], %w[a 2]], URI.decode_www_form("a=1&a=2"))
+      assert_equal([%w[a 1;a=2]], URI.decode_www_form("a=1;a=2"))
+      assert_equal([%w[a 1], ['', ''], %w[a 2]], URI.decode_www_form("a=1&&a=2"))
+      assert_raise(ArgumentError){URI.decode_www_form("\u3042")}
+      # assert_equal([%w[a 1], ["\u3042", "\u6F22"]],
+      #              URI.decode_www_form("a=1&%E3%81%82=%E6%BC%A2"))
+      # assert_equal([%w[a 1], ["\uFFFD%8", "\uFFFD"]],
+      #              URI.decode_www_form("a=1&%E3%81%8=%E6%BC"))
+      assert_equal([%w[?a 1], %w[a 2]], URI.decode_www_form("?a=1&a=2"))
+      assert_equal([], URI.decode_www_form(""))
+      # assert_equal([%w[% 1]], URI.decode_www_form("%=1"))
+      # assert_equal([%w[a %]], URI.decode_www_form("a=%"))
+      # assert_equal([%w[a 1], %w[% 2]], URI.decode_www_form("a=1&%=2"))
+      # assert_equal([%w[a 1], %w[b %]], URI.decode_www_form("a=1&b=%"))
+      assert_equal([['a', ''], ['b', '']], URI.decode_www_form("a&b"))
+      bug4098 = '[ruby-core:33464]'
+      assert_equal([['a', 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'], ['b', '']], URI.decode_www_form("a=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&b"), bug4098)
+
+      assert_raise(ArgumentError){ URI.decode_www_form("a=1&%82%A0=%8A%BF", "x-sjis") }
+      # assert_equal([["a", "1"], [s("\x82\xA0"), s("\x8a\xBF")]],
+      #              URI.decode_www_form("a=1&%82%A0=%8A%BF", "sjis"))
+      # assert_equal([["a", "1"], [s("\x82\xA0"), s("\x8a\xBF")], %w[_charset_ sjis], [s("\x82\xA1"), s("\x8a\xC0")]],
+      #              URI.decode_www_form("a=1&%82%A0=%8A%BF&_charset_=sjis&%82%A1=%8A%C0", use__charset_: true))
+      assert_equal([["", "isindex"], ["a", "1"]],
+                   URI.decode_www_form("isindex&a=1", isindex: true))
+    end
+  end
+end


### PR DESCRIPTION
Adding stdlib module URI, with the implementation of `decode_www_form`.

 I didn't manage out to find out how to test (though was an rspec test, but it was running CRuby `uri` instead). Also, implementation omits 2 arguments, because the features may not be implemented in JS (are string encodings a thing in JS?).

Help would be appreciated :) 