### PR TITLE
Fix "undefined method source_map for nil"

### DIFF
--- a/lib/opal/builder.rb
+++ b/lib/opal/builder.rb
@@ -162,8 +162,8 @@ module Opal
     def process_require(rel_path, autoloads, options)
       return if already_processed.include?(rel_path)
       already_processed << rel_path
-
-      processed << process_require_threadsafely(rel_path, autoloads, options)
+      asset = process_require_threadsafely(rel_path, autoloads, options)
+      processed << asset if asset
     end
 
     def already_processed


### PR DESCRIPTION
Fix
opal/lib/opal/builder.rb:133:in `map': undefined method `source_map' for nil:NilClass (NoMethodError)

      ::Opal::SourceMap::Index.new(processed.map(&:source_map), join: "\n")
                                            ^^^^
        from C:/Users/jan/workspace/opal/lib/opal/builder.rb:133:in `source_map'
        from C:/Users/jan/workspace/opal/lib/opal/cli_runners/chrome.rb:67:in `prepare_files_in'
        from C:/Users/jan/workspace/opal/lib/opal/cli_runners/chrome.rb:40:in `block (2 levels) in run'
        from C:/Users/jan/workspace/opal/lib/opal/cli_runners/chrome.rb:110:in `block in with_chrome_server'
        from C:/Users/jan/workspace/opal/lib/opal/cli_runners/chrome.rb:133:in `run_chrome_server'
        from C:/Users/jan/workspace/opal/lib/opal/cli_runners/chrome.rb:110:in `with_chrome_server'
        from C:/Users/jan/workspace/opal/lib/opal/cli_runners/chrome.rb:39:in `block in run'
        from C:/Ruby32-x64/lib/ruby/3.2.0+3/tmpdir.rb:94:in `mktmpdir'
        from C:/Users/jan/workspace/opal/lib/opal/cli_runners/chrome.rb:189:in `mktmpdir'
        from C:/Users/jan/workspace/opal/lib/opal/cli_runners/chrome.rb:38:in `run'
        from C:/Users/jan/workspace/opal/lib/opal/cli_runners/chrome.rb:19:in `call'
        from C:/Users/jan/workspace/opal/lib/opal/cli.rb:79:in `run'
        from exe/opal:26:in `<main>'