### PR TITLE
Replace all occurences of `'$'+name` with a cached helper

### DIFF
--- a/opal/corelib/basic_object.rb
+++ b/opal/corelib/basic_object.rb
@@ -30,7 +30,7 @@ class ::BasicObject
         #{raise ::TypeError, "#{inspect} is not a symbol nor a string"}
       }
 
-      var func = self['$' + symbol];
+      var func = self[Opal.jsid(symbol)];
 
       if (func) {
         if (block !== nil) {

--- a/opal/corelib/boolean.rb
+++ b/opal/corelib/boolean.rb
@@ -90,13 +90,13 @@ class ::Boolean < `Boolean`
   # the methods defined on Boolean, but our implementation doesn't allow that,
   # unless you define them on Boolean and not on TrueClass/FalseClass.
   def method_missing(method, *args, &block)
-    `var body = self.$$class.$$prototype['$' + #{method}]`
+    `var body = self.$$class.$$prototype[Opal.jsid(#{method})]`
     super unless `typeof body !== 'undefined' && !body.$$stub`
     `Opal.send(self, body, #{args}, #{block})`
   end
 
   def respond_to_missing?(method, _include_all = false)
-    `var body = self.$$class.$$prototype['$' + #{method}]`
+    `var body = self.$$class.$$prototype[Opal.jsid(#{method})]`
     `typeof body !== 'undefined' && !body.$$stub`
   end
 

--- a/opal/corelib/helpers.rb
+++ b/opal/corelib/helpers.rb
@@ -147,7 +147,7 @@ module ::Opal
       var method_name, method;
       for (var i = method_names.length - 1; i >= 0; i--) {
         method_name = method_names[i];
-        method = owner_class.$$prototype['$'+method_name];
+        method = owner_class.$$prototype[Opal.jsid(method_name)];
 
         if (method && !method.$$stub) {
           method.$$pristine = true;

--- a/opal/corelib/kernel.rb
+++ b/opal/corelib/kernel.rb
@@ -1,4 +1,4 @@
-# helpers: truthy, coerce_to, respond_to, Opal, deny_frozen_access, freeze, freeze_props
+# helpers: truthy, coerce_to, respond_to, Opal, deny_frozen_access, freeze, freeze_props, jsid
 # use_strict: true
 
 module ::Kernel
@@ -31,7 +31,7 @@ module ::Kernel
 
   def method(name)
     %x{
-      var meth = self['$' + name];
+      var meth = self[$jsid(name)];
 
       if (!meth || meth.$$stub) {
         #{::Kernel.raise ::NameError.new("undefined method `#{name}' for class `#{self.class}'", name)};
@@ -662,7 +662,7 @@ module ::Kernel
 
   def respond_to?(name, include_all = false)
     %x{
-      var body = self['$' + name];
+      var body = self[$jsid(name)];
 
       if (typeof(body) === "function" && !body.$$stub) {
         return true;

--- a/opal/corelib/module.rb
+++ b/opal/corelib/module.rb
@@ -1,4 +1,4 @@
-# helpers: truthy, coerce_to, const_set, Object, return_ivar, assign_ivar, ivar, deny_frozen_access, freeze, prop
+# helpers: truthy, coerce_to, const_set, Object, return_ivar, assign_ivar, ivar, deny_frozen_access, freeze, prop, jsid
 
 class ::Module
   def self.allocate
@@ -138,7 +138,7 @@ class ::Module
 
       for (var i = names.length - 1; i >= 0; i--) {
         var name = names[i],
-            id   = '$' + name,
+            id   = $jsid(name),
             ivar = $ivar(name);
 
         var body = $return_ivar(ivar);
@@ -164,7 +164,7 @@ class ::Module
 
       for (var i = names.length - 1; i >= 0; i--) {
         var name = names[i],
-            id   = '$' + name + '=',
+            id   = $jsid(name + '='),
             ivar = $ivar(name);
 
         var body = $assign_ivar(ivar)
@@ -424,7 +424,7 @@ class ::Module
       block.$$def         = block;
       block.$$define_meth = true;
 
-      return Opal.defn(self, '$' + name, block);
+      return Opal.defn(self, $jsid(name), block);
     }
   end
 
@@ -503,7 +503,7 @@ class ::Module
 
   def instance_method(name)
     %x{
-      var meth = self.$$prototype['$' + name];
+      var meth = self.$$prototype[$jsid(name)];
 
       if (!meth || meth.$$stub) {
         #{::Kernel.raise ::NameError.new("undefined method `#{name}' for class `#{self.name}'", name)};
@@ -589,7 +589,7 @@ class ::Module
 
   def method_defined?(method)
     %x{
-      var body = self.$$prototype['$' + method];
+      var body = self.$$prototype[$jsid(method)];
       return (!!body) && !body.$$stub;
     }
   end
@@ -605,7 +605,7 @@ class ::Module
       else {
         for (var i = 0, length = methods.length; i < length; i++) {
           var meth = methods[i],
-              id   = '$' + meth,
+              id   = $jsid(meth),
               func = self.$$prototype[id];
 
           Opal.defs(self, id, func);

--- a/opal/corelib/string.rb
+++ b/opal/corelib/string.rb
@@ -1333,6 +1333,7 @@ class ::String < `String`
 
   def to_proc
     method_name = `self.valueOf()`
+    jsid = `Opal.jsid(method_name)`
 
     proc = ::Kernel.proc do |*args, &block|
       %x{
@@ -1344,7 +1345,7 @@ class ::String < `String`
 
         if (recv == null) recv = nil;
 
-        var body = recv['$' + #{method_name}];
+        var body = recv[jsid];
 
         if (!body) {
           body = recv.$method_missing;

--- a/stdlib/native.rb
+++ b/stdlib/native.rb
@@ -615,7 +615,7 @@ end
 class Class
   def native_alias(new_jsid, existing_mid)
     %x{
-      var aliased = #{self}.prototype['$' + #{existing_mid}];
+      var aliased = #{self}.prototype[Opal.jsid(#{existing_mid})];
       if (!aliased) {
         #{raise NameError.new("undefined method `#{existing_mid}' for class `#{inspect}'", existing_mid)};
       }


### PR DESCRIPTION
`'$'+name` is an expensive call, by caching such calls, we save about 2% in performance.