### PR TITLE
Properly set default rspec CLI options in .rspec

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,5 @@
 --color
---require lib/spec_helper
+--default-path spec/lib
+-I spec
+--require spec_helper
+--pattern 'spec/lib/**/*_spec.rb'

--- a/spec/lib/builder_processors_spec.rb
+++ b/spec/lib/builder_processors_spec.rb
@@ -1,4 +1,4 @@
-require 'lib/spec_helper'
+require 'spec_helper'
 require 'opal/builder_processors'
 
 RSpec.describe Opal::BuilderProcessors::JsProcessor do

--- a/spec/lib/builder_spec.rb
+++ b/spec/lib/builder_spec.rb
@@ -1,4 +1,4 @@
-require 'lib/spec_helper'
+require 'spec_helper'
 require 'opal/builder'
 
 RSpec.describe Opal::Builder do

--- a/spec/lib/cli_runners/server_spec.rb
+++ b/spec/lib/cli_runners/server_spec.rb
@@ -1,4 +1,4 @@
-require 'lib/spec_helper'
+require 'spec_helper'
 require 'opal/cli_runners'
 require 'rack/test'
 

--- a/spec/lib/cli_runners_spec.rb
+++ b/spec/lib/cli_runners_spec.rb
@@ -1,4 +1,4 @@
-require 'lib/spec_helper'
+require 'spec_helper'
 require 'opal/cli_runners'
 
 RSpec.describe Opal::CliRunners do

--- a/spec/lib/cli_spec.rb
+++ b/spec/lib/cli_spec.rb
@@ -1,4 +1,4 @@
-require 'lib/spec_helper'
+require 'spec_helper'
 require 'opal/cli'
 require 'stringio'
 require 'tmpdir'

--- a/spec/lib/compiler_spec.rb
+++ b/spec/lib/compiler_spec.rb
@@ -1,4 +1,4 @@
-require 'lib/spec_helper'
+require 'spec_helper'
 require 'support/match_helpers'
 
 RSpec.describe Opal::Compiler do

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -1,4 +1,4 @@
-require 'lib/spec_helper'
+require 'spec_helper'
 require 'opal/config'
 
 RSpec.describe Opal::Config do

--- a/spec/lib/dependency_resolver_spec.rb
+++ b/spec/lib/dependency_resolver_spec.rb
@@ -1,4 +1,4 @@
-require 'lib/spec_helper'
+require 'spec_helper'
 
 RSpec.describe Opal::Nodes::CallNode::DependencyResolver do
   let(:compiler) { double(:compiler, dynamic_require_severity: :warning) }

--- a/spec/lib/deprecations_spec.rb
+++ b/spec/lib/deprecations_spec.rb
@@ -1,4 +1,4 @@
-require 'lib/spec_helper'
+require 'spec_helper'
 require 'opal/deprecations'
 
 RSpec.describe Opal::Deprecations do

--- a/spec/lib/path_reader_spec.rb
+++ b/spec/lib/path_reader_spec.rb
@@ -1,4 +1,4 @@
-require 'lib/spec_helper'
+require 'spec_helper'
 require 'opal/path_reader'
 
 RSpec.describe Opal::PathReader do

--- a/spec/lib/paths_spec.rb
+++ b/spec/lib/paths_spec.rb
@@ -1,4 +1,4 @@
-require 'lib/spec_helper'
+require 'spec_helper'
 
 RSpec.describe 'Opal.use_gem' do
   # Coverage probably should be improved

--- a/spec/lib/repl_spec.rb
+++ b/spec/lib/repl_spec.rb
@@ -1,4 +1,4 @@
-require 'lib/spec_helper'
+require 'spec_helper'
 require 'opal/repl'
 
 RSpec.describe Opal::REPL do

--- a/spec/lib/rewriters/base_spec.rb
+++ b/spec/lib/rewriters/base_spec.rb
@@ -1,4 +1,4 @@
-require 'lib/spec_helper'
+require 'spec_helper'
 require 'support/rewriters_helper'
 require 'opal/rewriters/base'
 

--- a/spec/lib/rewriters/binary_operator_assignment_spec.rb
+++ b/spec/lib/rewriters/binary_operator_assignment_spec.rb
@@ -1,4 +1,4 @@
-require 'lib/spec_helper'
+require 'spec_helper'
 require 'support/rewriters_helper'
 
 RSpec.describe Opal::Rewriters::BinaryOperatorAssignment do

--- a/spec/lib/rewriters/block_to_iter_spec.rb
+++ b/spec/lib/rewriters/block_to_iter_spec.rb
@@ -1,4 +1,4 @@
-require 'lib/spec_helper'
+require 'spec_helper'
 require 'support/rewriters_helper'
 
 RSpec.describe Opal::Rewriters::BlockToIter do

--- a/spec/lib/rewriters/dot_js_syntax_spec.rb
+++ b/spec/lib/rewriters/dot_js_syntax_spec.rb
@@ -1,4 +1,4 @@
-require 'lib/spec_helper'
+require 'spec_helper'
 require 'support/rewriters_helper'
 
 RSpec.describe Opal::Rewriters::DotJsSyntax do

--- a/spec/lib/rewriters/for_rewriter_spec.rb
+++ b/spec/lib/rewriters/for_rewriter_spec.rb
@@ -1,4 +1,4 @@
-require 'lib/spec_helper'
+require 'spec_helper'
 require 'support/rewriters_helper'
 require 'opal/rewriters/for_rewriter'
 

--- a/spec/lib/rewriters/forward_args_spec.rb
+++ b/spec/lib/rewriters/forward_args_spec.rb
@@ -1,4 +1,4 @@
-require 'lib/spec_helper'
+require 'spec_helper'
 require 'support/rewriters_helper'
 require 'opal/rewriters/forward_args'
 

--- a/spec/lib/rewriters/hashes/key_duplicates_rewriter_spec.rb
+++ b/spec/lib/rewriters/hashes/key_duplicates_rewriter_spec.rb
@@ -1,4 +1,4 @@
-require 'lib/spec_helper'
+require 'spec_helper'
 require 'support/rewriters_helper'
 require 'opal/rewriters/hashes/key_duplicates_rewriter'
 

--- a/spec/lib/rewriters/js_reserved_words_spec.rb
+++ b/spec/lib/rewriters/js_reserved_words_spec.rb
@@ -1,4 +1,4 @@
-require 'lib/spec_helper'
+require 'spec_helper'
 require 'support/rewriters_helper'
 
 RSpec.describe Opal::Rewriters::JsReservedWords do

--- a/spec/lib/rewriters/logical_operator_assignment_spec.rb
+++ b/spec/lib/rewriters/logical_operator_assignment_spec.rb
@@ -1,4 +1,4 @@
-require 'lib/spec_helper'
+require 'spec_helper'
 require 'support/rewriters_helper'
 
 RSpec.describe Opal::Rewriters::LogicalOperatorAssignment do

--- a/spec/lib/rewriters/numblocks_spec.rb
+++ b/spec/lib/rewriters/numblocks_spec.rb
@@ -1,4 +1,4 @@
-require 'lib/spec_helper'
+require 'spec_helper'
 require 'support/rewriters_helper'
 require 'opal/rewriters/numblocks'
 

--- a/spec/lib/rewriters/opal_engine_check_spec.rb
+++ b/spec/lib/rewriters/opal_engine_check_spec.rb
@@ -1,4 +1,4 @@
-require 'lib/spec_helper'
+require 'spec_helper'
 require 'support/rewriters_helper'
 
 RSpec.describe Opal::Rewriters::OpalEngineCheck do

--- a/spec/lib/rewriters/returnable_logic_spec.rb
+++ b/spec/lib/rewriters/returnable_logic_spec.rb
@@ -1,4 +1,4 @@
-require 'lib/spec_helper'
+require 'spec_helper'
 require 'support/rewriters_helper'
 require 'opal/rewriters/for_rewriter'
 

--- a/spec/lib/rewriters/rubyspec/filters_rewriter_spec.rb
+++ b/spec/lib/rewriters/rubyspec/filters_rewriter_spec.rb
@@ -1,4 +1,4 @@
-require 'lib/spec_helper'
+require 'spec_helper'
 require 'opal/rewriters/rubyspec/filters_rewriter'
 require 'support/rewriters_helper'
 

--- a/spec/lib/simple_server_spec.rb
+++ b/spec/lib/simple_server_spec.rb
@@ -1,4 +1,4 @@
-require 'lib/spec_helper'
+require 'spec_helper'
 require 'rack/test'
 
 RSpec.describe Opal::SimpleServer do


### PR DESCRIPTION
The default folder was set to spec instead of spec/lib.