### PR TITLE
Ensure UTF8 encoding of sourcesContent of SourceMaps

### DIFF
--- a/lib/opal/source_map/file.rb
+++ b/lib/opal/source_map/file.rb
@@ -51,7 +51,7 @@ class Opal::SourceMap::File
       # file: "out.js", # This is optional
       sourceRoot: source_root,
       sources: [file],
-      sourcesContent: [source.force_encoding('UTF-8')],
+      sourcesContent: [source.encoding == Encoding::UTF_8 ? source : source.encode('UTF-8', undef: :replace)],
       names: names,
       mappings: Opal::SourceMap::VLQ.encode_mappings(relative_mappings),
       # x_com_opalrb_original_lines: source.count("\n"),


### PR DESCRIPTION
Avoids exceoptions: JSON::GeneratorError and Encoding::UndefinedConversionError

sourcesContent will be valid UTF8. invalid UTF8 will be replaced by �

The previously used #force_encoding will keep invalid characters which may cause failures during subsequent handling of sourcesContent within opal or external consumers