### PR TITLE
bench&runner: Deno: MSpec: use a NodeJS formatter

### DIFF
--- a/spec/mspec-opal/runner.rb
+++ b/spec/mspec-opal/runner.rb
@@ -79,6 +79,7 @@ class OSpecFormatter
       'browser'      => BrowserFormatter,
       'server'       => BrowserFormatter,
       'chrome'       => DottedFormatter,
+      'deno'         => NodeJSFormatter,
       'node'         => NodeJSFormatter,
       'nodejs'       => NodeJSFormatter,
       'gjs'          => ColoredDottedFormatter,


### PR DESCRIPTION
This is a fixup to #2492