### PR TITLE
[experimental] failed attempt to reduce performance variation

### DIFF
--- a/opal.gemspec
+++ b/opal.gemspec
@@ -49,4 +49,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop-performance', '~> 1.1.0'
   spec.add_development_dependency 'rack'
   spec.add_development_dependency 'webrick'
+  spec.add_development_dependency 'isomorfeus-speednode', '~> 0.6.0'
 end

--- a/tasks/performance.rake
+++ b/tasks/performance.rake
@@ -82,7 +82,7 @@ class SpeedTiming
     @times = []
     until margin_achieved?
       puts "run #{@times.size + 1}"
-      puts "error #{error} max_error #{max_error}"
+      puts "error #{error} max_error #{max_error}" if @times.size > 1
       puts "times #{@times}"
       @times << block.()
     end

--- a/tasks/performance.rake
+++ b/tasks/performance.rake
@@ -22,8 +22,8 @@ class Timing
   # expecting 10 results within MAX_VARIATION margin
   def margin_achieved?
     @times.sort!
-    return true if @times.size >= WITHIN_VARIATION && error < max_error
-    return true if @times.size >= @max_tries
+    return true if tries >= WITHIN_VARIATION && error < max_error
+    return true if tries >= @max_tries
     false
   end
 

--- a/tasks/performance.rake
+++ b/tasks/performance.rake
@@ -7,7 +7,7 @@ OS = Opal::OS
 
 class Timing
   MAX_VARIATION = 3 # percent
-  WITHIN_VARIATION = 10 # results within MAX_VARIATION
+   = 10 # results within MAX_VARIATION
 
   def initialize(max_tries: 64, &block)
     @max_tries = max_tries
@@ -19,7 +19,7 @@ class Timing
     end
   end
 
-  # expecting 10 results within MAX_VARIATION margin
+  # expecting WITHIN_VARIATION results within MAX_VARIATION margin
   def margin_achieved?
     @times.sort!
     return true if tries >= WITHIN_VARIATION && error < max_error

--- a/tasks/performance.rake
+++ b/tasks/performance.rake
@@ -223,7 +223,7 @@ performance_stat_speed = ->(name) {
   puts "\n* Running AsciiDoctor in speednode with #{name}..."
   context = ExecJS.permissive_compile('')
   stat[:run_time] = SpeedTiming.new do
-    sleep 2
+    sleep 1
     res = context.bench(source)
     File.write("tmp/performance/opal_result_#{name}.html", res['result'])
     res['duration'] * 1000

--- a/tasks/performance.rake
+++ b/tasks/performance.rake
@@ -223,6 +223,7 @@ performance_stat_speed = ->(name) {
   puts "\n* Running AsciiDoctor in speednode with #{name}..."
   context = ExecJS.permissive_compile('')
   stat[:run_time] = SpeedTiming.new do
+    sleep 2
     res = context.bench(source)
     File.write("tmp/performance/opal_result_#{name}.html", res['result'])
     res['duration'] * 1000

--- a/tasks/performance.rake
+++ b/tasks/performance.rake
@@ -74,7 +74,7 @@ class Timing
 end
 
 class SpeedTiming
-  MAX_VARIATION = 3 # percent
+  MAX_VARIATION = 0.1 # percent
   WITHIN_VARIATION = 10 # results within MAX_VARIATION
 
   def initialize(max_tries: 64, &block)

--- a/tasks/performance.rake
+++ b/tasks/performance.rake
@@ -7,7 +7,7 @@ OS = Opal::OS
 
 class Timing
   MAX_VARIATION = 3 # percent
-   = 10 # results within MAX_VARIATION
+  WITHIN_VARIATION = 10 # results within MAX_VARIATION
 
   def initialize(max_tries: 64, &block)
     @max_tries = max_tries

--- a/tasks/performance.rake
+++ b/tasks/performance.rake
@@ -225,7 +225,7 @@ performance_stat_speed = ->(name) {
   stat[:run_time] = SpeedTiming.new do
     res = context.bench(source)
     File.write("tmp/performance/opal_result_#{name}.html", res['result'])
-    res['duration']
+    res['duration'] * 1000
   end
   stat[:correct] = File.read("tmp/performance/opal_result_#{name}.html") == File.read("tmp/performance/ruby_result.html")
   stat[:size] = Size.new File.size("tmp/performance/asciidoctor_test.js")

--- a/tasks/performance.rake
+++ b/tasks/performance.rake
@@ -221,8 +221,9 @@ performance_stat_speed = ->(name) {
   source = File.read("tmp/performance/asciidoctor_test.js")
 
   puts "\n* Running AsciiDoctor in speednode with #{name}..."
+  context = ExecJS.permissive_compile('')
   stat[:run_time] = SpeedTiming.new do
-    res = ExecJS.permissive_bench(source)
+    res = context.bench(source)
     File.write("tmp/performance/opal_result_#{name}.html", res['result'])
     res['duration']
   end

--- a/tasks/performance.rake
+++ b/tasks/performance.rake
@@ -77,7 +77,7 @@ class SpeedTiming
   MAX_VARIATION = 0.1 # percent
   WITHIN_VARIATION = 10 # results within MAX_VARIATION
 
-  def initialize(max_tries: 64, &block)
+  def initialize(max_tries: 128, &block)
     @max_tries = max_tries
     @times = []
     until margin_achieved?

--- a/tasks/performance.rake
+++ b/tasks/performance.rake
@@ -7,10 +7,10 @@ require 'isomorfeus-speednode'
 OS = Opal::OS
 
 class Timing
-  MAX_VARIATION = 3 # percent
+  MAX_VARIATION = 0.1 # percent
   WITHIN_VARIATION = 10 # results within MAX_VARIATION
 
-  def initialize(max_tries: 64, &block)
+  def initialize(max_tries: 128, &block)
     @max_tries = max_tries
     @times = []
     until margin_achieved?


### PR DESCRIPTION
This PR, based on #2455 tries to minimize obstructions like:
- node startup
- file io
- garbage collection

It measures within node using performance.*

Its focused on asciidoctor run time.

But still variation is too high, basically no advantage over #2455, to accurately measure small performance improvements.