### PR TITLE
Fix CLI file reading for macOS

### DIFF
--- a/exe/opal
+++ b/exe/opal
@@ -2,7 +2,7 @@
 
 # Error codes are taken from /usr/include/sysexits.h
 
-OriginalARGV = ARGV.dup
+argv_orig = ARGV.dup
 
 require 'opal/cli_options'
 options = Opal::CLIOptions.new
@@ -16,9 +16,10 @@ end
 require 'opal/cli'
 options_hash = options.options
 options_hash.merge!(
-  file:     ARGF.file,
-  filename: ARGF.filename,
-  argv:     ARGV.dup
+  file:      ARGF.file,
+  filename:  ARGF.filename,
+  argv:      ARGV.dup,
+  argv_orig: argv_orig,
 ) unless options_hash[:lib_only]
 cli = Opal::CLI.new options_hash
 
@@ -28,4 +29,8 @@ begin
 rescue Opal::CliRunners::RunnerError => e
   $stderr.puts e.message
   exit 72
+rescue SignalException => e
+  raise unless e.message == 'SIGUSR2'
+
+  exec($0, *argv_orig)
 end

--- a/lib/opal/cli.rb
+++ b/lib/opal/cli.rb
@@ -8,7 +8,7 @@ module Opal
   class CLI
     attr_reader :options, :file, :compiler_options, :evals, :load_paths, :argv,
       :output, :requires, :rbrequires, :gems, :stubs, :verbose, :runner_options,
-      :preload, :filename, :debug, :no_exit, :lib_only, :missing_require_severity,
+      :preload, :debug, :no_exit, :lib_only, :missing_require_severity,
       :no_cache, :argv_orig
 
     class << self
@@ -38,7 +38,7 @@ module Opal
       @output      = options.delete(:output)     { self.class.stdout || $stdout }
       @verbose     = options.delete(:verbose)    { false }
       @debug       = options.delete(:debug)      { false }
-      @filename    = options.delete(:filename)   { @file && @file.path }
+      @filename    = options.delete(:filename)   { @file&.path }
       @requires    = options.delete(:requires)   { [] }
       @rbrequires  = options.delete(:rbrequires) { [] }
       @no_cache    = options.delete(:no_cache)   { false }
@@ -60,6 +60,10 @@ module Opal
       raise ArgumentError, 'no runnable code provided (evals or file)' if @evals.empty? && @file.nil? && !@lib_only
       raise ArgumentError, "can't accept evals or file in `library only` mode" if (@evals.any? || @file) && @lib_only
       raise ArgumentError, "unknown options: #{options.inspect}" unless @options.empty?
+    end
+
+    def filename
+      @evals.any? ? '-e' : @filename
     end
 
     def run

--- a/lib/opal/cli.rb
+++ b/lib/opal/cli.rb
@@ -201,7 +201,9 @@ module Opal
         end
 
         if @cached_content.nil? || can_read_again
-          content = file.read
+          # On MacOS file.read is not enough to pick up changes, probably due to some
+          # cache or buffer, unclear if coming from ruby or the OS.
+          content = File.file?(file) ? File.read(file) : file.read
         end
 
         @cached_content ||= content unless can_read_again

--- a/lib/opal/cli.rb
+++ b/lib/opal/cli.rb
@@ -9,7 +9,7 @@ module Opal
     attr_reader :options, :file, :compiler_options, :evals, :load_paths, :argv,
       :output, :requires, :rbrequires, :gems, :stubs, :verbose, :runner_options,
       :preload, :filename, :debug, :no_exit, :lib_only, :missing_require_severity,
-      :no_cache
+      :no_cache, :argv_orig
 
     class << self
       attr_accessor :stdout
@@ -29,6 +29,7 @@ module Opal
       @no_exit     = options.delete(:no_exit)
       @lib_only    = options.delete(:lib_only)
       @argv        = options.delete(:argv)       { [] }
+      @argv_orig   = options.delete(:argv_orig)  { argv }
       @evals       = options.delete(:evals)      { [] }
       @load_paths  = options.delete(:load_paths) { [] }
       @gems        = options.delete(:gems)       { [] }
@@ -93,7 +94,7 @@ module Opal
       require 'opal/repl'
 
       repl = REPL.new
-      repl.run(OriginalARGV)
+      repl.run(argv_orig)
     end
 
     attr_reader :exit_status

--- a/lib/opal/cli_runners/compiler.rb
+++ b/lib/opal/cli_runners/compiler.rb
@@ -91,7 +91,7 @@ class Opal::CliRunners::Compiler
   end
 
   def reexec
-    system($0, *OriginalARGV) && exit
+    Process.kill('USR2', Process.pid)
   end
 
   def on_code_change(modified)


### PR DESCRIPTION
- Avoid relying on the `OriginalARGV` global var for communication between parts of the project
- Use `File.read` when possible to allow macOS read fresh data from the FS