### PR TITLE
[experimental] performance:compare : Take best time if WITHIN_VARIATION results are within MAX_VARIATION

### DIFF
--- a/tasks/performance.rake
+++ b/tasks/performance.rake
@@ -22,8 +22,8 @@ class Timing
   # expecting 10 results within MAX_VARIATION margin
   def margin_achieved?
     @times.sort!
-    return true if @times.size >= WITHIN_VARIATION && error < max_error
-    return true if @times.size >= @max_tries
+    return true if tries >= WITHIN_VARIATION && error < max_error
+    return true if tries >= @max_tries
     false
   end
 

--- a/tasks/performance.rake
+++ b/tasks/performance.rake
@@ -7,7 +7,7 @@ OS = Opal::OS
 
 class Timing
   MAX_VARIATION = 3 # percent
-  WITHIN_VARIATION = 10 # results within MAX_VARIATION
+   = 10 # results within MAX_VARIATION
 
   def initialize(max_tries: 64, &block)
     @max_tries = max_tries
@@ -19,7 +19,7 @@ class Timing
     end
   end
 
-  # expecting 10 results within MAX_VARIATION margin
+  # expecting WITHIN_VARIATION results within MAX_VARIATION margin
   def margin_achieved?
     @times.sort!
     return true if tries >= WITHIN_VARIATION && error < max_error

--- a/tasks/performance.rake
+++ b/tasks/performance.rake
@@ -7,7 +7,7 @@ OS = Opal::OS
 
 class Timing
   MAX_VARIATION = 3 # percent
-   = 10 # results within MAX_VARIATION
+  WITHIN_VARIATION = 10 # results within MAX_VARIATION
 
   def initialize(max_tries: 64, &block)
     @max_tries = max_tries


### PR DESCRIPTION
Keeps the performance task running until WITHIN_VARIATION results are within best_time + MAX_VARIATION %

MAX_VARIATION here is set to 3%
WITHIN_VARIATION here is set to 10
=>  If 10 results are within best_time + 3%, take the best time to compare


Verifying a performance improvement

Lets say a improvement of 1.5% is expected.
- Set MAX_VARIATION to below 1.5%, maybe 1%
- run the task
- if change is larger than variation and around the expected 1.5%, the improvement is verified within margin
- run multiple times to verify


Limits:
Improvements in Opal currently are usually below 2%, most often below 0.5%
Best achievable variation for 10 best times on my machine out of a total of 128 tries is around 0.65%
On my machine setting MAX_VARIATION to below 1% is useless,
thus accurately verifying improvements below 1% is not possible (unless setting tries to a very high number)


However, github results should be more reliable, as variation is kept below 3%.
So if the -5% change is hit, its probably accurate and not due to high variation.


Please play a bit with it, set MAX_VARIATION to 0.1 and max_tries to 128 and see whats the best variation that can be achieved on your machine