### PR TITLE
Fix Array#sample randomness

### DIFF
--- a/opal/corelib/array.rb
+++ b/opal/corelib/array.rb
@@ -1927,9 +1927,9 @@ class ::Array < `Array`
           break;
         case 2:
           i = #{rng.rand(`self.length`)};
-          j = #{rng.rand(`self.length`)};
-          if (i === j) {
-            j = i === 0 ? i + 1 : i - 1;
+          j = #{rng.rand(`self.length - 1`)};
+          if (i <= j) {
+            j++;
           }
           return [self[i], self[j]];
           break;
@@ -1981,7 +1981,7 @@ class ::Array < `Array`
           result = self.slice();
 
           for (var c = 0; c < count; c++) {
-            targetIndex = #{rng.rand(`self.length`)};
+            targetIndex = #{rng.rand(`self.length - c`)} + c;
             oldValue = result[c];
             result[c] = result[targetIndex];
             result[targetIndex] = oldValue;

--- a/spec/filters/bugs/array.rb
+++ b/spec/filters/bugs/array.rb
@@ -27,7 +27,6 @@ opal_filter "Array" do
   fails "Array#rassoc calls elem == obj on the second element of each contained array" # Expected [1, "foobar"] == [2, #<MockObject:0x4a6b4 @name="foobar", @null=nil>] to be truthy but was false
   fails "Array#rassoc does not check the last element in each contained but specifically the second" # Expected [1, "foobar", #<MockObject:0x4a37e @name="foobar", @null=nil>] == [2, #<MockObject:0x4a37e @name="foobar", @null=nil>, 1] to be truthy but was false
   fails "Array#sample returns nil for an empty array when called without n and a Random is given" # ArgumentError: invalid argument - 0
-  fails "Array#sample samples evenly" # Expected 15.82 <= 13.277 to be truthy but was false
   fails "Array#select returns a new array of elements for which block is true" # Expected [1] == [1, 4, 6] to be truthy but was false
   fails "Array#slice can be sliced with Enumerator::ArithmeticSequence has endless range with start outside of array's bounds" # Expected [] == nil to be truthy but was false
   fails "Array#slice can be sliced with Enumerator::ArithmeticSequence has range with bounds outside of array" # Expected RangeError but no exception was raised ([0, 2, 4] was returned)


### PR DESCRIPTION
Result of `Array#sample` is biased as shown below.
This PR fixes it.

### Test script
```rb
n = 2
array = [0, 1, 2]
h = array.permutation(n).map { [_1, 0] }.to_h

p 100000.times.map { array.sample(n) }.tally(h)
```

### Result
#### n = 2
```
{[0, 1]=>22253, [0, 2]=>11210, [1, 0]=>22379, [1, 2]=>11014, [2, 0]=>10970, [2, 1]=>22174}
```
#### n = 3
```
{[0, 1, 2]=>14988, [0, 2, 1]=>18262, [1, 0, 2]=>18453, [1, 2, 0]=>18645, [2, 0, 1]=>14864, [2, 1, 0]=>14788}
```
Note that the implemetation employs [Fisher–Yates shuffle](https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle) algorithm.