### PR TITLE
Make `Time.new` not depend on `Date.prototype.getTimezoneOffset()`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,7 @@ jobs:
             command: bin/rake lint
             ruby: '3.0'
           - name: timezone
+            command: bin/rake mspec_nodejs TZ="Pacific/Fiji"
             ruby: '3.0'
           - name: performance
             ruby: '3.0'

--- a/opal/corelib/time.rb
+++ b/opal/corelib/time.rb
@@ -135,7 +135,7 @@ class ::Time < `Date`
 
   def self.new(year = undefined, month = nil, day = nil, hour = nil, min = nil, sec = nil, utc_offset = nil)
     %x{
-      var args, result, timezone;
+      var args, result, timezone, utc_date;
 
       if (year === undefined) {
         return new Date();
@@ -149,19 +149,22 @@ class ::Time < `Date`
       min   = args[4];
       sec   = args[5];
 
-      result = new Date(year, month, day, hour, min, 0, sec * 1000);
+      if (utc_offset === nil) {
+        result = new Date(year, month, day, hour, min, 0, sec * 1000);
+        if (year < 100) {
+          result.setFullYear(year);
+        }
+        return result;
+      }
+
+      timezone = #{_parse_offset(utc_offset)};
+      utc_date = new Date(Date.UTC(year, month, day, hour, min, 0, sec * 1000));
       if (year < 100) {
-        result.setFullYear(year);
+        utc_date.setUTCFullYear(year);
       }
 
-      if (utc_offset !== nil) {
-        timezone = #{_parse_offset(utc_offset)};
-      }
-
-      if (timezone != null) {
-        result = new Date(result.getTime() - timezone * 3600000 - result.getTimezoneOffset() * 60000);
-        result.timezone = timezone;
-      }
+      result = new Date(utc_date.getTime() - timezone * 3600000);
+      result.timezone = timezone;
 
       return result;
     }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,10 @@ TOLERANCE = 0.00004
 
 ENV['MSPEC_RUNNER'] = true
 
+# Trigger autoloading, needed by `Module.constants`
+# in `spec/ruby/core/module/constants_spec.rb`.
+Dir
+
 module Kernel
   def opal_parse(str, file='(string)')
     Opal::Parser.new.parse str, file

--- a/tasks/testing.rake
+++ b/tasks/testing.rake
@@ -111,8 +111,8 @@ module Testing
         require 'opal/platform' # in node ENV is replaced
         #{env_data}
 
-        require 'spec_helper'
         require 'opal/full'
+        require 'spec_helper'
         require 'securerandom'
         #{enter_benchmarking_mode}
 


### PR DESCRIPTION
Fixes #2405

This is more general way than #2406.