### PR TITLE
Bridging: call original constructor for subclasses of level larger than 1

### DIFF
--- a/opal/corelib/error.rb
+++ b/opal/corelib/error.rb
@@ -36,6 +36,16 @@ class ::Exception < `Error`
     `self.message = (args.length > 0) ? args[0] : nil`
   end
 
+  # Those instance variables are not enumerable.
+  def copy_instance_variables(other)
+    super
+    %x{
+      self.message = other.message;
+      self.cause = other.cause;
+      self.stack = other.stack;
+    }
+  end
+
   %x{
     // Convert backtrace from any format to Ruby format
     function correct_backtrace(backtrace) {

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -538,6 +538,13 @@
   Opal.$$$ = Opal.const_get_qualified;
   Opal.$r = Opal.const_get_relative_factory;
 
+  function descends_from_bridged_class(klass) {
+    if (klass == null) return false;
+    if (klass.$$bridge) return klass;
+    if (klass.$$super) return descends_from_bridged_class(klass.$$super);
+    return false;
+  }
+
   // Modules & Classes
   // -----------------
 
@@ -567,14 +574,14 @@
   // @return new [Class]  or existing ruby class
   //
   function $allocate_class(name, superclass, singleton) {
-    var klass;
+    var klass, bridged_descendant;
 
-    if (superclass != null && superclass.$$bridge) {
+    if (bridged_descendant = descends_from_bridged_class(superclass)) {
       // Inheritance from bridged classes requires
       // calling original JS constructors
       klass = function() {
         var args = $slice(arguments),
-            self = new ($bind.apply(superclass.$$constructor, [null].concat(args)))();
+            self = new ($bind.apply(bridged_descendant.$$constructor, [null].concat(args)))();
 
         // and replacing a __proto__ manually
         $set_proto(self, klass.$$prototype);

--- a/spec/opal/core/runtime/bridged_classes_spec.rb
+++ b/spec/opal/core/runtime/bridged_classes_spec.rb
@@ -122,6 +122,42 @@ describe 'Bridged classes in different modules' do
   end
 end
 
+%x{
+  var counter = 0;
+  var reset_counter = function() { counter = 0; };
+  var bridge_class_with_constructor = function() { counter++; };
+}
+
+class BridgedLevel0 < `bridge_class_with_constructor`; end
+class BridgedLevel1 < BridgedLevel0; end
+class BridgedLevel2 < BridgedLevel1; end
+class BridgedLevel3 < BridgedLevel2; end
+
+describe 'Inheritance with bridged classes' do
+  it 'should call a JS constructor on level 0' do
+    `reset_counter()`
+    BridgedLevel0.new
+    `counter`.should == 1
+  end
+
+  it 'should call a JS constructor on level 1' do
+    `reset_counter()`
+    BridgedLevel1.new
+    `counter`.should == 1
+  end
+
+  it 'should call a JS constructor on level 2' do
+    `reset_counter()`
+    BridgedLevel2.new
+    `counter`.should == 1
+  end
+
+  it 'should call a JS constructor on level 3' do
+    `reset_counter()`
+    BridgedLevel3.new
+    `counter`.should == 1
+  end
+end
 
 describe "Invalid bridged classes" do
   it "raises a TypeError when trying to extend with non-Class" do


### PR DESCRIPTION
This commit introduces a function `descends_from_bridged_class(klass)` to check if a class or any of its ancestors is a bridged class. During the allocation of a new class, the `descends_from_bridged_class()` function is now used to determine if the new class is a descendant of a bridged class, and if so, it ensures the original JavaScript constructor is correctly called. This enables more accurate and robust handling of class hierarchies involving bridged classes.

This problem has manifested in Firefox which didn't capture stacktraces for RuntimeError, but did so for StandardError.

This fixes #2540