### PR TITLE
Fix Kernel#.Integer with `exception:` option

### DIFF
--- a/opal/corelib/kernel.rb
+++ b/opal/corelib/kernel.rb
@@ -391,24 +391,47 @@ module ::Kernel
 
       if (!value.$$is_string) {
         if (base !== undefined) {
-          #{::Kernel.raise ::ArgumentError, 'base specified for non string value'}
+          if ($truthy(#{exception})) {
+            #{::Kernel.raise ::ArgumentError, 'base specified for non string value'}
+          } else {
+            return nil;
+          }
         }
         if (value === nil) {
-          #{::Kernel.raise ::TypeError, "can't convert nil into Integer"}
+          if ($truthy(#{exception})) {
+            #{::Kernel.raise ::TypeError, "can't convert nil into Integer"}
+          } else {
+            return nil;
+          }
         }
         if (value.$$is_number) {
           if (value === Infinity || value === -Infinity || isNaN(value)) {
-            #{::Kernel.raise ::FloatDomainError, value}
+            if ($truthy(#{exception})) {
+              #{::Kernel.raise ::FloatDomainError, value}
+            } else {
+              return nil;
+            }
           }
           return Math.floor(value);
         }
         if (#{value.respond_to?(:to_int)}) {
           i = #{value.to_int};
-          if (i !== nil) {
+          if (Opal.is_a(i, #{::Integer})) {
             return i;
           }
         }
-        return #{::Opal.coerce_to!(value, ::Integer, :to_i)};
+        if (#{value.respond_to?(:to_i)}) {
+          i = #{value.to_i};
+          if (Opal.is_a(i, #{::Integer})) {
+            return i;
+          }
+        }
+
+        if ($truthy(#{exception})) {
+          #{::Kernel.raise ::TypeError, "can't convert #{value.class} into Integer"}
+        } else {
+          return nil;
+        }
       }
 
       if (value === "0") {
@@ -420,7 +443,11 @@ module ::Kernel
       } else {
         base = $coerce_to(base, #{::Integer}, 'to_int');
         if (base === 1 || base < 0 || base > 36) {
-          #{::Kernel.raise ::ArgumentError, "invalid radix #{base}"}
+          if ($truthy(#{exception})) {
+            #{::Kernel.raise ::ArgumentError, "invalid radix #{base}"}
+          } else {
+            return nil;
+          }
         }
       }
 
@@ -456,7 +483,11 @@ module ::Kernel
           }
           // no-break
         }
-        #{::Kernel.raise ::ArgumentError, "invalid value for Integer(): \"#{value}\""}
+        if ($truthy(#{exception})) {
+          #{::Kernel.raise ::ArgumentError, "invalid value for Integer(): \"#{value}\""}
+        } else {
+          return nil;
+        }
       });
 
       base = (base === 0 ? 10 : base);
@@ -464,23 +495,25 @@ module ::Kernel
       base_digits = '0-' + (base <= 10 ? base - 1 : '9a-' + String.fromCharCode(97 + (base - 11)));
 
       if (!(new RegExp('^\\s*[+-]?[' + base_digits + ']+\\s*$')).test(str)) {
-        #{::Kernel.raise ::ArgumentError, "invalid value for Integer(): \"#{value}\""}
+        if ($truthy(#{exception})) {
+          #{::Kernel.raise ::ArgumentError, "invalid value for Integer(): \"#{value}\""}
+        } else {
+          return nil;
+        }
       }
 
       i = parseInt(str, base);
 
       if (isNaN(i)) {
-        #{::Kernel.raise ::ArgumentError, "invalid value for Integer(): \"#{value}\""}
+        if ($truthy(#{exception})) {
+          #{::Kernel.raise ::ArgumentError, "invalid value for Integer(): \"#{value}\""}
+        } else {
+          return nil;
+        }
       }
 
       return i;
     }
-  rescue
-    unless exception
-      return nil
-    end
-
-    ::Kernel.raise
   end
 
   def Float(value, exception: true)

--- a/opal/corelib/kernel.rb
+++ b/opal/corelib/kernel.rb
@@ -385,7 +385,7 @@ module ::Kernel
     }
   end
 
-  def Integer(value, base = undefined)
+  def Integer(value, base = undefined, exception: true)
     %x{
       var i, str, base_digits;
 
@@ -475,6 +475,12 @@ module ::Kernel
 
       return i;
     }
+  rescue
+    unless exception
+      return nil
+    end
+
+    ::Kernel.raise
   end
 
   def Float(value, exception: true)

--- a/opal/corelib/kernel.rb
+++ b/opal/corelib/kernel.rb
@@ -389,16 +389,18 @@ module ::Kernel
     %x{
       var i, str, base_digits;
 
+      exception = $truthy(#{exception});
+
       if (!value.$$is_string) {
         if (base !== undefined) {
-          if ($truthy(#{exception})) {
+          if (exception) {
             #{::Kernel.raise ::ArgumentError, 'base specified for non string value'}
           } else {
             return nil;
           }
         }
         if (value === nil) {
-          if ($truthy(#{exception})) {
+          if (exception) {
             #{::Kernel.raise ::TypeError, "can't convert nil into Integer"}
           } else {
             return nil;
@@ -406,7 +408,7 @@ module ::Kernel
         }
         if (value.$$is_number) {
           if (value === Infinity || value === -Infinity || isNaN(value)) {
-            if ($truthy(#{exception})) {
+            if (exception) {
               #{::Kernel.raise ::FloatDomainError, value}
             } else {
               return nil;
@@ -427,7 +429,7 @@ module ::Kernel
           }
         }
 
-        if ($truthy(#{exception})) {
+        if (exception) {
           #{::Kernel.raise ::TypeError, "can't convert #{value.class} into Integer"}
         } else {
           return nil;
@@ -443,7 +445,7 @@ module ::Kernel
       } else {
         base = $coerce_to(base, #{::Integer}, 'to_int');
         if (base === 1 || base < 0 || base > 36) {
-          if ($truthy(#{exception})) {
+          if (exception) {
             #{::Kernel.raise ::ArgumentError, "invalid radix #{base}"}
           } else {
             return nil;
@@ -483,7 +485,7 @@ module ::Kernel
           }
           // no-break
         }
-        if ($truthy(#{exception})) {
+        if (exception) {
           #{::Kernel.raise ::ArgumentError, "invalid value for Integer(): \"#{value}\""}
         } else {
           return nil;
@@ -495,7 +497,7 @@ module ::Kernel
       base_digits = '0-' + (base <= 10 ? base - 1 : '9a-' + String.fromCharCode(97 + (base - 11)));
 
       if (!(new RegExp('^\\s*[+-]?[' + base_digits + ']+\\s*$')).test(str)) {
-        if ($truthy(#{exception})) {
+        if (exception) {
           #{::Kernel.raise ::ArgumentError, "invalid value for Integer(): \"#{value}\""}
         } else {
           return nil;
@@ -505,7 +507,7 @@ module ::Kernel
       i = parseInt(str, base);
 
       if (isNaN(i)) {
-        if ($truthy(#{exception})) {
+        if (exception) {
           #{::Kernel.raise ::ArgumentError, "invalid value for Integer(): \"#{value}\""}
         } else {
           return nil;
@@ -520,8 +522,10 @@ module ::Kernel
     %x{
       var str;
 
+      exception = $truthy(#{exception});
+
       if (value === nil) {
-        if ($truthy(#{exception})) {
+        if (exception) {
           #{::Kernel.raise ::TypeError, "can't convert nil into Float"}
         } else {
           return nil;
@@ -539,7 +543,7 @@ module ::Kernel
         }
 
         if (!/^\s*[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?\s*$/.test(str)) {
-          if ($truthy(#{exception})) {
+          if (exception) {
             #{::Kernel.raise ::ArgumentError, "invalid value for Float(): \"#{value}\""}
           } else {
             return nil;
@@ -549,7 +553,7 @@ module ::Kernel
         return parseFloat(str);
       }
 
-      if ($truthy(#{exception})) {
+      if (exception) {
         return #{::Opal.coerce_to!(value, ::Float, :to_f)};
       } else {
         return $coerce_to(value, #{::Float}, 'to_f');

--- a/spec/filters/bugs/kernel.rb
+++ b/spec/filters/bugs/kernel.rb
@@ -16,20 +16,6 @@ opal_filter "Kernel" do
   fails "Kernel#Float for hexadecimal literals with binary exponent returns Infinity for '0x1p10000'" # ArgumentError: invalid value for Float(): "0x1p10000"
   fails "Kernel#Integer raises a TypeError when to_int returns not-an-Integer object and to_i returns nil" # Expected TypeError but no exception was raised ("1" was returned)
   fails "Kernel#Integer return a result of to_i when to_int does not return an Integer" # Expected "1" == 42 to be truthy but was false
-  fails "Kernel#Integer when passed exception: false and an argument that contains a period swallows an error" # TypeError: no implicit conversion of Hash into Integer
-  fails "Kernel#Integer when passed exception: false and an empty string swallows an error" # TypeError: no implicit conversion of Hash into Integer
-  fails "Kernel#Integer when passed exception: false and invalid argument swallows an error" # ArgumentError: [MSpecEnv#Integer] wrong number of arguments (given 3, expected -2)
-  fails "Kernel#Integer when passed exception: false and multiple leading -s swallows an error" # TypeError: no implicit conversion of Hash into Integer
-  fails "Kernel#Integer when passed exception: false and multiple trailing -s swallows an error" # TypeError: no implicit conversion of Hash into Integer
-  fails "Kernel#Integer when passed exception: false and no to_int or to_i methods exist swallows an error" # ArgumentError: base specified for non string value
-  fails "Kernel#Integer when passed exception: false and passed Infinity swallows an error" # ArgumentError: base specified for non string value
-  fails "Kernel#Integer when passed exception: false and passed NaN swallows an error" # ArgumentError: base specified for non string value
-  fails "Kernel#Integer when passed exception: false and passed a String that can't be converted to an Integer swallows an error" # TypeError: no implicit conversion of Hash into Integer
-  fails "Kernel#Integer when passed exception: false and passed a String that contains numbers normally parses it and returns an Integer" # TypeError: no implicit conversion of Hash into Integer
-  fails "Kernel#Integer when passed exception: false and passed nil swallows an error" # ArgumentError: base specified for non string value
-  fails "Kernel#Integer when passed exception: false and to_i returns a value that is not an Integer swallows an error" # ArgumentError: base specified for non string value
-  fails "Kernel#Integer when passed exception: false and to_int returns nil and no to_i exists swallows an error" # ArgumentError: base specified for non string value
-  fails "Kernel#Integer when passed exception: false and valid argument returns an Integer number" # ArgumentError: [MSpecEnv#Integer] wrong number of arguments (given 3, expected -2)
   fails "Kernel#Pathname returns same argument when called with a pathname argument" # Expected #<Pathname:0xb23c2 @path="foo">.equal? #<Pathname:0xb23c4 @path="foo"> to be truthy but was false
   fails "Kernel#String calls #to_s if #respond_to?(:to_s) returns true" # TypeError: no implicit conversion of MockObject into String
   fails "Kernel#String raises a TypeError if #to_s is not defined, even though #respond_to?(:to_s) returns true" # Expected TypeError but got: NoMethodError (undefined method `to_s' for #<Object:0x2961a>)
@@ -322,20 +308,6 @@ opal_filter "Kernel" do
   fails "Kernel.Float for hexadecimal literals with binary exponent returns Infinity for '0x1p10000'" # ArgumentError: invalid value for Float(): "0x1p10000"
   fails "Kernel.Integer raises a TypeError when to_int returns not-an-Integer object and to_i returns nil" # Expected TypeError but no exception was raised ("1" was returned)
   fails "Kernel.Integer return a result of to_i when to_int does not return an Integer" # Expected "1" == 42 to be truthy but was false
-  fails "Kernel.Integer when passed exception: false and an argument that contains a period swallows an error" # TypeError: no implicit conversion of Hash into Integer
-  fails "Kernel.Integer when passed exception: false and an empty string swallows an error" # TypeError: no implicit conversion of Hash into Integer
-  fails "Kernel.Integer when passed exception: false and invalid argument swallows an error" # ArgumentError: [MSpecEnv#Integer] wrong number of arguments (given 3, expected -2)
-  fails "Kernel.Integer when passed exception: false and multiple leading -s swallows an error" # TypeError: no implicit conversion of Hash into Integer
-  fails "Kernel.Integer when passed exception: false and multiple trailing -s swallows an error" # TypeError: no implicit conversion of Hash into Integer
-  fails "Kernel.Integer when passed exception: false and no to_int or to_i methods exist swallows an error" # ArgumentError: base specified for non string value
-  fails "Kernel.Integer when passed exception: false and passed Infinity swallows an error" # ArgumentError: base specified for non string value
-  fails "Kernel.Integer when passed exception: false and passed NaN swallows an error" # ArgumentError: base specified for non string value
-  fails "Kernel.Integer when passed exception: false and passed a String that can't be converted to an Integer swallows an error" # TypeError: no implicit conversion of Hash into Integer
-  fails "Kernel.Integer when passed exception: false and passed a String that contains numbers normally parses it and returns an Integer" # TypeError: no implicit conversion of Hash into Integer
-  fails "Kernel.Integer when passed exception: false and passed nil swallows an error" # ArgumentError: base specified for non string value
-  fails "Kernel.Integer when passed exception: false and to_i returns a value that is not an Integer swallows an error" # ArgumentError: base specified for non string value
-  fails "Kernel.Integer when passed exception: false and to_int returns nil and no to_i exists swallows an error" # ArgumentError: base specified for non string value
-  fails "Kernel.Integer when passed exception: false and valid argument returns an Integer number" # ArgumentError: [MSpecEnv#Integer] wrong number of arguments (given 3, expected -2)
   fails "Kernel.Rational when passed a String converts the String to a Rational using the same method as String#to_r" # Expected (0/1) == (13/25) to be truthy but was false
   fails "Kernel.Rational when passed a String does not use the same method as Float#to_r" # Expected (5404319552844595/9007199254740992) == (3/5) to be truthy but was false
   fails "Kernel.Rational when passed a String raises a TypeError if the first argument is a Symbol" # Expected TypeError but no exception was raised ((0/1) was returned)


### PR DESCRIPTION
Support keyword argument `exception` of `Kernel#.Integer`.

RDoc: https://ruby-doc.org/3.2.1/Kernel.html#method-i-Integer