### PR TITLE
Fix links in docs/compiler.md

### DIFF
--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -28,7 +28,6 @@ generating source maps afterwards.
 
 
 [parser]: https://github.com/opal/opal/tree/master/lib/opal/parser.rb
-[sexps]: https://github.com/opal/opal/tree/master/lib/opal/parser/sexp.rb
 [compiler]: https://github.com/opal/opal/tree/master/lib/opal/compiler.rb
 [fragments]: https://github.com/opal/opal/tree/master/lib/opal/fragment.rb
 [base-node]: https://github.com/opal/opal/tree/master/lib/opal/nodes/base.rb

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -27,6 +27,7 @@ code as well as a reference back to the original sexp which is useful for
 generating source maps afterwards.
 
 
+[parser]: https://github.com/opal/opal/tree/master/lib/opal/parser.rb
 [sexps]: https://github.com/opal/opal/tree/master/lib/opal/parser/sexp.rb
 [compiler]: https://github.com/opal/opal/tree/master/lib/opal/compiler.rb
 [fragments]: https://github.com/opal/opal/tree/master/lib/opal/fragment.rb


### PR DESCRIPTION
This PR adds a missing link reference definition and removed an unused one in [docs/compiler](https://opalrb.com/docs/guides/v1.7.1/compiler).