### PR TITLE
String#length should be available when using opal/mini.rb

### DIFF
--- a/opal/corelib/string.rb
+++ b/opal/corelib/string.rb
@@ -648,6 +648,12 @@ class ::String < `String`
     `self.toString()`
   end
 
+  def length
+    `self.length`
+  end
+
+  alias size length
+
   def lines(separator = $/, chomp: false, &block)
     e = each_line(separator, chomp: chomp, &block)
     block ? self : e.to_a

--- a/opal/corelib/string/encoding.rb
+++ b/opal/corelib/string/encoding.rb
@@ -403,12 +403,6 @@ class ::String
     }
   end
 
-  def length
-    `self.length`
-  end
-
-  alias size length
-
   # stub
   def valid_encoding?
     true


### PR DESCRIPTION
So String#length and String#size definition should be moved from string/encoding.rb (which is not loaded by opal/mini.rb) to string.rb