### PR TITLE
Enable binmode for IO pipes

### DIFF
--- a/lib/opal/builder_scheduler/prefork.rb
+++ b/lib/opal/builder_scheduler/prefork.rb
@@ -131,8 +131,8 @@ module Opal
 
       class Fork
         def initialize(forkset)
-          @parent_read, @child_write = IO.pipe
-          @child_read, @parent_write = IO.pipe
+          @parent_read, @child_write = IO.pipe(binmode: true)
+          @child_read, @parent_write = IO.pipe(binmode: true)
           @forkset = forkset
           @in_fork = false
 


### PR DESCRIPTION
While setting up the Chrome runner for opal-rspec, I came across this error message with the builder:

```
# bundle exec rake
rake aborted!
Encoding::UndefinedConversionError: "\xFD" from ASCII-8BIT to UTF-8
/usr/local/bundle/gems/opal-1.7.2/lib/opal/builder_scheduler/prefork.rb:170:in `write'
/usr/local/bundle/gems/opal-1.7.2/lib/opal/builder_scheduler/prefork.rb:170:in `send_message'
/usr/local/bundle/gems/opal-1.7.2/lib/opal/builder_scheduler/prefork.rb:195:in `send'
/usr/local/bundle/gems/opal-1.7.2/lib/opal/builder_scheduler/prefork.rb:270:in `block (2 levels) in prefork_reactor'
/usr/local/bundle/gems/opal-1.7.2/lib/opal/builder_scheduler/prefork.rb:262:in `each'
/usr/local/bundle/gems/opal-1.7.2/lib/opal/builder_scheduler/prefork.rb:262:in `block in prefork_reactor'
/usr/local/bundle/gems/opal-1.7.2/lib/opal/builder_scheduler/prefork.rb:259:in `loop'
/usr/local/bundle/gems/opal-1.7.2/lib/opal/builder_scheduler/prefork.rb:259:in `prefork_reactor'
/usr/local/bundle/gems/opal-1.7.2/lib/opal/builder_scheduler/prefork.rb:17:in `process_requires'
/usr/local/bundle/gems/opal-1.7.2/lib/opal/builder.rb:216:in `process_requires'
/usr/local/bundle/gems/opal-1.7.2/lib/opal/builder.rb:107:in `build_str'
/usr/local/bundle/gems/opal-1.7.2/lib/opal/builder.rb:92:in `build'
/usr/local/bundle/gems/opal-1.7.2/lib/opal/cli.rb:135:in `block in create_builder'
/usr/local/bundle/gems/opal-1.7.2/lib/opal/cli.rb:135:in `each'
/usr/local/bundle/gems/opal-1.7.2/lib/opal/cli.rb:135:in `create_builder'
/usr/local/bundle/gems/opal-1.7.2/lib/opal/cli.rb:94:in `block in run'
/usr/local/bundle/gems/opal-1.7.2/lib/opal/cli_runners/chrome.rb:31:in `initialize'
/usr/local/bundle/gems/opal-1.7.2/lib/opal/cli_runners/chrome.rb:19:in `new'
/usr/local/bundle/gems/opal-1.7.2/lib/opal/cli_runners/chrome.rb:19:in `call'
/usr/local/bundle/gems/opal-1.7.2/lib/opal/cli.rb:96:in `run'
/usr/local/bundle/gems/opal-rspec-1.0.0/lib/opal/rspec/runner.rb:141:in `run'
/usr/src/app/Rakefile:12:in `block in <top (required)>'
/usr/local/bundle/gems/rake-13.0.6/exe/rake:27:in `<top (required)>'
/usr/local/bin/bundle:23:in `load'
/usr/local/bin/bundle:23:in `<main>'
Tasks: TOP => default
(See full trace by running task with --trace)
```

Since the code is using Marshal to pass data through the IO pipe, it expects to be in the ASCII-8BIT encoding. It would make sense then that we set `binmode` on the IO pipes so that they don't get confused with the string encoding.

Sorry for not including any tests, since I'm having trouble figuring out exactly what input causes it. It seems to work sometimes with a simple example, but loading more files causes it to crash? I'm not too sure.

I have an example repo here: https://github.com/bgastelo/example-opal-rspec-async where it is occurring. I've stepped through my debugger but I must be missing what causes it.

This is my first PR, so let me know if there is anything I can do to update my PR.

Thanks,

Brandon