### PR TITLE
Restore "Fix defining multiple methods with the same block"

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,6 +28,8 @@ module.exports = {
     "DataView": "readonly",
     "globalThis": "readonly",
     "Opal": "readonly",
+    "Promise": "readonly",
+    "Proxy": "readonly",
     "Reflect": "readonly",
     "Uint8Array": "readonly",
     "WeakRef": "readonly",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,12 +24,12 @@ module.exports = {
     "no-control-regex": "off",
   },
   "globals": {
-    "Opal": "readonly",
-    "DataView": "readonly",
     "ArrayBuffer": "readonly",
+    "DataView": "readonly",
     "globalThis": "readonly",
+    "Opal": "readonly",
+    "Reflect": "readonly",
     "Uint8Array": "readonly",
-    "Promise": "readonly",
     "WeakRef": "readonly",
   }
 };

--- a/opal/corelib/module.rb
+++ b/opal/corelib/module.rb
@@ -399,6 +399,7 @@ class ::Module
       if (typeof(Proxy) !== 'undefined') {
         var meta = Object.create(null)
 
+        block.$$proxy_target = block
         block = new Proxy(block, {
           apply: function(target, self, args) {
             var old_name = target.$$jsid

--- a/opal/corelib/module.rb
+++ b/opal/corelib/module.rb
@@ -396,14 +396,28 @@ class ::Module
               end
 
     %x{
-      var id = '$' + name;
+      if (typeof(Proxy) !== 'undefined') {
+        var meta = Object.create(null)
+
+        block = new Proxy(block, {
+          apply: function(target, self, args) {
+            var old_name = target.$$jsid
+            target.$$jsid = name;
+            try {
+              return target.apply(self, args);
+            } finally {
+              target.$$jsid = old_name
+            }
+          }
+        })
+      }
 
       block.$$jsid        = name;
       block.$$s           = null;
       block.$$def         = block;
       block.$$define_meth = true;
 
-      return Opal.defn(self, id, block);
+      return Opal.defn(self, '$' + name, block);
     }
   end
 

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -1607,7 +1607,10 @@
     }
 
     if (implicit && current_func.$$define_meth) {
-      throw Opal.RuntimeError.$new("implicit argument passing of super from method defined by define_method() is not supported. Specify all arguments explicitly");
+      throw Opal.RuntimeError.$new(
+        "implicit argument passing of super from method defined by define_method() is not supported. " +
+        "Specify all arguments explicitly"
+      );
     }
 
     if (current_func.$$def) {

--- a/spec/opal/core/language/super_spec.rb
+++ b/spec/opal/core/language/super_spec.rb
@@ -19,3 +19,29 @@ describe 'super without explicit argument' do
     klass.new.test_rest_kwargs(native: 4).should == {native: 4}
   end
 end
+
+class ABlockWithSuperSpec
+  BLOCK = proc {
+    return [self, super()]
+  }
+  def foo; :foo; end
+  def bar; :bar; end
+  def foo_bar; [foo, bar]; end
+end
+
+describe "a block with super" do
+  it "can be used to define multiple methods" do
+    block = nil
+
+    c = Class.new(ABlockWithSuperSpec) {
+      define_method :foo, ABlockWithSuperSpec::BLOCK
+      define_method :bar, ABlockWithSuperSpec::BLOCK
+      define_method :foo_bar, ABlockWithSuperSpec::BLOCK
+    }
+
+    obj = c.new
+    obj.foo.should == [obj, :foo]
+    obj.bar.should == [obj, :bar]
+    obj.foo_bar.should == [obj, [[obj, :foo], [obj, :bar]]]
+  end
+end

--- a/tasks/performance.rake
+++ b/tasks/performance.rake
@@ -155,14 +155,14 @@ namespace :performance do
     puts diff
 
     if diff_lines.grep(/^-\s+\[COMPILED\]/).count > 0
-      failure.("Some methods are no longer compiled on V8")
+      $failures << "Some methods are no longer compiled on V8"
     end
 
     puts
     puts "Comparison of the Asciidoctor (a real-life Opal application) compile and run:"
 
-    failure.("Wrong result on the current branch") unless current[:correct]
-    failure.("Wrong result on the previous branch - ignore it") unless previous[:correct]
+    $failures << "Wrong result on the current branch" unless current[:correct]
+    $failures << "Wrong result on the previous branch - ignore it" unless previous[:correct]
 
     current[:compiler_time].compare_to(previous[:compiler_time], "Compile time")
     current[:run_time     ].compare_to(previous[:run_time     ], "Run time")

--- a/tasks/performance/optimization_status.rb
+++ b/tasks/performance/optimization_status.rb
@@ -27,7 +27,7 @@ klasses = [
 
     return (optstatus & (1 << 6)) ? "[INTERPRETED]" : "[COMPILED]";
   }
-  
+
   function triggerOptAndGetStatus(fn) {
     // using try/catch to avoid having to call functions properly
     try {
@@ -52,6 +52,7 @@ optimization_status = Hash[klasses.map do |klass|
   methods -= [:product, :exit, :exit!, :at_exit]
   opt_status = Hash[methods.map do |method|
     method_func = `#{klass.instance_method(method)}.method`
+    method_func = `#{method_func}.$$proxy_target || #{method_func}`
     [method, `triggerOptAndGetStatus(#{method_func})`]
   end]
   by_status_grouped = opt_status.group_by {|method, status| status }


### PR DESCRIPTION
I ended up using `Proxy` and `Reflect` as they're supported everywhere except for explorer and seem to solve the issue pretty well.

Wasn't able to write a test that broke on this, I manually tested by adding paggio to the Gemfile and running:

```
bin/opal --gem paggio -rpaggio -e 'puts Paggio.html! { div.data(test: "test") {div.data(test: "test")} }'
```

---

This reverts commit 787c6065ff6045c57aeb3c98e887c920fb1270c7,
restoring commit 3eacd508eb55daa34198330bf6820579428d845d.

Ref https://github.com/opal/opal/pull/2377
Fixes https://github.com/opal/opal/pull/2379


