### PR TITLE
Fix eval with parser gem v3.2.1

### DIFF
--- a/lib/opal/parser/patch.rb
+++ b/lib/opal/parser/patch.rb
@@ -13,6 +13,12 @@ if RUBY_ENGINE == 'opal'
       else
         @source_pts = nil
       end
+
+      # Since parser v3.2.1 Parser::Lexer has @strings
+      if @strings
+        @strings.source_buffer = @source_buffer
+        @strings.source_pts = @source_pts
+      end
     end
   end
 


### PR DESCRIPTION
Opal fails to `eval` string literals with parser gem v3.2.1.

```console
$ opal -r opal-parser -e 'puts Parser::VERSION; puts eval %("foo")'
3.2.1.0
(eval):in `"foo"': undefined method `source' for nil (SyntaxError)
        from parser/lexer/literal.rb:253:50:in `clear_buffer'
        from parser/lexer/literal.rb:84:7:in `initialize'
        from <internal:corelib/class.rb>:43:1:in `Class_new$2'
        from parser/lexer-strings.rb:5010:41:in `push_literal'
        from parser/lexer-F1.rb:10275:17:in `advance'
        from parser/base.rb:252:21:in `next_token'
        from racc/parser.rb:293:34:in `$$1'
        from <internal:corelib/kernel.rb>:774:5:in `Kernel_catch$17'
        from racc/parser.rb:288:7:in `__send__'
        from <internal:corelib/basic_object.rb>:40:1:in `__send__'
        from racc/parser.rb:264:7:in `do_parse'
        from parser/base.rb:190:7:in `undefined'
        from parser/base.rb:187:7:in `parse'
        from opal/parser/default_config.rb:32:18:in `parse'
        from parser/base.rb:238:15:in `undefined'
        from parser/base.rb:234:7:in `tokenize'
        from opal/compiler.rb:284:64:in `$$3'
        from opal/compiler.rb:365:7:in `re_raise_with_location'
        from opal/compiler.rb:284:32:in `parse'
        from opal/compiler.rb:270:7:in `compile'
        from opal/compiler.rb:27:34:in `<top (required)>'
        from opal-parser.rb:40:1:in `eval'
        from -e:1:28:in `undefined'
        from -e:1:1:in `null'
        from node:internal/modules/cjs/loader:1165:14:in `Module._compile'
        from node:internal/modules/cjs/loader:1219:10:in `Module._extensions..js'
        from node:internal/modules/cjs/loader:1043:32:in `Module.load'
        from node:internal/modules/cjs/loader:878:12:in `Module._load'
        from node:internal/modules/run_main:81:12:in `executeUserEntryPoint'
        from node:internal/main/run_main_module:22:47:in `undefined'
(eval):in `"foo"': undefined method `source' for nil (NoMethodError)
        from parser/lexer/literal.rb:253:50:in `clear_buffer'
        from parser/lexer/literal.rb:84:7:in `initialize'
        from <internal:corelib/class.rb>:43:1:in `Class_new$2'
        from parser/lexer-strings.rb:5010:41:in `push_literal'
        from parser/lexer-F1.rb:10275:17:in `advance'
        from parser/base.rb:252:21:in `next_token'
        from racc/parser.rb:293:34:in `$$1'
        from <internal:corelib/kernel.rb>:774:5:in `Kernel_catch$17'
        from racc/parser.rb:288:7:in `__send__'
        from <internal:corelib/basic_object.rb>:40:1:in `__send__'
        from racc/parser.rb:264:7:in `do_parse'
        from parser/base.rb:190:7:in `undefined'
        from parser/base.rb:187:7:in `parse'
        from opal/parser/default_config.rb:32:18:in `parse'
        from parser/base.rb:238:15:in `undefined'
        from parser/base.rb:234:7:in `tokenize'
        from opal/compiler.rb:284:64:in `$$3'
        from opal/compiler.rb:365:7:in `re_raise_with_location'
        from opal/compiler.rb:284:32:in `parse'
        from opal/compiler.rb:270:7:in `compile'
        from opal/compiler.rb:27:34:in `<top (required)>'
        from opal-parser.rb:40:1:in `eval'
        from -e:1:28:in `undefined'
        from -e:1:1:in `null'
        from node:internal/modules/cjs/loader:1165:14:in `Module._compile'
        from node:internal/modules/cjs/loader:1219:10:in `Module._extensions..js'
        from node:internal/modules/cjs/loader:1043:32:in `Module.load'
        from node:internal/modules/cjs/loader:878:12:in `Module._load'
        from node:internal/modules/run_main:81:12:in `executeUserEntryPoint'
        from node:internal/main/run_main_module:22:47:in `undefined
```

It works if you add `gem 'parser', '3.2.0'` to your Gemfile.

```console
$ opal -r opal-parser -e 'puts Parser::VERSION; puts eval %("foo")'
3.2.0.0
foo
```

This PR fixes the issue.