### PR TITLE
Fix exception during Hash#each and Hash#each_key if keys get deleted during loop

### DIFF
--- a/opal/corelib/hash.rb
+++ b/opal/corelib/hash.rb
@@ -423,7 +423,7 @@ class ::Hash
     return enum_for(:each) { size } unless block
 
     %x{
-      for (var i = 0, keys = self.$$keys, length = keys.length, key, value; i < length; i++) {
+      for (var i = 0, keys = self.$$keys.slice(), length = keys.length, key, value; i < length; i++) {
         key = keys[i];
 
         if (key.$$is_string) {
@@ -444,7 +444,7 @@ class ::Hash
     return enum_for(:each_key) { size } unless block
 
     %x{
-      for (var i = 0, keys = self.$$keys, length = keys.length, key; i < length; i++) {
+      for (var i = 0, keys = self.$$keys.slice(), length = keys.length, key; i < length; i++) {
         key = keys[i];
 
         block(key.$$is_string ? key : key.key);

--- a/spec/filters/bugs/hash.rb
+++ b/spec/filters/bugs/hash.rb
@@ -22,7 +22,6 @@ opal_filter "Hash" do
   fails "Hash#invert compares new keys with eql? semantics" # spec relies on integer and float being different
   fails "Hash#rehash removes duplicate keys for large hashes" # Expected 102 == 101 to be truthy but was false
   fails "Hash#rehash removes duplicate keys" # Expected 2 to equal 1
-  fails "Hash#shift allows shifting entries while iterating" # Exception: Cannot read property '$$is_string' of undefined
   fails "Hash#store does not dispatch to hash for Boolean, Integer, Float, String, or Symbol" # NoMethodError: undefined method `insert' for "rubyexe.rb"
   fails "Hash#store keeps the existing String key in the hash if there is a matching one" # Expected "foo" not to be identical to "foo"
   fails "Hash#to_h with block does not coerce returned pair to Array with #to_a" # Expected TypeError (/wrong element type MockObject/) but no exception was raised ({"a"=>1} was returned)

--- a/spec/filters/bugs/hash.rb
+++ b/spec/filters/bugs/hash.rb
@@ -9,7 +9,6 @@ opal_filter "Hash" do
   fails "Hash#[]= does not dispatch to hash for Boolean, Integer, Float, String, or Symbol" # NoMethodError: undefined method `insert' for "rubyexe.rb"
   fails "Hash#[]= keeps the existing String key in the hash if there is a matching one" # Expected "foo" not to be identical to "foo"
   fails "Hash#compare_by_identity gives different identity for string literals" # Expected [2] to equal [1, 2]
-  fails "Hash#delete allows removing a key while iterating" # Exception: Cannot read property '$$is_string' of undefined
   fails "Hash#each always yields an Array of 2 elements, even when given a callable of arity 2" # Expected ArgumentError but no exception was raised ({"a"=>1} was returned)
   fails "Hash#each_pair always yields an Array of 2 elements, even when given a callable of arity 2" # Expected ArgumentError but no exception was raised ({"a"=>1} was returned)
   fails "Hash#eql? compares keys with eql? semantics" # spec relies on integer and float being different


### PR DESCRIPTION
Given the following ruby:
```ruby
o = { a: 1, b: 2, c: 3 }
h = o.dup
h.each { |k,v| h.delete(k) }
i = o.dup
i.each_key { |k| i.delete(k) }
puts "o: #{o}\nh: #{h}\ni: #{i}"
```
and executed with matz ruby results in the following expected output:
```
o: {:a=>1, :b=>2, :c=>3}
h: {}
i: {}
```
However, using opal master the following exceptions are thrown (need to comment out the .each ain above code to get the second exception):
```
<internal:corelib/hash.rb>:429:1:in `each': Cannot read properties of undefined (reading '$$is_string') (Exception)
        from <internal:corelib/runtime.js>:1900:5:in `Opal.send2'
        from <internal:corelib/runtime.js>:1888:5:in `each'
        from test.rb:3:2:in `undefined'
        from <internal:corelib/runtime.js>:2760:7:in `<main>'
        from test.rb:1:1:in `null'
        from node:internal/modules/cjs/loader:1103:14:in `Module._compile'
        from node:internal/modules/cjs/loader:1155:10:in `Module._extensions..js'
        from node:internal/modules/cjs/loader:981:32:in `Module.load'
        from node:internal/modules/cjs/loader:822:12:in `Module._load'
        
<internal:corelib/hash.rb>:450:1:in `each_key': Cannot read properties of undefined (reading '$$is_string') (Exception)
        from <internal:corelib/runtime.js>:1900:5:in `Opal.send2'
        from <internal:corelib/runtime.js>:1888:5:in `each_key'
        from test.rb:5:2:in `undefined'
        from <internal:corelib/runtime.js>:2760:7:in `<main>'
        from test.rb:1:1:in `null'
        from node:internal/modules/cjs/loader:1103:14:in `Module._compile'
        from node:internal/modules/cjs/loader:1155:10:in `Module._extensions..js'
        from node:internal/modules/cjs/loader:981:32:in `Module.load'
        from node:internal/modules/cjs/loader:822:12:in `Module._load'
```

This happens because the original $$keys aray is used for the loop. If that gets modified during the loop, the indexes fail to match during the loop, resulting in `null` keys and failing.

The patch copies the $$keys using .slice() (the supposedly fastest way to copy arrays) before entering the loop:

```
o: {"a"=>1, "b"=>2, "c"=>3}
h: {}
i: {}
```
