### PR TITLE
Fix for Opal::Cache::FileCache.dir_writable?

### DIFF
--- a/lib/opal/cache/file_cache.rb
+++ b/lib/opal/cache/file_cache.rb
@@ -78,19 +78,16 @@ module Opal
         nil
       end
 
-      # This complex piece of code tries to check if we can robustly mkdir_p a directory.
+      # Check if we can robustly mkdir_p a directory.
       def self.dir_writable?(*paths)
-        dir = nil
-        paths = paths.reduce([]) do |a, b|
-          [*a, dir = a.last ? File.expand_path(b, a.last) : b]
+        return false unless File.exist?(paths.first)
+
+        until paths.empty?
+          dir = File.expand_path(paths.shift, dir)
+          ok = File.directory?(dir) && File.writable?(dir) if File.exist?(dir)
         end
 
-        File.exist?(paths.first) &&
-          paths.reverse.all? do |i|
-            !File.exist?(i) || (File.directory?(i) && File.writable?(i))
-          end
-
-        dir
+        dir if ok
       end
 
       def self.find_dir


### PR DESCRIPTION
which previously returned truthy regardless of the dir being writeable or not, resulting in `dir_writable?(Dir.home, '.cache', 'opal')` being always true, even for non-login user (with $HOME set to /nonexistent)