### PR TITLE
Behave like Ruby, treat \r\n as \n when reading a file, not binary

### DIFF
--- a/stdlib/nodejs/file.rb
+++ b/stdlib/nodejs/file.rb
@@ -127,7 +127,7 @@ class File < IO
 
 
   def self.read(path)
-    `return executeIOAction(function(){return __fs__.readFileSync(#{path}).toString()})`
+    `return executeIOAction(function(){return __fs__.readFileSync(#{path}).toString().replaceAll("\r\n", "\n")})`
   end
 
   def self.write(path, data)
@@ -279,7 +279,7 @@ class File < IO
         }
         res = `content`
       else
-        res = `executeIOAction(function(){return __fs__.readFileSync(#{@path}).toString('utf8')})`
+        res = `executeIOAction(function(){return __fs__.readFileSync(#{@path}).toString('utf8').replaceAll("\r\n", "\n")})`
       end
       @eof = true
       @lineno = res.size


### PR DESCRIPTION
In MRI, when reading a file with \r\n as line separator, File#read and File.open.read return \r\n as \n.
File#binread or File.open.read with mode 'b' will still return \r\n as \r\n