### PR TITLE
Improve performance of Array#intersect? and intersection

### DIFF
--- a/opal/corelib/array.rb
+++ b/opal/corelib/array.rb
@@ -1417,7 +1417,7 @@ class ::Array < `Array`
 
     # First, calculate intersection of argument arrays.
     # Array#& is faster when the argument size is small.
-    # So `largest & shotest & second_shortest & ...` would be the fastest.
+    # So `largest & shortest & second_shortest & ...` would be the fastest.
     largest = `arrays.pop()`
     intersection_of_args = arrays.reduce(largest, &:&)
 

--- a/opal/corelib/array.rb
+++ b/opal/corelib/array.rb
@@ -142,11 +142,13 @@ class ::Array < `Array`
   end
 
   def &(other)
-    return [] if `self.length === 0`
-
-    other = `convertToArray(other)`
-
     %x{
+      other = convertToArray(other)
+
+      if (self.length === 0 || other.length === 0) {
+        return [];
+      }
+
       var result = [], hash = #{{}}, i, length, item;
 
       for (i = 0, length = other.length; i < length; i++) {
@@ -210,9 +212,9 @@ class ::Array < `Array`
   end
 
   def -(other)
-    return [] if `self.length === 0`
-
     other = `convertToArray(other)`
+
+    return [] if `self.length === 0`
     return `self.slice()` if `other.length === 0`
 
     %x{

--- a/opal/corelib/array.rb
+++ b/opal/corelib/array.rb
@@ -68,6 +68,13 @@ class ::Array < `Array`
 
       if (raised) throw raised;
     }
+
+    function convertToArray(array) {
+      if (!array.$$is_array) {
+        array = $coerce_to(array, #{::Array}, 'to_ary');
+      }
+      return #{`array`.to_a};
+    }
   }
 
   def self.[](*objects)
@@ -135,11 +142,7 @@ class ::Array < `Array`
   end
 
   def &(other)
-    other = if ::Array === other
-              other.to_a
-            else
-              `$coerce_to(other, #{::Array}, 'to_ary')`.to_a
-            end
+    other = `convertToArray(other)`
 
     %x{
       var result = [], hash = #{{}}, i, length, item;
@@ -160,11 +163,7 @@ class ::Array < `Array`
   end
 
   def |(other)
-    other = if ::Array === other
-              other.to_a
-            else
-              `$coerce_to(other, #{::Array}, 'to_ary')`.to_a
-            end
+    other = `convertToArray(other)`
 
     %x{
       var hash = #{{}}, i, length, item;
@@ -203,23 +202,15 @@ class ::Array < `Array`
   end
 
   def +(other)
-    other = if ::Array === other
-              other.to_a
-            else
-              `$coerce_to(other, #{::Array}, 'to_ary')`.to_a
-            end
+    other = `convertToArray(other)`
 
     `self.concat(other)`
   end
 
   def -(other)
-    other = if ::Array === other
-              other.to_a
-            else
-              `$coerce_to(other, #{::Array}, 'to_ary')`.to_a
-            end
-
     return [] if `self.length === 0`
+
+    other = `convertToArray(other)`
     return `self.slice()` if `other.length === 0`
 
     %x{
@@ -849,11 +840,7 @@ class ::Array < `Array`
     `$deny_frozen_access(self)`
 
     others = others.map do |other|
-      other = if ::Array === other
-                other.to_a
-              else
-                `$coerce_to(other, #{::Array}, 'to_ary')`.to_a
-              end
+      `other = convertToArray(other)`
 
       if other.equal?(self)
         other = other.dup
@@ -1782,11 +1769,7 @@ class ::Array < `Array`
   def replace(other)
     `$deny_frozen_access(self)`
 
-    other = if ::Array === other
-              other.to_a
-            else
-              `$coerce_to(other, #{::Array}, 'to_ary')`.to_a
-            end
+    other = `convertToArray(other)`
 
     %x{
       self.splice(0, self.length);
@@ -2325,11 +2308,7 @@ class ::Array < `Array`
     max    = nil
 
     each do |row|
-      row = if ::Array === row
-              row.to_a
-            else
-              `$coerce_to(row, #{::Array}, 'to_ary')`.to_a
-            end
+      `row = convertToArray(row)`
 
       max ||= `row.length`
 

--- a/opal/corelib/array.rb
+++ b/opal/corelib/array.rb
@@ -1414,7 +1414,27 @@ class ::Array < `Array`
   end
 
   def intersect?(other)
-    !intersection(other).empty?
+    %x{
+      var small, large, hash = #{{}}, i, length;
+      if (self.length < other.length) {
+        small = self;
+        large = other;
+      } else {
+        small = other;
+        large = self;
+      }
+
+      for (i = 0, length = small.length; i < length; i++) {
+        $hash_put(hash, small[i], true);
+      }
+
+      for (i = 0, length = large.length; i < length; i++) {
+        if ($hash_get(hash, large[i])) {
+          return true;
+        }
+      }
+      return false;
+    }
   end
 
   def join(sep = nil)


### PR DESCRIPTION
This PR improves performance of `Array#intersect?` and `Array#intersection`.

### Array#intersect?
It returns true immediately when first common element is found instead of calculating the whole of intersection.
This is what CRuby (and probably most other implementations) do.

### Array#intersection
These two intersection method calls give identical results, but former is significantly slow on current master.
```ruby
large_array = (1..10000).to_a
large_array.intersection(large_array, [1]) # slow
large_array.intersection([1], large_array) # fast
```
It is now optimized with this PR.