### PR TITLE
Fix compilation of a call: `gets&.chomp`

### DIFF
--- a/lib/opal/nodes/call.rb
+++ b/lib/opal/nodes/call.rb
@@ -186,7 +186,8 @@ module Opal
       end
 
       def compile_simple_call_chain
-        push recv(receiver_sexp), method_jsid, '(', expr(arglist), ')'
+        compile_receiver
+        push method_jsid, '(', expr(arglist), ')'
       end
 
       def splat?
@@ -469,7 +470,7 @@ module Opal
       def handle_conditional_send
         # temporary variable that stores method receiver
         receiver_temp = scope.new_temp
-        push "#{receiver_temp} = ", expr(recvr)
+        push "#{receiver_temp} = ", expr(receiver_sexp)
 
         # execute the sexp only if the receiver isn't nil
         push ", (#{receiver_temp} === nil || #{receiver_temp} == null) ? nil : "

--- a/opal/corelib/io.rb
+++ b/opal/corelib/io.rb
@@ -89,7 +89,7 @@ class ::IO
     parts = ''
 
     # Will execure at most twice - one time reading from a buffer
-    # second time
+    # second time executing read proc
     begin
       @read_buffer += parts
       if @read_buffer != ''

--- a/spec/opal/core/language/safe_navigator_spec.rb
+++ b/spec/opal/core/language/safe_navigator_spec.rb
@@ -4,4 +4,14 @@ describe 'Safe navigator' do
       value&.unknown.should == nil
     end
   end
+
+  it "calls a receiver exactly once" do
+    def receiver
+      @calls += 1
+    end
+    @calls = 0
+    receiver&.itself.should == 1
+    @calls = 0
+    receiver&.itself{}.should == 1
+  end
 end


### PR DESCRIPTION
There was missing logic in CallNode#compile_simple_call_chain (this is the most basic version of call compilation, which didn't use the CallNode#compile_receiver).

This caused `opal-repl -Rchrome` to stop working.

The bug was introduced by 6ef5abea33259822ef5ee10d1121025c58b40687

This fixes #2467