### PR TITLE
Hash#freeze

### DIFF
--- a/opal/corelib/error.rb
+++ b/opal/corelib/error.rb
@@ -224,7 +224,6 @@ class ::ZeroDivisionError   < ::StandardError; end
 class ::NameError           < ::StandardError; end
 class ::NoMethodError         < ::NameError; end
 class ::RuntimeError        < ::StandardError; end
-class ::FrozenError           < ::RuntimeError; end
 class ::LocalJumpError      < ::StandardError; end
 class ::TypeError           < ::StandardError; end
 class ::ArgumentError       < ::StandardError; end
@@ -243,6 +242,15 @@ class ::ThreadError         < ::StandardError; end
 class ::FiberError          < ::StandardError; end
 
 ::Object.autoload :Errno, 'corelib/error/errno'
+
+class ::FrozenError < ::RuntimeError
+  attr_reader :receiver
+
+  def initialize(message, receiver: nil)
+    super message
+    @receiver = receiver
+  end
+end
 
 class ::UncaughtThrowError < ::ArgumentError
   attr_reader :tag, :value

--- a/opal/corelib/error.rb
+++ b/opal/corelib/error.rb
@@ -224,6 +224,7 @@ class ::ZeroDivisionError   < ::StandardError; end
 class ::NameError           < ::StandardError; end
 class ::NoMethodError         < ::NameError; end
 class ::RuntimeError        < ::StandardError; end
+class ::FrozenError           < ::RuntimeError; end
 class ::LocalJumpError      < ::StandardError; end
 class ::TypeError           < ::StandardError; end
 class ::ArgumentError       < ::StandardError; end

--- a/opal/corelib/hash.rb
+++ b/opal/corelib/hash.rb
@@ -572,7 +572,9 @@ class ::Hash
         Object.freeze(self.$$map);
         Object.freeze(self.$$smap);
         Object.freeze(self.$$keys);
-        Object.freeze(self);
+        // some properties (eg. used as cache) are lazily added to instances
+        // therefor currently can't freeze the instances
+        // Object.freeze(self);
       }
     }
     self

--- a/opal/corelib/hash.rb
+++ b/opal/corelib/hash.rb
@@ -565,19 +565,14 @@ class ::Hash
 
   def freeze
     %x{
-      // calling Object.isFrozen is way slower than testing for a flag
-      // set the flag and test for it in the other methods for performance
-      self.$$frozen = true;
-      try {
-        // try to use Object.freeze()
+      if (!self.$$frozen) {
+        // calling Object.isFrozen is way slower than testing for a flag
+        // set the flag and test for it in the other methods for performance
+        self.$$frozen = true;
         Object.freeze(self.$$map);
         Object.freeze(self.$$smap);
         Object.freeze(self.$$keys);
         Object.freeze(self);
-      } catch(err) {
-        // Object.freeze may fail for various reasons depending on js engine
-        // but ignore if it fails, it is just a safe guard against manipulation
-        // from javascript, rely on $$frozen instead for access from ruby
       }
     }
     self

--- a/opal/corelib/hash.rb
+++ b/opal/corelib/hash.rb
@@ -565,20 +565,20 @@ class ::Hash
 
   def freeze
     %x{
+      // calling Object.isFrozen is way slower than testing for a flag
+      // set the flag and test for it in the other methods for performance
+      self.$$frozen = true;
       try {
         // try to use Object.freeze()
         Object.freeze(self.$$map);
         Object.freeze(self.$$smap);
         Object.freeze(self.$$keys);
-        // Object.freeze(self); // causes lots of errors in the specs
+        Object.freeze(self);
       } catch(err) {
         // Object.freeze may fail for various reasons depending on js engine
         // but ignore if it fails, it is just a safe guard against manipulation
         // from javascript, rely on $$frozen instead for access from ruby
       }
-      // calling Object.isFrozen is way slower than testing for a flag
-      // set the flag and test for it in the other methods for performance
-      self.$$frozen = true;
     }
     self
   end

--- a/opal/corelib/hash.rb
+++ b/opal/corelib/hash.rb
@@ -16,6 +16,12 @@ class ::Hash
   # Mark all hash instances as valid hashes (used to check keyword args, etc)
   `self.$$prototype.$$is_hash = true`
 
+  %x{
+    Object.defineProperty(self.$$prototype, 'frozen_err', { value: function() {
+      return #{::FrozenError.new("can't modify frozen #{self.class}: #{self}", receiver: self)}
+    }});
+  }
+
   def self.[](*argv)
     %x{
       var hash, argc = argv.length, i;
@@ -84,7 +90,7 @@ class ::Hash
 
   def initialize(defaults = undefined, &block)
     %x{
-      if (self.$$frozen) { #{raise FrozenError.new("can't modify frozen #{self.class}: #{self}", receiver: self)} }
+      if (self.$$frozen) { #{raise `self.frozen_err()`} }
 
       if (defaults !== undefined && block !== nil) {
         #{::Kernel.raise ::ArgumentError, 'wrong number of arguments (1 for 0)'}
@@ -191,7 +197,7 @@ class ::Hash
 
   def []=(key, value)
     %x{
-      if (self.$$frozen) { #{raise FrozenError.new("can't modify frozen #{self.class}: #{self}", receiver: self)} }
+      if (self.$$frozen) { #{raise `self.frozen_err()`} }
 
       $hash_put(self, key, value);
       return value;
@@ -220,7 +226,7 @@ class ::Hash
 
   def clear
     %x{
-      if (self.$$frozen) { #{raise FrozenError.new("can't modify frozen #{self.class}: #{self}", receiver: self)} }
+      if (self.$$frozen) { #{raise `self.frozen_err()`} }
 
       $hash_init(self);
       return self;
@@ -263,7 +269,7 @@ class ::Hash
 
   def compact!
     %x{
-      if (self.$$frozen) { #{raise FrozenError.new("can't modify frozen #{self.class}: #{self}", receiver: self)} }
+      if (self.$$frozen) { #{raise `self.frozen_err()`} }
 
       var changes_were_made = false;
 
@@ -292,7 +298,7 @@ class ::Hash
 
   def compare_by_identity
     %x{
-      if (self.$$frozen) { #{raise FrozenError.new("can't modify frozen #{self.class}: #{self}", receiver: self)} }
+      if (self.$$frozen) { #{raise `self.frozen_err()`} }
 
       var i, ii, key, keys = self.$$keys, identity_hash;
 
@@ -334,7 +340,7 @@ class ::Hash
 
   def default=(object)
     %x{
-      if (self.$$frozen) { #{raise FrozenError.new("can't modify frozen #{self.class}: #{self}", receiver: self)} }
+      if (self.$$frozen) { #{raise `self.frozen_err()`} }
 
       self.$$proc = nil;
       self.$$none = object;
@@ -354,7 +360,7 @@ class ::Hash
 
   def default_proc=(default_proc)
     %x{
-      if (self.$$frozen) { #{raise FrozenError.new("can't modify frozen #{self.class}: #{self}", receiver: self)} }
+      if (self.$$frozen) { #{raise `self.frozen_err()`} }
 
       var proc = default_proc;
 
@@ -375,7 +381,7 @@ class ::Hash
 
   def delete(key, &block)
     %x{
-      if (self.$$frozen) { #{raise FrozenError.new("can't modify frozen #{self.class}: #{self}", receiver: self)} }
+      if (self.$$frozen) { #{raise `self.frozen_err()`} }
       var value = $hash_delete(self, key);
 
       if (value !== undefined) {
@@ -394,7 +400,7 @@ class ::Hash
     return enum_for(:delete_if) { size } unless block
 
     %x{
-      if (self.$$frozen) { #{raise FrozenError.new("can't modify frozen #{self.class}: #{self}", receiver: self)} }
+      if (self.$$frozen) { #{raise `self.frozen_err()`} }
 
       for (var i = 0, keys = self.$$keys, length = keys.length, key, value, obj; i < length; i++) {
         key = keys[i];
@@ -755,7 +761,7 @@ class ::Hash
     return enum_for(:keep_if) { size } unless block
 
     %x{
-      if (self.$$frozen) { #{raise FrozenError.new("can't modify frozen #{self.class}: #{self}", receiver: self)} }
+      if (self.$$frozen) { #{raise `self.frozen_err()`} }
 
       for (var i = 0, keys = self.$$keys, length = keys.length, key, value, obj; i < length; i++) {
         key = keys[i];
@@ -809,7 +815,7 @@ class ::Hash
 
   def merge!(*others, &block)
     %x{
-      if (self.$$frozen) { #{raise FrozenError.new("can't modify frozen #{self.class}: #{self}", receiver: self)} }
+      if (self.$$frozen) { #{raise `self.frozen_err()`} }
       var i, j, other, other_keys, length, key, value, other_value;
       for (i = 0; i < others.length; ++i) {
         other = #{::Opal.coerce_to!(`others[i]`, ::Hash, :to_hash)};
@@ -878,7 +884,7 @@ class ::Hash
 
   def rehash
     %x{
-      if (self.$$frozen) { #{raise FrozenError.new("can't modify frozen #{self.class}: #{self}", receiver: self)} }
+      if (self.$$frozen) { #{raise `self.frozen_err()`} }
       Opal.hash_rehash(self);
       return self;
     }
@@ -915,7 +921,7 @@ class ::Hash
     return enum_for(:reject!) { size } unless block
 
     %x{
-      if (self.$$frozen) { #{raise FrozenError.new("can't modify frozen #{self.class}: #{self}", receiver: self)} }
+      if (self.$$frozen) { #{raise `self.frozen_err()`} }
 
       var changes_were_made = false;
 
@@ -945,7 +951,7 @@ class ::Hash
   end
 
   def replace(other)
-    `if (self.$$frozen) { #{raise FrozenError.new("can't modify frozen #{self.class}: #{self}", receiver: self)} }`
+    `if (self.$$frozen) { #{raise `self.frozen_err()`} }`
 
     other = ::Opal.coerce_to!(other, ::Hash, :to_hash)
 
@@ -1006,7 +1012,7 @@ class ::Hash
     return enum_for(:select!) { size } unless block
 
     %x{
-      if (self.$$frozen) { #{raise FrozenError.new("can't modify frozen #{self.class}: #{self}", receiver: self)} }
+      if (self.$$frozen) { #{raise `self.frozen_err()`} }
 
       var result = nil;
 
@@ -1037,7 +1043,7 @@ class ::Hash
 
   def shift
     %x{
-      if (self.$$frozen) { #{raise FrozenError.new("can't modify frozen #{self.class}: #{self}", receiver: self)} }
+      if (self.$$frozen) { #{raise `self.frozen_err()`} }
       var keys = self.$$keys,
           key;
 
@@ -1152,7 +1158,7 @@ class ::Hash
     return enum_for(:transform_keys!) { size } unless block
 
     %x{
-      if (self.$$frozen) { #{raise FrozenError.new("can't modify frozen #{self.class}: #{self}", receiver: self)} }
+      if (self.$$frozen) { #{raise `self.frozen_err()`} }
 
       var keys = Opal.slice.call(self.$$keys),
           i, length = keys.length, key, value, new_key;
@@ -1206,7 +1212,7 @@ class ::Hash
     return enum_for(:transform_values!) { size } unless block
 
     %x{
-      if (self.$$frozen) { #{raise FrozenError.new("can't modify frozen #{self.class}: #{self}", receiver: self)} }
+      if (self.$$frozen) { #{raise `self.frozen_err()`} }
 
       for (var i = 0, keys = self.$$keys, length = keys.length, key, value; i < length; i++) {
         key = keys[i];

--- a/spec/filters/unsupported/freeze.rb
+++ b/spec/filters/unsupported/freeze.rb
@@ -79,56 +79,12 @@ opal_unsupported_filter "freezing" do
   fails "FalseClass#to_s returns a frozen string" # Expected "false".frozen? to be truthy but was false
   fails "File.basename returns a new unfrozen String" # Expected "foo.rb" not to be identical to "foo.rb"
   fails "FrozenError#receiver should return frozen object that modification was attempted on" # RuntimeError: RuntimeError
-  fails "FrozenError.new should take optional receiver argument" # NoMethodError: undefined method `receiver' for #<FrozenError: msg>
   fails "Hash literal does not change encoding of literal string keys during creation"
   fails "Hash literal freezes string keys on initialization"
   fails "Hash#== compares keys with matching hash codes via eql?"
   fails "Hash#[]= doesn't duplicate and freeze already frozen string keys"
-  fails "Hash#[]= raises a FrozenError if called on a frozen instance" # Expected FrozenError but no exception was raised (2 was returned)
-  fails "Hash#clear raises a FrozenError if called on a frozen instance" # Expected FrozenError but no exception was raised ({} was returned)
-  fails "Hash#compact! on frozen instance keeps pairs and raises a FrozenError" # Expected FrozenError but no exception was raised ({"truthy"=>true, "false"=>false, nil=>true} was returned)
-  fails "Hash#compact! on frozen instance keeps pairs and raises a RuntimeError"
-  fails "Hash#compare_by_identity raises a FrozenError on frozen hashes" # Expected FrozenError but no exception was raised ({} was returned)
-  fails "Hash#default= raises a FrozenError if called on a frozen instance" # Expected FrozenError but no exception was raised (nil was returned)
-  fails "Hash#default_proc= raises a FrozenError if self is frozen" # Expected FrozenError but no exception was raised (main was returned)
-  fails "Hash#delete raises a FrozenError if called on a frozen instance" # Expected FrozenError but no exception was raised (nil was returned)
-  fails "Hash#delete_if raises a FrozenError if called on a frozen instance" # Expected FrozenError but no exception was raised ({1=>2, 3=>4} was returned)
-  fails "Hash#delete_if returns an Enumerator if called on a frozen instance"
-  fails "Hash#each returns an Enumerator if called on a frozen instance"
-  fails "Hash#each_key returns an Enumerator if called on a frozen instance"
-  fails "Hash#each_pair returns an Enumerator if called on a frozen instance"
-  fails "Hash#each_value returns an Enumerator if called on a frozen instance"
   fails "Hash#eql? compares keys with matching hash codes via eql?"
-  fails "Hash#filter returns an Enumerator if called on a frozen instance" # NoMethodError: undefined method `filter' for {1=>2, 3=>4, 5=>6}
-  fails "Hash#filter! raises a FrozenError if called on a frozen instance that would not be modified" # Expected FrozenError but got: NoMethodError (undefined method `filter!' for {1=>2, 3=>4})
-  fails "Hash#filter! raises a FrozenError if called on an empty frozen instance" # Expected FrozenError but got: NoMethodError (undefined method `filter!' for {})
-  fails "Hash#filter! returns an Enumerator if called on a frozen instance" # NoMethodError: undefined method `filter!' for {1=>2, 3=>4, 5=>6}
-  fails "Hash#initialize raises a FrozenError if called on a frozen instance" # Expected FrozenError but no exception was raised ({1=>2, 3=>4} was returned)
-  fails "Hash#keep_if raises a FrozenError if called on a frozen instance" # Expected FrozenError but no exception was raised ({} was returned)
-  fails "Hash#keep_if returns an Enumerator if called on a frozen instance"
-  fails "Hash#merge! raises a FrozenError on a frozen instance that is modified" # Expected FrozenError but no exception was raised ({1=>2} was returned)
-  fails "Hash#merge! raises a FrozenError on a frozen instance that would not be modified" # Expected FrozenError but no exception was raised ({1=>2} was returned)
-  fails "Hash#rehash raises a FrozenError if called on a frozen instance" # Expected FrozenError but no exception was raised ({} was returned)
-  fails "Hash#reject returns an Enumerator if called on a frozen instance"
-  fails "Hash#reject! raises a FrozenError if called on a frozen instance that is modified" # Expected FrozenError but no exception was raised (nil was returned)
-  fails "Hash#reject! raises a FrozenError if called on a frozen instance that would not be modified" # Expected FrozenError but no exception was raised (nil was returned)
-  fails "Hash#replace raises a FrozenError if called on a frozen instance that is modified" # Expected FrozenError but no exception was raised ({} was returned)
-  fails "Hash#replace raises a FrozenError if called on a frozen instance that would not be modified" # Expected FrozenError but no exception was raised ({} was returned)
-  fails "Hash#select returns an Enumerator if called on a frozen instance"
-  fails "Hash#select! raises a FrozenError if called on a frozen instance that would not be modified" # Expected FrozenError but no exception was raised (nil was returned)
-  fails "Hash#select! raises a FrozenError if called on an empty frozen instance" # Expected FrozenError but no exception was raised (nil was returned)
-  fails "Hash#select! returns an Enumerator if called on a frozen instance"
-  fails "Hash#shift raises a FrozenError if called on a frozen instance" # Expected FrozenError but no exception was raised (nil was returned)
   fails "Hash#store doesn't duplicate and freeze already frozen string keys"
-  fails "Hash#store raises a FrozenError if called on a frozen instance" # Expected FrozenError but no exception was raised (2 was returned)
-  fails "Hash#transform_keys! on frozen instance keeps pairs and raises a FrozenError" # NoMethodError: undefined method `transform_keys!' for {"a"=>1, "b"=>2, "c"=>3, "d"=>4}
-  fails "Hash#transform_keys! on frozen instance raises a FrozenError on an empty hash" # NoMethodError: undefined method `transform_keys!' for {}
-  fails "Hash#transform_values! on frozen instance keeps pairs and raises a FrozenError" # Expected FrozenError but no exception was raised ({"a"=>2, "b"=>3, "c"=>4} was returned)
-  fails "Hash#transform_values! on frozen instance keeps pairs and raises a RuntimeError"
-  fails "Hash#transform_values! on frozen instance raises a FrozenError on an empty hash" # Expected FrozenError but no exception was raised ({} was returned)
-  fails "Hash#transform_values! on frozen instance when no block is given does not raise an exception"
-  fails "Hash#update raises a FrozenError on a frozen instance that is modified" # Expected FrozenError but no exception was raised ({1=>2} was returned)
-  fails "Hash#update raises a FrozenError on a frozen instance that would not be modified" # Expected FrozenError but no exception was raised ({} was returned)
   fails "Kernel#clone copies frozen state from the original"
   fails "Kernel#clone copies frozen? and tainted?" # Expected false to be true
   fails "Kernel#clone takes an freeze: true option to frozen copy" # Expected #<KernelSpecs::Duplicate:0x25158>.frozen? to be truthy but was false


### PR DESCRIPTION
Mostly working, well pragmatically working in a acceptable way

I still need to check performance impact of using Object.freeze, maybe it has to go and using the $$frozen flag has to be sufficient, or maybe Object.freeze can be optional.

Object.freeze on the Hash instance causes lots of problems with other specs.

If in matz ruby one does:
```
a = Hash.new.freeze
a.define_singleton_method(:b) { true } # >> FrozenError
```

But that doesnt happen yet with this implementation.
Either $$frozen can be accepted globally, so that other methods can check, or Object.freeze on the instance can be made to work. Not sure yet, need to investigate the problems with the other specs further.

