### PR TITLE
Try to compile case statements as switch

### DIFF
--- a/lib/opal/ast/matcher.rb
+++ b/lib/opal/ast/matcher.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'ast'
+require 'parser/ast/node'
+
+module Opal
+  module AST
+    class Matcher
+      def initialize(&block)
+        @root = instance_exec(&block)
+      end
+
+      def s(type, *children)
+        Node.new(type, children)
+      end
+
+      def cap(capture)
+        Node.new(:capture, [capture])
+      end
+
+      def match(ast)
+        @captures = []
+        @root.match(ast, self) || (return false)
+        @captures
+      end
+
+      def inspect
+        "#<Opal::AST::Matcher: #{@root.inspect}>"
+      end
+
+      attr_accessor :captures
+
+      Node = Struct.new(:type, :children) do
+        def match(ast, matcher)
+          return false if ast.nil?
+
+          ast_parts = [ast.type] + ast.children
+          self_parts = [type] + children
+
+          return false if ast_parts.length != self_parts.length
+
+          ast_parts.length.times.all? do |i|
+            ast_elem = ast_parts[i]
+            self_elem = self_parts[i]
+
+            if self_elem.is_a?(Node) && self_elem.type == :capture
+              capture = true
+              self_elem = self_elem.children.first
+            end
+
+            res = case self_elem
+                  when Node
+                    self_elem.match(ast_elem, matcher)
+                  when Array
+                    self_elem.include?(ast_elem)
+                  when :*
+                    true
+                  else
+                    self_elem == ast_elem
+                  end
+
+            matcher.captures << ast_elem if capture
+            res
+          end
+        end
+
+        def inspect
+          if type == :capture
+            "{#{children.first.inspect}}"
+          else
+            "s(#{type.inspect}, #{children.inspect[1..-2]})"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/opal/nodes/if.rb
+++ b/lib/opal/nodes/if.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'opal/nodes/base'
+require 'opal/ast/matcher'
 
 module Opal
   module Nodes
@@ -18,6 +19,8 @@ module Opal
           else
             compile_with_ternary
           end
+        elsif could_become_switch?
+          compile_with_switch
         else
           compile_with_if
         end
@@ -156,6 +159,225 @@ module Opal
           end
         else
           true
+        end
+      end
+
+      # NOTE: all following matcher will act on case/when statements in their rewitten form:
+      #
+      #   bin/opal --sexp -e'case some_value_or_expression; when 123; when 456, 789; end'
+      #
+      #   s(:top,
+      #     s(:if,
+      #       s(:send,
+      #         s(:int, 123), :===,
+      #         s(:lvasgn, "$ret_or_1",
+      #           s(:send, nil, :some_value_or_expression))), nil,
+      #       s(:if,
+      #         s(:if,
+      #           s(:send,
+      #             s(:int, 456), :===,
+      #             s(:js_tmp, "$ret_or_1")),
+      #           s(:true),
+      #           s(:send,
+      #             s(:int, 789), :===,
+      #             s(:js_tmp, "$ret_or_1"))), nil,
+      #         s(:nil))))
+      #
+
+      # Matches: `case some_value_or_expression; when 123`
+      # Captures: [s(:int, 123), "$ret_or_1", s(:send, nil, :some_value_or_expression))]
+      SWITCH_TEST_MATCH = AST::Matcher.new do
+        s(:send,
+          cap(s(%i[float int sym str true false nil], :*)),
+          :===,
+          s(:lvasgn, cap(:*), cap(:*))
+        )
+      end
+
+      # Matches: case some_value_or_expression; when 123, 456; end
+      # Captures: [
+      #   s(:int, 123),
+      #   "$ret_or_1",
+      #   s(:send, nil, :some_value_or_expression)),
+      #   …here we delegate to either SWITCH_BRANCH_TEST_MATCH or SWITCH_BRANCH_TEST_MATCH_CONTINUED
+      # ]
+      SWITCH_TEST_MATCH_CONTINUED = AST::Matcher.new do
+        s(:if,
+          s(:send,
+            cap(s(%i[float int sym str true false nil], :*)),
+            :===,
+            s(:lvasgn, cap(:*), cap(:*))
+          ),
+          s(:true),
+          cap(:*)
+        )
+      end
+
+      # Matches: `when 456` (from `case foo; when 123; when 456; end`)
+      # Captures: [s(:int, 456), "$ret_or_1"]
+      SWITCH_BRANCH_TEST_MATCH = AST::Matcher.new do
+        s(:send,
+          cap(s(%i[float int sym str true false nil], :*)),
+          :===,
+          s(:js_tmp, cap(:*))
+        )
+      end
+
+      # Matches: `when 456`
+      # Captures: [
+      #   s(:int, 789),
+      #   "$ret_or_1",
+      #   …here we delegate to either SWITCH_BRANCH_TEST_MATCH or SWITCH_BRANCH_TEST_MATCH_CONTINUED
+      # ]
+      SWITCH_BRANCH_TEST_MATCH_CONTINUED = AST::Matcher.new do
+        s(:if,
+          s(:send,
+            cap(s(%i[float int sym str true false nil], :*)),
+            :===,
+            s(:js_tmp, cap(:*))
+          ),
+          s(:true),
+          cap(:*)
+        )
+      end
+
+      def could_become_switch?
+        return false if expects_expression?
+
+        return true if sexp.meta[:switch_child]
+
+        test_match = SWITCH_TEST_MATCH.match(test) || SWITCH_TEST_MATCH_CONTINUED.match(test)
+        return false unless test_match
+        @switch_test, @switch_variable, @switch_first_test, additional_rules = *test_match
+
+        additional_rules = handle_additional_switch_rules(additional_rules)
+        return false unless additional_rules # It's ok for them to be empty, but false denotes a mismatch
+        @switch_additional_rules = additional_rules
+
+        return false unless valid_switch_body?(true_body)
+
+        could_become_switch_branch?(false_body)
+      end
+
+      def handle_additional_switch_rules(additional_rules)
+        switch_additional_rules = []
+        while additional_rules
+          match = SWITCH_BRANCH_TEST_MATCH.match(additional_rules) || SWITCH_BRANCH_TEST_MATCH_CONTINUED.match(additional_rules)
+          return false unless match
+
+          switch_test, switch_variable, additional_rules = *match
+          return false unless switch_variable == @switch_variable
+
+          switch_additional_rules << switch_test
+        end
+        switch_additional_rules
+      end
+
+      def could_become_switch_branch?(body)
+        if !body
+          return true
+        elsif body.type != :if
+          if valid_switch_body?(body)
+            body.meta[:switch_default] = true
+            return true
+          end
+          return false
+        end
+
+        test, true_body, false_body = *body
+
+        test_match = SWITCH_BRANCH_TEST_MATCH.match(test) || SWITCH_BRANCH_TEST_MATCH_CONTINUED.match(test)
+        unless test_match
+          if valid_switch_body?(body, true)
+            body.meta[:switch_default] = true
+            return true
+          end
+        end
+        switch_test, switch_variable, additional_rules = *test_match
+
+        switch_additional_rules = handle_additional_switch_rules(additional_rules)
+        return false unless switch_additional_rules # It's ok for them to be empty, but false denotes a mismatch
+
+        return false unless switch_variable == @switch_variable
+
+        return false unless valid_switch_body?(true_body)
+        return false unless could_become_switch_branch?(false_body)
+
+        body.meta.merge!(switch_child: true,
+                         switch_test: switch_test,
+                         switch_variable: @switch_variable,
+                         switch_additional_rules: switch_additional_rules
+        )
+
+        true
+      end
+
+      def valid_switch_body?(body, check_variable = false)
+        case body
+        when AST::Node
+          case body.type
+          when :break, :redo, :retry
+            false
+          when :iter, :while
+            # Don't traverse the iters or whiles!
+            true
+          else
+            body.children.all? { |i| valid_switch_body?(i, check_variable) }
+          end
+        when @switch_variable
+          # Perhaps we ended abruptly and we lack a $ret_or variable... but sometimes
+          # we can ignore this.
+          !check_variable
+        else
+          true
+        end
+      end
+
+      def compile_with_switch
+        if sexp.meta[:switch_child]
+          @switch_variable = sexp.meta[:switch_variable]
+          @switch_additional_rules = sexp.meta[:switch_additional_rules]
+          compile_switch_case(sexp.meta[:switch_test])
+        else
+          line "switch (", expr(@switch_first_test), ") {"
+          indent do
+            compile_switch_case(@switch_test)
+          end
+          line "}"
+        end
+      end
+
+      def returning?(body)
+        %i[return js_return next].include?(body.type) ||
+          (body.type == :begin && %i[return js_return next].include?(body.children.last.type))
+      end
+
+      def compile_switch_case(test)
+        line "case ", expr(test), ":"
+        if @switch_additional_rules
+          @switch_additional_rules.each do |rule|
+            line "case ", expr(rule), ":"
+          end
+        end
+        indent do
+          line stmt(true_body)
+          line "break;" if !true_body || !returning?(true_body)
+        end
+        if false_body
+          if false_body.meta[:switch_default]
+            compile_switch_default
+          elsif false_body.meta[:switch_child]
+            push stmt(false_body)
+          end
+        else
+          push stmt(s(:nil))
+        end
+      end
+
+      def compile_switch_default
+        line "default:"
+        indent do
+          line stmt(false_body)
         end
       end
     end


### PR DESCRIPTION
<s>Basically an experiment to improve opalopal compiler performance and something more perhaps...</s>

This improves deeply nested `case` structures, like in... lexer.
Compared to a tree of else ifs, `switch` is more like a goto, so more
likely to be more performant.
    
This makes our `ifs` (or `&&`, `||`) to be compiled to either `if`,
ternary, `&&`, `||` or `switch`, making use of all the JS control flow
features.