### PR TITLE
Fix ruby-head runner

### DIFF
--- a/opal.gemspec
+++ b/opal.gemspec
@@ -44,9 +44,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rack-test'
   spec.add_development_dependency 'selenium-webdriver'
   spec.add_development_dependency 'benchmark-ips', '< 2.8'
-  spec.add_development_dependency 'sinatra'
+  spec.add_development_dependency 'sinatra', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 0.67.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.1.0'
-  spec.add_development_dependency 'rack'
+  spec.add_development_dependency 'rack', '~> 2.2'
   spec.add_development_dependency 'webrick'
 end


### PR DESCRIPTION
This is being done by forcing the versions of rack and sinatra, so that we don't pull rack 3.0.0 (which moves rackup to a separate gem) mistakenly.
We would like to upgrade this later on, but for now Sinatra does not support rack 3.0