### PR TITLE
Run performance tests on GitHub actions until ryzen is back

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
             permissive: true
             fetchdepth: '0'
             command: bin/rake performance:compare
-            os: ryzen
+            # os: ryzen
 
           # Currently failing:
           # - ruby: truffleruby


### PR DESCRIPTION
The ryzen runner is currently down, although going back to the GH runner could have more variance, it's worth a try.