### PR TITLE
Add a magic comment to mark every method defined in a file as pristine

### DIFF
--- a/lib/opal/compiler.rb
+++ b/lib/opal/compiler.rb
@@ -183,6 +183,11 @@ module Opal
     # Enables JavaScript's strict mode (i.e., adds 'use strict'; statement)
     compiler_option :use_strict, default: false, as: :use_strict?, magic_comment: true
 
+    # @!method pristine?
+    #
+    # Marks all the methods in the file as "pristine" for fast tracking in the runtime
+    compiler_option :pristine, default: false, as: :pristine?, magic_comment: true
+
     # @!method parse_comments?
     #
     # Adds comments for every method definition

--- a/lib/opal/nodes/def.rb
+++ b/lib/opal/nodes/def.rb
@@ -28,6 +28,10 @@ module Opal
           blockopts["$$source_location"] = source_location
         end
 
+        if compiler.pristine?
+          blockopts["$$pristine"] = true
+        end
+
         if blockopts.keys == ["$$arity"]
           push ", #{arity}"
         elsif !blockopts.empty?

--- a/opal/corelib/array.rb
+++ b/opal/corelib/array.rb
@@ -1,5 +1,6 @@
 # helpers: truthy, falsy, hash_ids, yield1, hash_get, hash_put, hash_delete, coerce_to, respond_to, deny_frozen_access, freeze
 # backtick_javascript: true
+# pristine: true
 
 require 'corelib/enumerable'
 require 'corelib/numeric'
@@ -2540,7 +2541,4 @@ class ::Array < `Array`
   alias size length
   alias slice []
   alias to_s inspect
-
-  ::Opal.pristine singleton_class, :allocate
-  ::Opal.pristine self, :copy_instance_variables, :initialize_dup
 end

--- a/opal/corelib/basic_object.rb
+++ b/opal/corelib/basic_object.rb
@@ -1,5 +1,6 @@
 # use_strict: true
 # backtick_javascript: true
+# pristine: true
 
 class ::BasicObject
   def initialize(*)
@@ -147,8 +148,6 @@ class ::BasicObject
       "undefined method `#{symbol}' for #{inspect_result}", symbol, args
     ), nil, ::Kernel.caller(1)
   end
-
-  ::Opal.pristine(self, :method_missing)
 
   def respond_to_missing?(method_name, include_all = false)
     false

--- a/opal/corelib/class.rb
+++ b/opal/corelib/class.rb
@@ -1,4 +1,5 @@
 # backtick_javascript: true
+# pristine: true
 
 require 'corelib/module'
 

--- a/opal/corelib/kernel.rb
+++ b/opal/corelib/kernel.rb
@@ -1,6 +1,7 @@
 # helpers: truthy, coerce_to, respond_to, Opal, deny_frozen_access, freeze, freeze_props, jsid
 # use_strict: true
 # backtick_javascript: true
+# pristine: true
 
 module ::Kernel
   def =~(obj)
@@ -735,8 +736,6 @@ module ::Kernel
   def respond_to_missing?(method_name, include_all = false)
     false
   end
-
-  ::Opal.pristine(self, :respond_to?, :respond_to_missing?)
 
   def require(file)
     %x{

--- a/opal/corelib/string.rb
+++ b/opal/corelib/string.rb
@@ -1,5 +1,6 @@
 # helpers: coerce_to, respond_to, global_multiline_regexp, prop
 # backtick_javascript: true
+# pristine: true
 
 require 'corelib/comparable'
 require 'corelib/regexp'
@@ -1887,8 +1888,6 @@ class ::String < `String`
   alias succ next
   alias to_str to_s
   alias to_sym intern
-
-  ::Opal.pristine self, :initialize
 end
 
 Symbol = String


### PR DESCRIPTION
Over time we'll probably mark the whole core library as pristine.
Pristine was also added to class.rb so Class#allocate would be marked as pristine.