### PR TITLE
Fix Chrome CDP interface connection

### DIFF
--- a/lib/opal/cli_runners/chrome_cdp_interface.rb
+++ b/lib/opal/cli_runners/chrome_cdp_interface.rb
@@ -121,14 +121,16 @@ var server = http.createServer(function(req, res) {
 
 // actual CDP code
 
-CDP.List(options, function(err, targets) {
+CDP.List(options, async function(err, targets) {
   // default CDP port is 9222, Firefox runner is at 9333
   // Lets collect clients for
   // Chrome CDP starting at 9273 ...
   // Firefox CDP starting 9334 ...
   port_offset = targets ? targets.length + 51 : 51; // default CDP port is 9222, Node CDP port 9229, Firefox is at 9333
 
-  return CDP(options, function(browser_client) {
+  const {webSocketDebuggerUrl} = await CDP.Version(options);
+
+  return await CDP({target: webSocketDebuggerUrl}, function(browser_client) {
 
     server.listen({ port: port_offset + options.port, host: options.host });
 

--- a/lib/opal/cli_runners/firefox_cdp_interface.rb
+++ b/lib/opal/cli_runners/firefox_cdp_interface.rb
@@ -94,10 +94,12 @@ var server = http.createServer(function(req, res) {
 
 // actual CDP code
 
-CDP.List(options, function(err, targets) {
+CDP.List(options, async function(err, targets) {
   offset = targets ? targets.length + 1 : 1;
 
-  return CDP(options, function(browser_client) {
+  const {webSocketDebuggerUrl} = await CDP.Version(options);
+
+  return await CDP({target: webSocketDebuggerUrl}, function(browser_client) {
 
     server.listen({port: offset + options.port, host: options.host });
 


### PR DESCRIPTION
These changes should fix the issue with connecting to the chrome runner.

This is the error message:
```
<js:/home/runner/work/opal/opal/lib/opal/cli_runners/node_modules/chrome-remote-interface/lib/chrome.js>:48:23:in `defaultTarget': No inspectable targets (Exception)
	from <js:/home/runner/work/opal/opal/lib/opal/cli_runners/node_modules/chrome-remote-interface/lib/chrome.js>:193:28:in `_fetchDebuggerURL'
	from node:internal/process/task_queues:95:5:in `processTicksAndRejections'
	from <js:/home/runner/work/opal/opal/lib/opal/cli_runners/node_modules/chrome-remote-interface/lib/chrome.js>:140:25:in `_start'
```

I based my changes on this comment from the repo: https://github.com/cyrus-and/chrome-remote-interface/issues/445#issuecomment-761773141

Testing locally, this seems to fix the main issue with CDP. However I am still seeing 2 errors in mspec:
```
1)
DateTime#to_date maintains the same julian day regardless of local time or zone FAILED
Expected 2456286 == 2456285
to be truthy but was false

2)
Time#wday returns an integer representing the day of the week, 0..6, with Sunday being 0 FAILED
Expected 3 == 4
to be truthy but was false
```

Maybe it's an issue with my local config?

Thanks,

Brandon