### PR TITLE
[experimental, 2.0] Compile every method call using $send

### DIFF
--- a/lib/opal/nodes/call.rb
+++ b/lib/opal/nodes/call.rb
@@ -66,23 +66,14 @@ module Opal
         iter.meta[:has_break]
       end
 
-      # Opal has a runtime helper 'Opal.send_method_name' that assigns
+      # Opal has a runtime helper 'Opal.send' that assigns
       # provided block to a '$$p' property of the method body
       # and invokes a method using 'apply'.
       #
-      # We have to compile a method call using this 'Opal.send_method_name' when a method:
-      # 1. takes a splat
-      # 2. takes a block
-      #
-      # Arguments that contain splat must be handled in a different way.
-      # @see #compile_arguments
-      #
-      # When a method takes a block we have to calculate all arguments
-      # **before** assigning '$$p' property (that stores a passed block)
-      # to a method body. This is some kind of protection from method calls
-      # like 'a(a {}) { 1 }'.
+      # We use this helper every time now, but subclasses may
+      # override it.
       def invoke_using_send?
-        iter || splat? || call_is_writer_that_needs_handling?
+        true
       end
 
       def invoke_using_refinement?
@@ -285,9 +276,10 @@ module Opal
           dir = File.dirname(file)
           compiler.requires << Pathname(dir).join(arg.children[0]).cleanpath.to_s
         end
-        push fragment("#{scope.self}.$require(#{file.inspect}+ '/../' + ")
+        helper :send
+        push fragment("$send(#{scope.self}, 'require', [#{file.inspect}+ '/../' + ")
         push process(arglist)
-        push fragment(')')
+        push fragment('])')
       end
 
       add_special :autoload do |compile_default|
@@ -392,6 +384,8 @@ module Opal
       # This can be refactored in terms of binding, but it would need 'corelib/binding'
       # to be required in existing code.
       add_special :eval do |compile_default|
+        helper :send
+
         # Catch the return throw coming from eval
         thrower(:eval_return)
 
@@ -404,7 +398,7 @@ module Opal
         push ", typeof Opal.compile === 'function' ? eval(Opal.compile(#{temp}"
         push ', {scope_variables: ', scope_variables
         push ", arity_check: #{compiler.arity_check?}, file: '(eval)', eval: true})) : "
-        push "#{scope.self}.$eval(#{temp}))"
+        push "$send(#{scope.self}, 'eval', [#{temp}]))"
       end
 
       add_special :local_variables do |compile_default|
@@ -415,17 +409,19 @@ module Opal
       end
 
       add_special :binding do |compile_default|
+        helper :send
+
         next compile_default.call unless recvr.nil?
 
         scope.nesting
-        push "Opal.Binding.$new("
+        push "$send(Opal.Binding, 'new', ["
         push "  function($code) {"
         push "    return eval($code);"
         push "  },"
         push "  ", scope.scope_locals.map(&:to_s).inspect, ","
         push "  ", scope.self, ","
         push "  ", source_location
-        push ")"
+        push "])"
       end
 
       add_special :__await__ do |compile_default|

--- a/lib/opal/nodes/call_special.rb
+++ b/lib/opal/nodes/call_special.rb
@@ -50,6 +50,11 @@ module Opal
         ".#{meth}"
       end
 
+      # We want to avoid "compiling using send" whenever possible
+      def invoke_using_send?
+        iter || splat? || call_is_writer_that_needs_handling?
+      end
+
       def compile_using_send
         push recv(receiver_sexp), method_jsid, '.apply(null'
         compile_arguments


### PR DESCRIPTION
This is a work in progress proposal for 2.0, but why attempt this deoptimization:

The great symbolization: What reads better:
```
$send(self, "hello_world", [1,2,3])
```
Or:
```
self[$s("hello world")](1,2,3)
```
(Perhaps we should introduce a nicer $send helper for some usecases? Like, one that doesn't allocate arrays...)

In general, this branch is an experiment and I will attempt some ideas that we may want to have for 2.0.