### PR TITLE
Correct String#to_proc and method_missing compatibility

### DIFF
--- a/opal/corelib/string.rb
+++ b/opal/corelib/string.rb
@@ -1315,7 +1315,7 @@ class ::String < `String`
   end
 
   def to_proc
-    method_name = '$' + `self.valueOf()`
+    method_name = `self.valueOf()`
 
     ::Kernel.proc do |*args, &block|
       %x{
@@ -1327,20 +1327,23 @@ class ::String < `String`
 
         if (recv == null) recv = nil;
 
-        var body = recv[#{method_name}];
+        var body = recv['$' + #{method_name}];
 
         if (!body) {
-          return recv.$method_missing.apply(recv, args);
+          body = recv.$method_missing;
+          args[0] = #{method_name};
+        } else {
+          args = args.slice(1);
         }
 
         if (typeof block === 'function') {
           body.$$p = block;
         }
 
-        if (args.length === 1) {
+        if (args.length === 0) {
           return body.call(recv);
         } else {
-          return body.apply(recv, args.slice(1));
+          return body.apply(recv, args);
         }
       }
     end

--- a/spec/opal/core/string/to_proc_spec.rb
+++ b/spec/opal/core/string/to_proc_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe "Symbol#to_proc" do
+  # bug #2417
+  it "correctly passes method name to #method_missing" do
+    obj = Object.new
+    def obj.method_missing(*args); args; end;
+    result = :a.to_proc.call(obj, 6, 7)
+    result.should == [:a, 6, 7]
+  end
+
+  it "correctly passes a block to #method_missing" do
+    obj = Object.new
+    block = ->{}
+    def obj.method_missing(*args, &block); block; end;
+    result = :a.to_proc.call(obj, 1, 2, 3, &block)
+    result.should == block
+  end
+end


### PR DESCRIPTION
This fixes #2417

Co-authored-by: Lionel Chauvin <megabigbug@yahoo.fr>