### PR TITLE
Fix Kernel#.Float with `exception:` option

### DIFF
--- a/opal/corelib/kernel.rb
+++ b/opal/corelib/kernel.rb
@@ -477,7 +477,7 @@ module ::Kernel
     }
   end
 
-  def Float(value)
+  def Float(value, exception: true)
     %x{
       var str;
 
@@ -504,6 +504,12 @@ module ::Kernel
 
       return #{::Opal.coerce_to!(value, ::Float, :to_f)};
     }
+  rescue
+    unless exception
+      return nil
+    end
+
+    ::Kernel.raise
   end
 
   def Hash(arg)

--- a/opal/corelib/kernel.rb
+++ b/opal/corelib/kernel.rb
@@ -482,7 +482,11 @@ module ::Kernel
       var str;
 
       if (value === nil) {
-        #{::Kernel.raise ::TypeError, "can't convert nil into Float"}
+        if ($truthy(#{exception})) {
+          #{::Kernel.raise ::TypeError, "can't convert nil into Float"}
+        } else {
+          return nil;
+        }
       }
 
       if (value.$$is_string) {
@@ -496,20 +500,22 @@ module ::Kernel
         }
 
         if (!/^\s*[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?\s*$/.test(str)) {
-          #{::Kernel.raise ::ArgumentError, "invalid value for Float(): \"#{value}\""}
+          if ($truthy(#{exception})) {
+            #{::Kernel.raise ::ArgumentError, "invalid value for Float(): \"#{value}\""}
+          } else {
+            return nil;
+          }
         }
 
         return parseFloat(str);
       }
 
-      return #{::Opal.coerce_to!(value, ::Float, :to_f)};
+      if ($truthy(#{exception})) {
+        return #{::Opal.coerce_to!(value, ::Float, :to_f)};
+      } else {
+        return $coerce_to(value, #{::Float}, 'to_f');
+      }
     }
-  rescue
-    unless exception
-      return nil
-    end
-
-    ::Kernel.raise
   end
 
   def Hash(arg)

--- a/spec/filters/bugs/kernel.rb
+++ b/spec/filters/bugs/kernel.rb
@@ -14,9 +14,6 @@ opal_filter "Kernel" do
   fails "Kernel#Float for hexadecimal literals with binary exponent returns 0 for '0x1p-10000'" # ArgumentError: invalid value for Float(): "0x1p-10000"
   fails "Kernel#Float for hexadecimal literals with binary exponent returns Infinity for '0x1P10000'" # ArgumentError: invalid value for Float(): "0x1P10000"
   fails "Kernel#Float for hexadecimal literals with binary exponent returns Infinity for '0x1p10000'" # ArgumentError: invalid value for Float(): "0x1p10000"
-  fails "Kernel#Float when passed exception: false and invalid input swallows an error" # ArgumentError: [Object#Float] wrong number of arguments (given 2, expected 1)
-  fails "Kernel#Float when passed exception: false and nil swallows it" # ArgumentError: [Object#Float] wrong number of arguments (given 2, expected 1)
-  fails "Kernel#Float when passed exception: false and valid input returns a Float number" # ArgumentError: [Object#Float] wrong number of arguments (given 2, expected 1)
   fails "Kernel#Integer raises a TypeError when to_int returns not-an-Integer object and to_i returns nil" # Expected TypeError but no exception was raised ("1" was returned)
   fails "Kernel#Integer return a result of to_i when to_int does not return an Integer" # Expected "1" == 42 to be truthy but was false
   fails "Kernel#Integer when passed exception: false and an argument that contains a period swallows an error" # TypeError: no implicit conversion of Hash into Integer
@@ -323,9 +320,6 @@ opal_filter "Kernel" do
   fails "Kernel.Float for hexadecimal literals with binary exponent returns 0 for '0x1p-10000'" # ArgumentError: invalid value for Float(): "0x1p-10000"
   fails "Kernel.Float for hexadecimal literals with binary exponent returns Infinity for '0x1P10000'" # ArgumentError: invalid value for Float(): "0x1P10000"
   fails "Kernel.Float for hexadecimal literals with binary exponent returns Infinity for '0x1p10000'" # ArgumentError: invalid value for Float(): "0x1p10000"
-  fails "Kernel.Float when passed exception: false and invalid input swallows an error" # ArgumentError: [Kernel.Float] wrong number of arguments (given 2, expected 1)
-  fails "Kernel.Float when passed exception: false and nil swallows it" # ArgumentError: [Kernel.Float] wrong number of arguments (given 2, expected 1)
-  fails "Kernel.Float when passed exception: false and valid input returns a Float number" # ArgumentError: [Kernel.Float] wrong number of arguments (given 2, expected 1)
   fails "Kernel.Integer raises a TypeError when to_int returns not-an-Integer object and to_i returns nil" # Expected TypeError but no exception was raised ("1" was returned)
   fails "Kernel.Integer return a result of to_i when to_int does not return an Integer" # Expected "1" == 42 to be truthy but was false
   fails "Kernel.Integer when passed exception: false and an argument that contains a period swallows an error" # TypeError: no implicit conversion of Hash into Integer


### PR DESCRIPTION
Support keyword argument `exception` of `Kernel#.Float`.

RDoc: https://ruby-doc.org/3.2.1/Kernel.html#method-i-Float