### PR TITLE
Fix a problem with assigning Module to a constant after freezing

### DIFF
--- a/opal/corelib/module.rb
+++ b/opal/corelib/module.rb
@@ -1,4 +1,4 @@
-# helpers: truthy, coerce_to, const_set, Object, return_ivar, assign_ivar, ivar, deny_frozen_access, freeze
+# helpers: truthy, coerce_to, const_set, Object, return_ivar, assign_ivar, ivar, deny_frozen_access, freeze, prop
 
 class ::Module
   def self.allocate
@@ -426,9 +426,16 @@ class ::Module
   end
 
   def freeze
+    # Specialized version of freeze, because the $$base_module property needs to be
+    # accessible despite the frozen status
+
     return self if frozen?
 
-    `$freeze(self)`
+    %x{
+      if (!self.hasOwnProperty('$$base_module')) { $prop(self, '$$base_module', null); }
+
+      return $freeze(self);
+    }
   end
 
   def remove_method(*names)

--- a/spec/opal/core/module_spec.rb
+++ b/spec/opal/core/module_spec.rb
@@ -60,4 +60,12 @@ describe 'Module' do
     ->{ klass.new.cvarz0 }.should raise_error NameError
     ->{ klass.new.cvar0 }.should raise_error NameError
   end
+
+  it "can be set to a constant while being frozen" do
+    OPAL_SPEC_MODULE = Module.new.freeze
+    OPAL_SPEC_CLASS = Class.new.freeze
+
+    OPAL_SPEC_MODULE.class.should == Module
+    OPAL_SPEC_CLASS.class.should == Class
+  end
 end


### PR DESCRIPTION
This PR fixes running the working branch of Opal-RSpec