### PR TITLE
Fix builder.dup

### DIFF
--- a/lib/opal/builder.rb
+++ b/lib/opal/builder.rb
@@ -123,6 +123,7 @@ module Opal
       @compiler_options = other.compiler_options.dup
       @missing_require_severity = other.missing_require_severity.to_sym
       @processed = other.processed.dup
+      @scheduler = other.scheduler.dup.tap { |i| i.builder = self }
     end
 
     def to_s
@@ -175,7 +176,7 @@ module Opal
     attr_reader :processed
 
     attr_accessor :processors, :path_reader, :stubs, :prerequired, :preload,
-      :compiler_options, :missing_require_severity, :cache
+      :compiler_options, :missing_require_severity, :cache, :scheduler
 
     def esm?
       @compiler_options[:esm]

--- a/lib/opal/builder_scheduler.rb
+++ b/lib/opal/builder_scheduler.rb
@@ -8,7 +8,7 @@ module Opal
       @builder = builder
     end
 
-    attr_reader :builder
+    attr_accessor :builder
   end
 
   singleton_class.attr_accessor :builder_scheduler

--- a/spec/lib/builder_spec.rb
+++ b/spec/lib/builder_spec.rb
@@ -68,6 +68,16 @@ RSpec.describe Opal::Builder do
         b2.send(m).should_not equal(builder.send(m))
       end
     end
+
+    it 'processes dependencies correctly' do
+      b2 = builder
+      2.times do
+        b2 = b2.dup
+        source = 'require "json"'
+        b2.build_str(source, 'bar.rb')
+        b2.to_s.should include("$to_json")
+      end
+    end
   end
 
   describe 'requiring a native .js file' do


### PR DESCRIPTION
Due to us introducing BuilderScheduler, we got a regression for Tilt users where dependency resolution broke.