### PR TITLE
Add CLI support for ESM, at least for Chrome, NodeJS, QuickJS and GJS

### DIFF
--- a/lib/opal/builder.rb
+++ b/lib/opal/builder.rb
@@ -99,7 +99,10 @@ module Opal
       rel_path = expand_ext(rel_path)
       asset = processor_for(source, rel_path, abs_path, false, options)
       requires = preload + asset.requires + tree_requires(asset, abs_path)
-      requires.map { |r| process_require(r, asset.autoloads, options) }
+      requires.map do |r|
+        # Don't automatically load modules required by the module
+        process_require(r, asset.autoloads, options.merge(load: false))
+      end
       processed << asset
       self
     rescue MissingRequire => error
@@ -140,6 +143,20 @@ module Opal
 
     attr_accessor :processors, :path_reader, :stubs, :prerequired, :preload,
       :compiler_options, :missing_require_severity, :cache
+
+    def esm?
+      @compiler_options[:esm]
+    end
+
+    # Output extension, to be used by runners. At least Node.JS switches
+    # to ESM mode only if the extension is "mjs"
+    def output_extension
+      if esm?
+        'mjs'
+      else
+        'js'
+      end
+    end
 
     private
 

--- a/lib/opal/cli.rb
+++ b/lib/opal/cli.rb
@@ -113,22 +113,22 @@ module Opal
       gems.each { |gem_name| builder.use_gem gem_name }
 
       # --require
-      requires.each { |required| builder.build(required) }
+      requires.each { |required| builder.build(required, requirable: true, load: true) }
 
       # --preload
       preload.each { |path| builder.build_require(path) }
 
       # --verbose
-      builder.build_str '$VERBOSE = true', '(flags)' if verbose
+      builder.build_str '$VERBOSE = true', '(flags)', no_export: true if verbose
 
       # --debug
-      builder.build_str '$DEBUG = true', '(flags)' if debug
+      builder.build_str '$DEBUG = true', '(flags)', no_export: true if debug
 
       # --eval / stdin / file
       evals_or_file { |source, filename| builder.build_str(source, filename) }
 
       # --no-exit
-      builder.build_str '::Kernel.exit', '(exit)' unless no_exit
+      builder.build_str '::Kernel.exit', '(exit)', no_export: true unless no_exit
 
       builder
     end

--- a/lib/opal/cli_runners/chrome.rb
+++ b/lib/opal/cli_runners/chrome.rb
@@ -67,10 +67,13 @@ module Opal
         map = builder.source_map.to_json
         stack = File.read("#{__dir__}/source-map-support-browser.js")
 
+        ext = builder.output_extension
+        module_type = ' type="module"' if builder.esm?
+
         # Chrome can't handle huge data passed to `addScriptToEvaluateOnLoad`
         # https://groups.google.com/a/chromium.org/forum/#!topic/chromium-discuss/U5qyeX_ydBo
         # The only way is to create temporary files and pass them to chrome.
-        File.write("#{dir}/index.js", js)
+        File.write("#{dir}/index.#{ext}", js)
         File.write("#{dir}/source-map-support.js", stack)
         File.write("#{dir}/index.html", <<~HTML)
           <html><head>
@@ -79,14 +82,14 @@ module Opal
             <script>
             sourceMapSupport.install({
               retrieveSourceMap: function(path) {
-                return path.endsWith('/index.js') ? {
+                return path.endsWith('/index.#{ext}') ? {
                   url: './index.map', map: #{map.to_json}
                 } : null;
               }
             });
             </script>
           </head><body>
-            <script src='./index.js'></script>
+            <script src='./index.#{ext}'#{module_type}></script>
           </body></html>
         HTML
       end

--- a/lib/opal/cli_runners/gjs.rb
+++ b/lib/opal/cli_runners/gjs.rb
@@ -12,6 +12,7 @@ module Opal
         exe = ENV['GJS_PATH'] || 'gjs'
 
         opts = Shellwords.shellwords(ENV['GJS_OPTS'] || '')
+        opts.unshift('-m') if data[:builder].esm?
 
         SystemRunner.call(data) do |tempfile|
           [exe, *opts, tempfile.path, *data[:argv]]

--- a/lib/opal/cli_runners/system_runner.rb
+++ b/lib/opal/cli_runners/system_runner.rb
@@ -23,11 +23,13 @@ SystemRunner = ->(data, &block) {
   # Temporary issue with UTF-8, Base64 and source maps
   code += "\n" + builder.source_map.to_data_uri_comment unless RUBY_ENGINE == 'opal'
 
+  ext = builder.output_extension
+
   tempfile =
     if debug
-      File.new('opal-nodejs-runner.js', 'w')
+      File.new("opal-nodejs-runner.#{ext}", 'w')
     else
-      Tempfile.new('opal-system-runner-')
+      Tempfile.new(['opal-system-runner', ".#{ext}"])
     end
 
   tempfile.write code

--- a/lib/opal/compiler.rb
+++ b/lib/opal/compiler.rb
@@ -137,10 +137,22 @@ module Opal
     # Prepare the code for future requires
     compiler_option :requirable, default: false, as: :requirable?
 
+    # @!method load?
+    #
+    # Instantly load a requirable module
+    compiler_option :load, default: false, as: :load?
+
     # @!method esm?
     #
-    # Wrap compiler result as self contained ES6 module
+    # Encourage ESM semantics, eg. exporting run result
     compiler_option :esm, default: false, as: :esm?
+
+    # @!method no_export?
+    #
+    # Don't export this compile, even if ESM mode is enabled. We use
+    # this internally in CLI, so that even if ESM output is desired,
+    # we would only have one default export.
+    compiler_option :no_export, default: false, as: :no_export?
 
     # @!method inline_operators?
     #

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -2650,9 +2650,7 @@
     }
   };
 
-  Opal.load = function(path) {
-    path = Opal.normalize(path);
-
+  Opal.load_normalized = function(path) {
     Opal.loaded([path]);
 
     var module = Opal.modules[path];
@@ -2684,6 +2682,12 @@
     return true;
   };
 
+  Opal.load = function(path) {
+    path = Opal.normalize(path);
+
+    return Opal.load_normalized(path);
+  };
+
   Opal.require = function(path) {
     path = Opal.normalize(path);
 
@@ -2691,7 +2695,7 @@
       return false;
     }
 
-    return Opal.load(path);
+    return Opal.load_normalized(path);
   };
 
 


### PR DESCRIPTION
* This also fixes a bug which caused CLI options `-r` to not be tracked by loaded_features
* This fixes a bug which caused CLI-generated ESM files to have a double default export