### PR TITLE
Rewriters refactor

### DIFF
--- a/lib/opal/cache.rb
+++ b/lib/opal/cache.rb
@@ -41,7 +41,7 @@ module Opal
 
       data || begin
                 compiler = yield
-                cache.set(key, compiler)
+                cache.set(key, compiler) unless compiler.dynamic_cache_result
                 compiler
               end
     end

--- a/lib/opal/nodes/top.rb
+++ b/lib/opal/nodes/top.rb
@@ -14,6 +14,7 @@ module Opal
 
       def compile
         compiler.top_scope = self
+        compiler.dynamic_cache_result = true if sexp.meta[:dynamic_cache_result]
 
         push version_comment
 

--- a/lib/opal/parser/default_config.rb
+++ b/lib/opal/parser/default_config.rb
@@ -29,8 +29,9 @@ module Opal
       end
 
       def parse(source_buffer)
-        parsed = super
-        rewriten = rewrite(parsed)
+        parsed = super || ::Opal::AST::Node.new(:nil)
+        wrapped = ::Opal::AST::Node.new(:top, [parsed])
+        rewriten = rewrite(wrapped)
         rewriten
       end
 

--- a/lib/opal/rewriter.rb
+++ b/lib/opal/rewriter.rb
@@ -19,6 +19,8 @@ require 'opal/rewriters/forward_args'
 
 module Opal
   class Rewriter
+    @disabled = false
+
     class << self
       def list
         @list ||= []
@@ -32,15 +34,21 @@ module Opal
         list.delete(rewriter)
       end
 
-      def disable
-        @disabled = true
+      def disable(except: nil)
+        old_disabled = @disabled
+        @disabled = except || true
         yield
       ensure
-        @disabled = false
+        @disabled = old_disabled
       end
 
       def disabled?
-        @disabled if defined?(@disabled)
+        @disabled == true
+      end
+
+      def rewritter_disabled?(rewriter)
+        return false if @disabled == false
+        @disabled != rewriter
       end
     end
 
@@ -69,6 +77,7 @@ module Opal
       return @sexp if self.class.disabled?
 
       self.class.list.each do |rewriter_class|
+        next if self.class.rewritter_disabled?(rewriter_class)
         rewriter = rewriter_class.new
         @sexp = rewriter.process(@sexp)
       end

--- a/lib/opal/rewriters/base.rb
+++ b/lib/opal/rewriters/base.rb
@@ -51,7 +51,6 @@ module Opal
       end
 
       alias on_iter       process_regular_node
-      alias on_top        process_regular_node
       alias on_zsuper     process_regular_node
       alias on_jscall     on_send
       alias on_jsattr     process_regular_node
@@ -123,6 +122,18 @@ module Opal
         error = ::Opal::RewritingError.new(msg)
         error.location = current_node.loc if current_node
         raise error
+      end
+
+      def on_top(node)
+        node = process_regular_node(node)
+        node.meta[:dynamic_cache_result] = true if @dynamic_cache_result
+        node
+      end
+
+      # Called when a given transformation is deemed to be dynamic, so
+      # that cache is conditionally disabled for a given file.
+      def dynamic!
+        @dynamic_cache_result = true
       end
     end
   end

--- a/lib/opal/rewriters/rubyspec/filters_rewriter.rb
+++ b/lib/opal/rewriters/rubyspec/filters_rewriter.rb
@@ -36,6 +36,7 @@ module Opal
         _recvr, method_name, *args = *node
 
         if rubyspec_dsl?(method_name)
+          dynamic!
           spec_name, _ = *args.first
           begin
             @specs_stack.push(spec_name)

--- a/spec/lib/cli_spec.rb
+++ b/spec/lib/cli_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe Opal::CLI do
   describe ':sexp option' do
     let(:options) { {evals: ['puts 4'], sexp: true} }
     it 'prints syntax expressions for the given code' do
-      expect_output_of{ subject.run }.to eq("s(:send, nil, :puts,\n  s(:int, 4))\n")
+      expect_output_of{ subject.run }.to eq("s(:top,\n  s(:send, nil, :puts,\n    s(:int, 4)))\n")
     end
   end
 

--- a/spec/lib/rewriters/base_spec.rb
+++ b/spec/lib/rewriters/base_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Opal::Rewriters::Base do
   include RewritersHelper
 
   def body_ast_of(method_source)
-    def_ast = parse_without_rewriting(method_source)
+    def_ast = parse_without_rewriting(method_source).children.first
     _, _, body_ast = *def_ast
     body_ast
   end

--- a/spec/lib/rewriters/binary_operator_assignment_spec.rb
+++ b/spec/lib/rewriters/binary_operator_assignment_spec.rb
@@ -1,71 +1,46 @@
 require 'lib/spec_helper'
+require 'support/rewriters_helper'
 
 RSpec.describe Opal::Rewriters::BinaryOperatorAssignment do
-  def s(type, *children)
-    ::Opal::AST::Node.new(type, children)
-  end
+  include RewritersHelper
 
-  let(:rewriter) { Opal::Rewriters::BinaryOperatorAssignment.new }
+  use_only_described_rewriter!
 
-  def parse(source)
-    parser = Opal::Parser.default_parser
-    buffer = ::Opal::Parser::SourceBuffer.new('(eval)')
-    buffer.source = source
-    parser.parse(buffer)
-  end
-
-  def rewrite(ast)
-    rewriter.process(ast)
-  end
-
-  around(:each) do |e|
-    Opal::Rewriters::BinaryOperatorAssignment.reset_tmp_counter!
-    Opal::Rewriter.disable { e.run }
-  end
+  before(:each) { Opal::Rewriters::BinaryOperatorAssignment.reset_tmp_counter! }
   let(:cache_tmp_name) { :$binary_op_recvr_tmp_1 }
   let(:cached) { s(:js_tmp, cache_tmp_name) }
 
-  shared_examples 'it rewrites' do |from, to|
-    it "rewrites #{from.inspect} to #{to.inspect}" do
-      input = parse(from)
-      rewritten = rewrite(input)
-      expected = parse(to)
-
-      expect(rewritten).to eq(expected)
-    end
-  end
-
   context 'rewriting or_asgn and and_asgn nodes' do
     context 'local variable' do
-      include_examples 'it rewrites', 'a = 1; a += 2', 'a = 1; a = a + 2'
+      include_examples 'it rewrites source-to-source', 'a = 1; a += 2', 'a = 1; a = a + 2'
     end
 
     context 'instance variable' do
-      include_examples 'it rewrites', '@a += 1', '@a = @a + 1'
+      include_examples 'it rewrites source-to-source', '@a += 1', '@a = @a + 1'
     end
 
     context 'constant' do
-      include_examples 'it rewrites', 'CONST += 1', 'CONST = CONST + 1'
+      include_examples 'it rewrites source-to-source', 'CONST += 1', 'CONST = CONST + 1'
     end
 
     context 'global variable' do
-      include_examples 'it rewrites', '$g += 1', '$g = $g + 1'
+      include_examples 'it rewrites source-to-source', '$g += 1', '$g = $g + 1'
     end
 
     context 'class variable' do
-      include_examples 'it rewrites', '@@a += 1', '@@a = @@a + 1'
+      include_examples 'it rewrites source-to-source', '@@a += 1', '@@a = @@a + 1'
     end
 
     context 'simple method call' do
-      include_examples 'it rewrites', 'recvr = 1; recvr.meth += rhs', 'recvr = 1; recvr.meth = recvr.meth + rhs'
+      include_examples 'it rewrites source-to-source', 'recvr = 1; recvr.meth += rhs', 'recvr = 1; recvr.meth = recvr.meth + rhs'
     end
 
     context '[] / []= method call' do
-      include_examples 'it rewrites', 'recvr = 1; recvr[idx] += rhs', 'recvr = 1; recvr[idx] = recvr[idx] + rhs'
+      include_examples 'it rewrites source-to-source', 'recvr = 1; recvr[idx] += rhs', 'recvr = 1; recvr[idx] = recvr[idx] + rhs'
     end
 
     context '[] / []= method call with multiple arguments' do
-      include_examples 'it rewrites',
+      include_examples 'it rewrites source-to-source',
         'recvr = 1; recvr[idx1, idx2] += rhs',
           'recvr = 1; recvr[idx1, idx2] = recvr[idx1, idx2] + rhs'
     end
@@ -73,15 +48,15 @@ RSpec.describe Opal::Rewriters::BinaryOperatorAssignment do
     context 'chain of method calls' do
       it 'rewrites += by caching receiver to a temporary local variable' do
         input = parse('recvr.a.b += rhs')
-        rewritten = rewrite(input)
+        rewritten = rewrite(input).children.first
 
         expected = s(:begin,
-          s(:lvasgn, cache_tmp_name, parse('recvr.a')), # cached = recvr.a
+          s(:lvasgn, cache_tmp_name, ast_of('recvr.a')), # cached = recvr.a
           s(:send, cached, :b=,
             s(:send,
               s(:send, cached, :b),
               :+,
-              parse('rhs'))))
+              ast_of('rhs'))))
 
         expect(rewritten).to eq(expected)
       end
@@ -90,19 +65,19 @@ RSpec.describe Opal::Rewriters::BinaryOperatorAssignment do
     context 'method call using safe nafigator' do
       it 'rewrites += by caching receiver and rewriting it to if and or_asgn' do
         input = parse('recvr&.meth += rhs')
-        rewritten = rewrite(input)
+        rewritten = rewrite(input).children.first
 
         expected = s(:begin,
-          s(:lvasgn, cache_tmp_name, parse('recvr')), # cached = recvr
-          s(:if, s(:send, cached, :nil?),             # if cached.nil?
-            s(:nil),                                  #   nil
-                                                      # else
-            s(:send, cached, :meth=,                  #   cached.meth =
+          s(:lvasgn, cache_tmp_name, ast_of('recvr')), # cached = recvr
+          s(:if, s(:send, cached, :nil?),              # if cached.nil?
+            s(:nil),                                   #   nil
+                                                       # else
+            s(:send, cached, :meth=,                   #   cached.meth =
               s(:send,
-                s(:send, cached, :meth),              #     cached.meth +
+                s(:send, cached, :meth),               #     cached.meth +
                 :+,
-                parse('rhs')))                        #     rhs
-          ))                                          # end
+                ast_of('rhs')))                        #     rhs
+          ))                                           # end
 
         expect(rewritten).to eq(expected)
       end
@@ -111,43 +86,43 @@ RSpec.describe Opal::Rewriters::BinaryOperatorAssignment do
 
   context 'rewriting defined?(or_asgn) and defined?(and_asgn)' do
     context 'local variable' do
-      include_examples 'it rewrites', 'a = nil; defined?(a += 1)', 'a = nil; "assignment"'
+      include_examples 'it rewrites source-to-source', 'a = nil; defined?(a += 1)', 'a = nil; "assignment"'
     end
 
     context 'instance variable' do
-      include_examples 'it rewrites', 'defined?(@a += 1)', %q("assignment")
+      include_examples 'it rewrites source-to-source', 'defined?(@a += 1)', %q("assignment")
     end
 
     context 'constant' do
-      include_examples 'it rewrites', 'defined?(CONST += 1)', %q("assignment")
+      include_examples 'it rewrites source-to-source', 'defined?(CONST += 1)', %q("assignment")
     end
 
     context 'global variable' do
-      include_examples 'it rewrites', 'defined?($g += 1)', %q("assignment")
+      include_examples 'it rewrites source-to-source', 'defined?($g += 1)', %q("assignment")
     end
 
     context 'class variable' do
-      include_examples 'it rewrites', 'defined?(@@a += 1)', %q("assignment")
+      include_examples 'it rewrites source-to-source', 'defined?(@@a += 1)', %q("assignment")
     end
 
     context 'simple method call' do
-      include_examples 'it rewrites', 'defined?(recvr.meth += rhs)', %q("assignment")
+      include_examples 'it rewrites source-to-source', 'defined?(recvr.meth += rhs)', %q("assignment")
     end
 
     context '[] / []= method call' do
-      include_examples 'it rewrites', 'defined?(recvr[idx] += rhs)', %q("assignment")
+      include_examples 'it rewrites source-to-source', 'defined?(recvr[idx] += rhs)', %q("assignment")
     end
 
     context '[] / []= method call with multiple arguments' do
-      include_examples 'it rewrites', 'defined?(recvr[idx1, idx2] += rhs)', %q("assignment")
+      include_examples 'it rewrites source-to-source', 'defined?(recvr[idx1, idx2] += rhs)', %q("assignment")
     end
 
     context 'chain of method calls' do
-      include_examples 'it rewrites', 'defined?(recvr.a.b.c += rhs)', %q("assignment")
+      include_examples 'it rewrites source-to-source', 'defined?(recvr.a.b.c += rhs)', %q("assignment")
     end
 
     context 'method call using safe nafigator' do
-      include_examples 'it rewrites', 'defined?(recvr&.meth += rhs)', %q("assignment")
+      include_examples 'it rewrites source-to-source', 'defined?(recvr&.meth += rhs)', %q("assignment")
     end
   end
 end

--- a/spec/lib/rewriters/block_to_iter_spec.rb
+++ b/spec/lib/rewriters/block_to_iter_spec.rb
@@ -1,11 +1,8 @@
 require 'lib/spec_helper'
+require 'support/rewriters_helper'
 
 RSpec.describe Opal::Rewriters::BlockToIter do
-  def s(type, *children)
-    ::Opal::AST::Node.new(type, children)
-  end
-
-  let(:rewriter) { Opal::Rewriters::BlockToIter.new }
+  include RewritersHelper
 
   let(:block_node) do
     # m { |arg1| 1 }
@@ -23,6 +20,6 @@ RSpec.describe Opal::Rewriters::BlockToIter do
   end
 
   it 'rewriters s(:block) to s(:iter)' do
-    expect(rewriter.process(block_node)).to eq(iter_node)
+    expect(rewritten(block_node)).to eq(iter_node)
   end
 end

--- a/spec/lib/rewriters/dot_js_syntax_spec.rb
+++ b/spec/lib/rewriters/dot_js_syntax_spec.rb
@@ -1,11 +1,8 @@
 require 'lib/spec_helper'
+require 'support/rewriters_helper'
 
 RSpec.describe Opal::Rewriters::DotJsSyntax do
-  def s(type, *children)
-    ::Opal::AST::Node.new(type, children)
-  end
-
-  let(:rewriter) { Opal::Rewriters::DotJsSyntax.new }
+  include RewritersHelper
 
   context '.JS. syntax' do
     let(:send_node) do

--- a/spec/lib/rewriters/explicit_writer_return_spec.rb
+++ b/spec/lib/rewriters/explicit_writer_return_spec.rb
@@ -1,21 +1,8 @@
 require 'lib/spec_helper'
+require 'support/rewriters_helper'
 
 RSpec.describe Opal::Rewriters::ExplicitWriterReturn do
-  def s(type, *children)
-    ::Opal::AST::Node.new(type, children)
-  end
-
-  let(:rewriter) { Opal::Rewriters::ExplicitWriterReturn.new }
-  let(:processed) { rewriter.process(input) }
-
-  def expect_rewritten(sexp)
-    processed = rewriter.process(sexp)
-    expect(processed)
-  end
-
-  def expect_no_rewriting_for(sexp)
-    expect_rewritten(sexp).to eq(sexp)
-  end
+  include RewritersHelper
 
   let(:receiver) do
     # self.a

--- a/spec/lib/rewriters/for_rewriter_spec.rb
+++ b/spec/lib/rewriters/for_rewriter_spec.rb
@@ -4,7 +4,6 @@ require 'opal/rewriters/for_rewriter'
 
 RSpec.describe Opal::Rewriters::ForRewriter do
   include RewritersHelper
-  extend  RewritersHelper
 
   before(:each) { Opal::Rewriters::ForRewriter.reset_tmp_counter! }
 

--- a/spec/lib/rewriters/forward_args_spec.rb
+++ b/spec/lib/rewriters/forward_args_spec.rb
@@ -4,7 +4,6 @@ require 'opal/rewriters/forward_args'
 
 RSpec.describe Opal::Rewriters::ForwardArgs do
   include RewritersHelper
-  extend  RewritersHelper
 
   before(:each) { Opal::Rewriters::ForRewriter.reset_tmp_counter! }
 
@@ -23,7 +22,7 @@ RSpec.describe Opal::Rewriters::ForwardArgs do
     end
   end
 
-  include_examples 'it rewrites source-to-AST', <<~ENDSOURCE, correct_names.(parse(<<~ENDDEST))
+  include_examples 'it rewrites source-to-AST', <<~ENDSOURCE, correct_names.(ast_of(<<~ENDDEST))
     def forward(...)
       other(...)
     end
@@ -33,7 +32,7 @@ RSpec.describe Opal::Rewriters::ForwardArgs do
     end
   ENDDEST
 
-  include_examples 'it rewrites source-to-AST', <<~ENDSOURCE, correct_names.(parse(<<~ENDDEST))
+  include_examples 'it rewrites source-to-AST', <<~ENDSOURCE, correct_names.(ast_of(<<~ENDDEST))
     def forward(first_arg, ...)
       other(first_arg, second_arg, ...)
       other(other_arg, ...)

--- a/spec/lib/rewriters/js_reserved_words_spec.rb
+++ b/spec/lib/rewriters/js_reserved_words_spec.rb
@@ -1,21 +1,8 @@
 require 'lib/spec_helper'
+require 'support/rewriters_helper'
 
 RSpec.describe Opal::Rewriters::JsReservedWords do
-  def s(type, *children)
-    ::Opal::AST::Node.new(type, children)
-  end
-
-  def rewrite(sexp)
-    Opal::Rewriters::JsReservedWords.new.process(sexp)
-  end
-
-  def expect_rewritten(sexp)
-    expect(rewrite(sexp))
-  end
-
-  def expect_no_rewriting_for(sexp)
-    expect_rewritten(sexp).to eq(sexp)
-  end
+  include RewritersHelper
 
   reserved_lvars = %i(
     do if in for let new try var case else enum eval false

--- a/spec/lib/rewriters/logical_operator_assignment_spec.rb
+++ b/spec/lib/rewriters/logical_operator_assignment_spec.rb
@@ -1,82 +1,57 @@
 require 'lib/spec_helper'
+require 'support/rewriters_helper'
 
 RSpec.describe Opal::Rewriters::LogicalOperatorAssignment do
-  def s(type, *children)
-    ::Opal::AST::Node.new(type, children)
-  end
+  include RewritersHelper
 
-  let(:rewriter) { Opal::Rewriters::LogicalOperatorAssignment.new }
+  use_only_described_rewriter!
 
-  def parse(source)
-    parser = Opal::Parser.default_parser
-    buffer = ::Opal::Parser::SourceBuffer.new('(eval)')
-    buffer.source = source
-    parser.parse(buffer)
-  end
-
-  def rewrite(ast)
-    rewriter.process(ast)
-  end
-
-  around(:each) do |e|
-    Opal::Rewriters::LogicalOperatorAssignment.reset_tmp_counter!
-    Opal::Rewriter.disable { e.run }
-  end
+  before(:each) { Opal::Rewriters::LogicalOperatorAssignment.reset_tmp_counter! }
   let(:cache_tmp_name) { :$logical_op_recvr_tmp_1 }
   let(:cached) { s(:js_tmp, cache_tmp_name) }
 
-  shared_examples 'it rewrites' do |from, to|
-    it "rewrites #{from.inspect} to #{to.inspect}" do
-      input = parse(from)
-      rewritten = rewrite(input)
-      expected = parse(to)
-
-      expect(rewritten).to eq(expected)
-    end
-  end
-
   context 'rewriting or_asgn and and_asgn nodes' do
     context 'local variable' do
-      include_examples 'it rewrites', 'a = local; a ||= 1', 'a = local; a = a || 1'
-      include_examples 'it rewrites', 'a = local; a &&= 1', 'a = local; a = a && 1'
+      include_examples 'it rewrites source-to-source', 'a = local; a ||= 1', 'a = local; a = a || 1'
+      include_examples 'it rewrites source-to-source', 'a = local; a &&= 1', 'a = local; a = a && 1'
     end
 
     context 'instance variable' do
-      include_examples 'it rewrites', '@a ||= 1', '@a = @a || 1'
-      include_examples 'it rewrites', '@a &&= 1', '@a = @a && 1'
+      include_examples 'it rewrites source-to-source', '@a ||= 1', '@a = @a || 1'
+      include_examples 'it rewrites source-to-source', '@a &&= 1', '@a = @a && 1'
     end
 
     context 'constant' do
-      include_examples 'it rewrites', 'CONST ||= 1', 'CONST = defined?(CONST) ? (CONST || 1) : 1'
-      include_examples 'it rewrites', 'CONST &&= 1', 'CONST = CONST && 1'
+      include_examples 'it rewrites source-to-source', 'CONST ||= 1', 'CONST = defined?(CONST) ? (CONST || 1) : 1'
+      include_examples 'it rewrites source-to-source', 'CONST &&= 1', 'CONST = CONST && 1'
     end
 
     context 'global variable' do
-      include_examples 'it rewrites', '$g ||= 1', '$g = $g || 1'
-      include_examples 'it rewrites', '$g &&= 1', '$g = $g && 1'
+      include_examples 'it rewrites source-to-source', '$g ||= 1', '$g = $g || 1'
+      include_examples 'it rewrites source-to-source', '$g &&= 1', '$g = $g && 1'
     end
 
     context 'class variable' do
-      include_examples 'it rewrites', '@@a ||= 1', '@@a = defined?(@@a) ? (@@a || 1) : 1'
-      include_examples 'it rewrites', '@@a &&= 1', '@@a = @@a && 1'
+      include_examples 'it rewrites source-to-source', '@@a ||= 1', '@@a = defined?(@@a) ? (@@a || 1) : 1'
+      include_examples 'it rewrites source-to-source', '@@a &&= 1', '@@a = @@a && 1'
     end
 
     context 'simple method call' do
-      include_examples 'it rewrites', 'recvr = 1; recvr.meth ||= rhs', 'recvr = 1; recvr.meth || recvr.meth = rhs'
-      include_examples 'it rewrites', 'recvr = 1; recvr.meth &&= rhs', 'recvr = 1; recvr.meth && recvr.meth = rhs'
+      include_examples 'it rewrites source-to-source', 'recvr = 1; recvr.meth ||= rhs', 'recvr = 1; recvr.meth || recvr.meth = rhs'
+      include_examples 'it rewrites source-to-source', 'recvr = 1; recvr.meth &&= rhs', 'recvr = 1; recvr.meth && recvr.meth = rhs'
     end
 
     context '[] / []= method call' do
-      include_examples 'it rewrites', 'recvr = 1; recvr[idx] ||= rhs', 'recvr = 1; recvr[idx] || recvr[idx] = rhs'
-      include_examples 'it rewrites', 'recvr = 1; recvr[idx] &&= rhs', 'recvr = 1; recvr[idx] && recvr[idx] = rhs'
+      include_examples 'it rewrites source-to-source', 'recvr = 1; recvr[idx] ||= rhs', 'recvr = 1; recvr[idx] || recvr[idx] = rhs'
+      include_examples 'it rewrites source-to-source', 'recvr = 1; recvr[idx] &&= rhs', 'recvr = 1; recvr[idx] && recvr[idx] = rhs'
     end
 
     context '[] / []= method call with multiple arguments' do
-      include_examples 'it rewrites',
+      include_examples 'it rewrites source-to-source',
         'recvr = 1; recvr[idx1, idx2] ||= rhs',
           'recvr = 1; recvr[idx1, idx2] || recvr[idx1, idx2] = rhs'
 
-      include_examples 'it rewrites',
+      include_examples 'it rewrites source-to-source',
         'recvr = 1; recvr[idx1, idx2] &&= rhs',
           'recvr = 1; recvr[idx1, idx2] && recvr[idx1, idx2] = rhs'
     end
@@ -84,26 +59,26 @@ RSpec.describe Opal::Rewriters::LogicalOperatorAssignment do
     context 'chain of method calls' do
       it 'rewrites ||= by caching receiver to a temporary local variable' do
         input = parse('recvr.a.b ||= rhs')
-        rewritten = rewrite(input)
+        rewritten = rewrite(input).children.first
 
         expected = s(:begin,
-          s(:lvasgn, cache_tmp_name, parse('recvr.a')), # cached = recvr.a
+          s(:lvasgn, cache_tmp_name, ast_of('recvr.a')), # cached = recvr.a
           s(:or,
-            s(:send, cached, :b),                       # cached.b
-            s(:send, cached, :b=, parse('rhs'))))       # cached.b = rhs
+            s(:send, cached, :b),                        # cached.b ||
+            s(:send, cached, :b=, ast_of('rhs'))))       # cached.b = rhs
 
         expect(rewritten).to eq(expected)
       end
 
       it 'rewrites &&= by caching receiver to a temporary local variable' do
         input = parse('recvr.a.b &&= rhs')
-        rewritten = rewrite(input)
+        rewritten = rewrite(input).children.first
 
         expected = s(:begin,
-          s(:lvasgn, cache_tmp_name, parse('recvr.a')), # cached = recvr.a
+          s(:lvasgn, cache_tmp_name, ast_of('recvr.a')), # cached = recvr.a
           s(:and,
-            s(:send, cached, :b),                       # cached.b
-            s(:send, cached, :b=, parse('rhs'))))       # cached.b = rhs
+            s(:send, cached, :b),                        # cached.b ||
+            s(:send, cached, :b=, ast_of('rhs'))))       # cached.b = rhs
 
         expect(rewritten).to eq(expected)
       end
@@ -112,17 +87,17 @@ RSpec.describe Opal::Rewriters::LogicalOperatorAssignment do
     context 'method call using safe nafigator' do
       it 'rewrites ||= by caching receiver and rewriting it to if and or_asgn' do
         input = parse('recvr&.meth ||= rhs')
-        rewritten = rewrite(input)
+        rewritten = rewrite(input).children.first
 
         expected = s(:begin,
-          s(:lvasgn, cache_tmp_name, parse('recvr')), # cached = recvr
-          s(:if, s(:send, cached, :nil?),             # if cached.nil?
-            s(:nil),                                  #   nil
-                                                      # else
+          s(:lvasgn, cache_tmp_name, ast_of('recvr')), # cached = recvr
+          s(:if, s(:send, cached, :nil?),              # if cached.nil?
+            s(:nil),                                   #   nil
+                                                       # else
             s(:or,
-              s(:send, cached, :meth),                #   cached.meth ||
-              s(:send, cached, :meth=, parse('rhs'))) #     cached.meth = rhs
-            )                                         # end
+              s(:send, cached, :meth),                 #   cached.meth ||
+              s(:send, cached, :meth=, ast_of('rhs'))) #     cached.meth = rhs
+            )                                          # end
           )
 
         expect(rewritten).to eq(expected)
@@ -130,17 +105,17 @@ RSpec.describe Opal::Rewriters::LogicalOperatorAssignment do
 
       it 'rewrites &&= by caching receiver and rewriting it to if and or_asgn' do
         input = parse('recvr&.meth &&= rhs')
-        rewritten = rewrite(input)
+        rewritten = rewrite(input).children.first
 
         expected = s(:begin,
-          s(:lvasgn, cache_tmp_name, parse('recvr')), # cached = recvr
-          s(:if, s(:send, cached, :nil?),             # if cached.nil?
-            s(:nil),                                  #   nil
-                                                      # else
+          s(:lvasgn, cache_tmp_name, ast_of('recvr')), # cached = recvr
+          s(:if, s(:send, cached, :nil?),              # if cached.nil?
+            s(:nil),                                   #   nil
+                                                       # else
             s(:and,
-              s(:send, cached, :meth),                #   cached.meth ||
-              s(:send, cached, :meth=, parse('rhs'))) #     cached.meth = rhs
-            )                                         # end
+              s(:send, cached, :meth),                 #   cached.meth &&
+              s(:send, cached, :meth=, ast_of('rhs'))) #     cached.meth = rhs
+            )                                          # end
           )
 
         expect(rewritten).to eq(expected)
@@ -150,53 +125,53 @@ RSpec.describe Opal::Rewriters::LogicalOperatorAssignment do
 
   context 'rewriting defined?(or_asgn) and defined?(and_asgn)' do
     context 'local variable' do
-      include_examples 'it rewrites', 'a = nil; defined?(a ||= 1)', 'a = nil; "assignment"'
-      include_examples 'it rewrites', 'a = nil; defined?(a &&= 1)', 'a = nil; "assignment"'
+      include_examples 'it rewrites source-to-source', 'a = nil; defined?(a ||= 1)', 'a = nil; "assignment"'
+      include_examples 'it rewrites source-to-source', 'a = nil; defined?(a &&= 1)', 'a = nil; "assignment"'
     end
 
     context 'instance variable' do
-      include_examples 'it rewrites', 'defined?(@a ||= 1)', %q("assignment")
-      include_examples 'it rewrites', 'defined?(@a &&= 1)', %q("assignment")
+      include_examples 'it rewrites source-to-source', 'defined?(@a ||= 1)', %q("assignment")
+      include_examples 'it rewrites source-to-source', 'defined?(@a &&= 1)', %q("assignment")
     end
 
     context 'constant' do
-      include_examples 'it rewrites', 'defined?(CONST ||= 1)', %q("assignment")
-      include_examples 'it rewrites', 'defined?(CONST &&= 1)', %q("assignment")
+      include_examples 'it rewrites source-to-source', 'defined?(CONST ||= 1)', %q("assignment")
+      include_examples 'it rewrites source-to-source', 'defined?(CONST &&= 1)', %q("assignment")
     end
 
     context 'global variable' do
-      include_examples 'it rewrites', 'defined?($g ||= 1)', %q("assignment")
-      include_examples 'it rewrites', 'defined?($g &&= 1)', %q("assignment")
+      include_examples 'it rewrites source-to-source', 'defined?($g ||= 1)', %q("assignment")
+      include_examples 'it rewrites source-to-source', 'defined?($g &&= 1)', %q("assignment")
     end
 
     context 'class variable' do
-      include_examples 'it rewrites', 'defined?(@@a ||= 1)', %q("assignment")
-      include_examples 'it rewrites', 'defined?(@@a &&= 1)', %q("assignment")
+      include_examples 'it rewrites source-to-source', 'defined?(@@a ||= 1)', %q("assignment")
+      include_examples 'it rewrites source-to-source', 'defined?(@@a &&= 1)', %q("assignment")
     end
 
     context 'simple method call' do
-      include_examples 'it rewrites', 'defined?(recvr.meth ||= rhs)', %q("assignment")
-      include_examples 'it rewrites', 'defined?(recvr.meth &&= rhs)', %q("assignment")
+      include_examples 'it rewrites source-to-source', 'defined?(recvr.meth ||= rhs)', %q("assignment")
+      include_examples 'it rewrites source-to-source', 'defined?(recvr.meth &&= rhs)', %q("assignment")
     end
 
     context '[] / []= method call' do
-      include_examples 'it rewrites', 'defined?(recvr[idx] ||= rhs)', %q("assignment")
-      include_examples 'it rewrites', 'defined?(recvr[idx] &&= rhs)', %q("assignment")
+      include_examples 'it rewrites source-to-source', 'defined?(recvr[idx] ||= rhs)', %q("assignment")
+      include_examples 'it rewrites source-to-source', 'defined?(recvr[idx] &&= rhs)', %q("assignment")
     end
 
     context '[] / []= method call with multiple arguments' do
-      include_examples 'it rewrites', 'defined?(recvr[idx1, idx2] ||= rhs)', %q("assignment")
-      include_examples 'it rewrites', 'defined?(recvr[idx1, idx2] &&= rhs)', %q("assignment")
+      include_examples 'it rewrites source-to-source', 'defined?(recvr[idx1, idx2] ||= rhs)', %q("assignment")
+      include_examples 'it rewrites source-to-source', 'defined?(recvr[idx1, idx2] &&= rhs)', %q("assignment")
     end
 
     context 'chain of method calls' do
-      include_examples 'it rewrites', 'defined?(recvr.a.b.c ||= rhs)', %q("assignment")
-      include_examples 'it rewrites', 'defined?(recvr.a.b.c &&= rhs)', %q("assignment")
+      include_examples 'it rewrites source-to-source', 'defined?(recvr.a.b.c ||= rhs)', %q("assignment")
+      include_examples 'it rewrites source-to-source', 'defined?(recvr.a.b.c &&= rhs)', %q("assignment")
     end
 
     context 'method call using safe nafigator' do
-      include_examples 'it rewrites', 'defined?(recvr&.meth ||= rhs)', %q("assignment")
-      include_examples 'it rewrites', 'defined?(recvr&.meth &&= rhs)', %q("assignment")
+      include_examples 'it rewrites source-to-source', 'defined?(recvr&.meth ||= rhs)', %q("assignment")
+      include_examples 'it rewrites source-to-source', 'defined?(recvr&.meth &&= rhs)', %q("assignment")
     end
   end
 end

--- a/spec/lib/rewriters/numblocks_spec.rb
+++ b/spec/lib/rewriters/numblocks_spec.rb
@@ -4,9 +4,7 @@ require 'opal/rewriters/numblocks'
 
 RSpec.describe Opal::Rewriters::Numblocks do
   include RewritersHelper
-  extend  RewritersHelper
-
-  before(:each) { Opal::Rewriters::ForRewriter.reset_tmp_counter! }
+  extend RewritersHelper # s() in example scope
 
   correct_names = proc do |ast|
     case ast
@@ -22,7 +20,7 @@ RSpec.describe Opal::Rewriters::Numblocks do
     end
   end
 
-  include_examples 'it rewrites source-to-AST', <<~ENDSOURCE, correct_names.(parse(<<~ENDDEST))
+  include_examples 'it rewrites source-to-AST', <<~ENDSOURCE, correct_names.(ast_of(<<~ENDDEST))
     proc do
       _1
     end
@@ -32,7 +30,7 @@ RSpec.describe Opal::Rewriters::Numblocks do
     end
   ENDDEST
 
-  include_examples 'it rewrites source-to-AST', <<~ENDSOURCE, correct_names.(parse(<<~ENDDEST))
+  include_examples 'it rewrites source-to-AST', <<~ENDSOURCE, correct_names.(ast_of(<<~ENDDEST))
     proc do
       _3
     end

--- a/spec/lib/rewriters/opal_engine_check_spec.rb
+++ b/spec/lib/rewriters/opal_engine_check_spec.rb
@@ -1,20 +1,8 @@
 require 'lib/spec_helper'
+require 'support/rewriters_helper'
 
 RSpec.describe Opal::Rewriters::OpalEngineCheck do
-  def s(type, *children)
-    ::Opal::AST::Node.new(type, children)
-  end
-
-  let(:rewriter) { Opal::Rewriters::OpalEngineCheck.new }
-
-  def expect_rewritten(node)
-    processed = rewriter.process(node)
-    expect(processed)
-  end
-
-  def expect_no_rewriting_for(node)
-    expect_rewritten(node).to eq(node)
-  end
+  include RewritersHelper
 
   let(:opal_str_sexp) { s(:str, 'opal') }
   let(:true_branch) { s(:int, 1) }

--- a/spec/lib/rewriters/rubyspec/filters_rewriter_spec.rb
+++ b/spec/lib/rewriters/rubyspec/filters_rewriter_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Opal::Rubyspec::FiltersRewriter do
     SOURCE
   end
 
-  let(:ast) { ast_of(source) }
+  let(:ast) { parse(source) }
 
   context 'when spec is filtered' do
     around(:each) do |e|
@@ -44,16 +44,24 @@ RSpec.describe Opal::Rubyspec::FiltersRewriter do
       SOURCE
     end
 
-    let(:expected_ast) { ast_of(rewritten_source) }
+    let(:expected_ast) { parse(rewritten_source) }
 
     it 'replaces it with nil' do
       expect_rewritten(ast).to eq(expected_ast)
+    end
+
+    it 'disables cache' do
+      expect(rewritten(ast).meta[:dynamic_cache_result]).to be_truthy
     end
   end
 
   context 'when spec is not filtered' do
     it 'does not rewrite it' do
       expect_no_rewriting_for(ast)
+    end
+
+    it 'disables cache' do
+      expect(rewritten(ast).meta[:dynamic_cache_result]).to be_truthy
     end
   end
 end

--- a/spec/support/rewriters_helper.rb
+++ b/spec/support/rewriters_helper.rb
@@ -1,13 +1,47 @@
 module RewritersHelper
-  def s(type, *children)
-    ::Opal::AST::Node.new(type, children)
+  module Common
+    def s(type, *children)
+      ::Opal::AST::Node.new(type, children)
+    end
+
+    def parse(source)
+      buffer = Opal::Parser::SourceBuffer.new('(eval)')
+      buffer.source = source
+      parser = Opal::Parser.default_parser
+      parser.parse(buffer)
+    end
+
+    # Parse, but drop the :top node
+    def ast_of(source)
+      parse(source).children.first
+    end
   end
 
-  def rewritten(ast)
-    described_class.new.process(ast)
+  module DSL
+    def use_only_described_rewriter!
+      around(:each) do |e|
+        Opal::Rewriter.disable(except: described_class) { e.run }
+      end
+    end
   end
 
-  alias :rewrite :rewritten
+  include Common
+
+  def self.included(klass)
+    klass.extend(Common)
+    klass.extend(DSL)
+  end
+
+  def rewriter
+    described_class.new
+  end
+
+  def rewritten(ast = input)
+    rewriter.process(ast)
+  end
+
+  alias rewrite rewritten
+  alias processed rewritten
 
   def expect_rewritten(ast)
     expect(rewritten(ast))
@@ -17,28 +51,15 @@ module RewritersHelper
     expect_rewritten(ast).to eq(ast)
   end
 
-  def parse(source)
-    buffer = Opal::Parser::SourceBuffer.new('(eval)')
-    buffer.source = source
-    parser = Opal::Parser.default_parser
-    parser.parse(buffer)
-  end
-
-  alias :ast_of :parse
-
   def parse_without_rewriting(source)
-    buffer = Opal::Parser::SourceBuffer.new('(eval)')
-    buffer.source = source
-    parser = Parser::Ruby31.new
-    parser.parse(buffer)
+    Opal::Rewriter.disable { parse(source) }
   end
 end
 
 RSpec.shared_examples 'it rewrites source-to-source' do |from_source, to_source|
   it "rewrites source #{from_source} to source #{to_source}" do
-    initial = ast_of(from_source)
-    rewritten = self.rewritten(initial)
-    expected = ast_of(to_source)
+    rewritten = parse(from_source)
+    expected = parse(to_source)
 
     expect(rewritten).to eq(expected)
   end
@@ -46,8 +67,7 @@ end
 
 RSpec.shared_examples 'it rewrites source-to-AST' do |from_source, to_ast|
   it "rewrites source #{from_source} to AST #{to_ast}" do
-    initial = ast_of(from_source)
-    rewritten = self.rewritten(initial)
+    rewritten = parse(from_source).children.first
 
     expect(rewritten).to eq(to_ast)
   end


### PR DESCRIPTION
Rewriters refactor:
    
* The :top node is created before rewriting now.
* Allow for a rewriter to mark content as dynamic, bypassing cache
* mspec filters rewriter to mark spec files as dynamic, fixing #2343,
  but also in turn requiring specs to be recompiled

Fix and clean up the rewriter specs
