### PR TITLE
Fix switch with Object-wrapped values

### DIFF
--- a/lib/opal/nodes/if.rb
+++ b/lib/opal/nodes/if.rb
@@ -349,7 +349,7 @@ module Opal
           @switch_additional_rules = sexp.meta[:switch_additional_rules]
           compile_switch_case(sexp.meta[:switch_test])
         else
-          line "switch (", expr(@switch_first_test), ") {"
+          line "switch (", expr(@switch_first_test), ".valueOf()) {"
           indent do
             compile_switch_case(@switch_test)
           end

--- a/spec/opal/core/language/case_spec.rb
+++ b/spec/opal/core/language/case_spec.rb
@@ -1,0 +1,13 @@
+describe "Case statement" do
+  it "works with JS object-wrapped values" do
+    a = false
+    objwr = `new String("abc")`
+
+    case objwr
+    when "abc"
+      a = true
+    end
+
+    a.should == true
+  end
+end


### PR DESCRIPTION
This manifested itself by parser (if compiled with Opal) dropping a minus sign on integers if there is encoding set (eg. by adding some UTF-8 characters to input).

This fixes #2539