### PR TITLE
Chrome CLI Runner to facilitate an async exit.

### DIFF
--- a/lib/opal/cli_runners/chrome.rb
+++ b/lib/opal/cli_runners/chrome.rb
@@ -80,6 +80,7 @@ module Opal
             <meta charset='utf-8'>
             <script src='./source-map-support.js'></script>
             <script>
+            window.opalheadlesschrome = true;
             sourceMapSupport.install({
               retrieveSourceMap: function(path) {
                 return path.endsWith('/index.#{ext}') ? {

--- a/stdlib/headless_chrome.rb
+++ b/stdlib/headless_chrome.rb
@@ -1,11 +1,15 @@
 %x{
+  // Inhibit the default exit behavior
+  window.OPAL_EXIT_CODE = "noexit";
+
   Opal.exit = function(code) {
-    // You can't exit from the browser.
     // The first call to Opal.exit should save an exit code.
     // All next invocations must be ignored.
+    // Then we send an event to Chrome CDP Interface that we are finished
 
-    if (typeof(window.OPAL_EXIT_CODE) === "undefined") {
+    if (window.OPAL_EXIT_CODE === "noexit") {
       window.OPAL_EXIT_CODE = code;
+      window.alert("opalheadlesschromeexit");
     }
   }
 }

--- a/stdlib/opal-platform.rb
+++ b/stdlib/opal-platform.rb
@@ -3,7 +3,7 @@
 browser         = `typeof(document) !== "undefined"`
 node            = `typeof(process) !== "undefined" && process.versions && process.versions.node`
 nashorn         = `typeof(Java) !== "undefined" && Java.type`
-headless_chrome = `typeof(navigator) !== "undefined" && /\bHeadlessChrome\//.test(navigator.userAgent)`
+headless_chrome = `typeof(opalheadlesschrome) !== 'undefined'`
 gjs             = `typeof(window) !== "undefined" && typeof(GjsFileImporter) !== 'undefined'`
 quickjs         = `typeof(window) === "undefined" && typeof(__loadScript) !== 'undefined'`
 opal_miniracer  = `typeof(opalminiracer) !== 'undefined'`


### PR DESCRIPTION
* We now load a headless chrome platform ONLY if Chrome CLIRunner is being used
* We inhibit a default exit from CDP interface if Kernel#exit hasn't been called (and opal-platform has been loaded)
* We modify Kernel#exit to run a special alert message to communicate with Chrome CDP interface (we would have sent an exception, but it doesn't bubble in the async mess - perhaps it will once we migrate to PromiseV2)

Thanks to Brandon Gastelo for spotting this bug.

Ref: opal-rspec#89