### PR TITLE
Fix `--watch` ignoring some directories (e.g. `tmp`)

### DIFF
--- a/lib/opal/cli_runners/compiler.rb
+++ b/lib/opal/cli_runners/compiler.rb
@@ -52,22 +52,20 @@ class Opal::CliRunners::Compiler
   end
 
   def fail_unrewindable!
-    warn <<~ERROR
+    abort <<~ERROR
       You have specified --watch, but for watch to work, you must specify an
       --output file.
     ERROR
-    exit 1
   end
 
   def fail_no_listen!
-    warn <<~ERROR
+    abort <<~ERROR
       --watch mode requires the `listen` gem present. Please try to run:
 
           gem install listen
 
       Or if you are using bundler, add listen to your Gemfile.
     ERROR
-    exit 1
   end
 
   def watch_compile

--- a/lib/opal/cli_runners/compiler.rb
+++ b/lib/opal/cli_runners/compiler.rb
@@ -86,6 +86,9 @@ class Opal::CliRunners::Compiler
     $stderr.puts "* Opal v#{Opal::VERSION} successfully compiled your program in --watch mode"
 
     sleep
+  rescue Interrupt
+    $stderr.puts '* Stopping watcher...'
+    @code_listener.stop
   end
 
   def reexec

--- a/lib/opal/cli_runners/compiler.rb
+++ b/lib/opal/cli_runners/compiler.rb
@@ -134,7 +134,7 @@ class Opal::CliRunners::Compiler
   def watch_files
     @directories = files_to_directories
 
-    Listen.to(*@directories) do |modified, added, removed|
+    Listen.to(*@directories, ignore!: []) do |modified, added, removed|
       our_modified = @files & (modified + added + removed)
       on_code_change(our_modified) unless our_modified.empty?
     end


### PR DESCRIPTION
A couple of QoL improvements like CTRL-C support and a configuration change that will make Listen not ignore files if they're in a directory named `tmp`.