### PR TITLE
[NEXT] Opal 2.0 development branch

### DIFF
--- a/.eslintrc.await.js
+++ b/.eslintrc.await.js
@@ -1,6 +1,0 @@
-module.exports = {
-  "extends": "./.eslintrc.js",
-  "parserOptions": {
-    "ecmaVersion": 8
-  },
-};

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
   },
   "extends": "eslint:recommended",
   "parserOptions": {
-    "ecmaVersion": 3
+    "ecmaVersion": 12
   },
   "rules": {
     "no-unused-vars": ["error", {

--- a/lib/opal/version.rb
+++ b/lib/opal/version.rb
@@ -3,5 +3,5 @@
 module Opal
   # WHEN RELEASING:
   # Remember to update RUBY_ENGINE_VERSION in opal/corelib/constants.rb too!
-  VERSION = '1.8.1'
+  VERSION = '2.0.0dev'
 end

--- a/opal/corelib/constants.rb
+++ b/opal/corelib/constants.rb
@@ -1,8 +1,8 @@
 ::RUBY_PLATFORM       = 'opal'
 ::RUBY_ENGINE         = 'opal'
 ::RUBY_VERSION        = '3.2.0'
-::RUBY_ENGINE_VERSION = '1.8.1'
-::RUBY_RELEASE_DATE   = '2023-11-09'
+::RUBY_ENGINE_VERSION = '2.0.0dev'
+::RUBY_RELEASE_DATE   = '2023-11-16'
 ::RUBY_PATCHLEVEL     = 0
 ::RUBY_REVISION       = '0'
 ::RUBY_COPYRIGHT      = 'opal - Copyright (C) 2011-2023 Adam Beynon and the Opal contributors'

--- a/tasks/linting.rake
+++ b/tasks/linting.rake
@@ -15,17 +15,12 @@ namespace :lint do
     Rake::Task[:dist].invoke
 
     files = Dir["#{dir}/*.js"]
-    es8, es3 = files.partition { |i| i.include? "await" }
 
-    [es3, es8].each do |files|
-      config = (files == es8) ? ["-c", __dir__+"/../.eslintrc.await.js"] : []
-
-      sh "yarn", "run", "eslint", *config, *files, "--format", "json", "--output-file", result_path do |ok, _|
-        if ok
-          puts "Successful."
-        else
-          sh 'node tasks/linting-parse-eslint-results.js'
-        end
+    sh "yarn", "run", "eslint", *files, "--format", "json", "--output-file", result_path do |ok, _|
+      if ok
+        puts "Successful."
+      else
+        sh 'node tasks/linting-parse-eslint-results.js'
       end
     end
   end


### PR DESCRIPTION
This (`next`) is a development branch of 2.0 to which we should direct our pull requests.

As of now, we are in development of Opal 1.8 (`master`), which is meant to be a deprecation-warning release. A rule of thumb is, if you want to break compatibility, you should whenever possible push one pull request to `master` and one to `next` - `master` warns about impending consequences, `next` breaks compatibility.

Another rule of thumb is, that we should provide a way to stay compatible with both versions.

If Opal 2.0 is not ready[define readiness] by the time Opal 1.8 is released, we will start Opal 1.9 development. If it is, we will merge this branch into `master` and focus on preparing the 2.0 release.

This branch is special, as it SHOULD NOT be force-pushed, it will contain occasional merges from `master`.