### PR TITLE
Retry if file cache write operation exits with Zlib::BufError

### DIFF
--- a/lib/opal/cache/file_cache.rb
+++ b/lib/opal/cache/file_cache.rb
@@ -23,6 +23,11 @@ module Opal
         out = Marshal.dump(data)
         out = Zlib.gzip(out, level: 9)
         File.binwrite(file, out)
+      rescue Zlib::BufError
+        # This sometimes happens, unsure why, makes no sense, possibly
+        # some race condition
+        warn '[Opal]: Zlib::BufError; retrying'
+        retry
       end
 
       def get(key)


### PR DESCRIPTION
This error shouldn't happen and is likely a bug in Zlib. This is a temporary measure, also for older Rubies, so that tests won't break randomly.

This started happening since we merged Prefork