### PR TITLE
nodejs/yaml: restore functionality

### DIFF
--- a/stdlib/nodejs/js-yaml-3-6-1.js
+++ b/stdlib/nodejs/js-yaml-3-6-1.js
@@ -3848,7 +3848,7 @@ module.exports = new Type('tag:yaml.org,2002:timestamp', {
 var yaml = require('./lib/js-yaml.js');
 
 
-module.exports = yaml;
+module.exports = globalThis.jsyaml = yaml;
 
 },{"./lib/js-yaml.js":1}]},{},[])("/")
 });

--- a/stdlib/nodejs/yaml.rb
+++ b/stdlib/nodejs/yaml.rb
@@ -1,14 +1,18 @@
 # backtick_javascript: true
 
 require 'native'
-require_relative './js-yaml-3-6-1'
+require 'nodejs/js-yaml-3-6-1'
 
 module YAML
-  @__yaml__ = `jsyaml`
+  @__yaml__ = `globalThis.jsyaml`
   `var __yaml__ = #{@__yaml__}`
 
   def self.load_path(path)
-    loaded = `__yaml__.safeLoad(#{File}.__fs__.readFileSync(#{path}, 'utf8'))`
+    load(`#{File}.__fs__.readFileSync(#{path}, 'utf8')`)
+  end
+
+  def self.load(data)
+    loaded = `__yaml__.safeLoad(data)`
     loaded = Hash.new(loaded) if native?(loaded)
     loaded
   end

--- a/tasks/testing.rake
+++ b/tasks/testing.rake
@@ -389,6 +389,7 @@ node_platforms.each do |platform|
       nodejs/test_opal_builder.rb
       nodejs/test_string.rb
       nodejs/test_await.rb
+      nodejs/test_yaml.rb
     ]
 
     filename = "tmp/minitest_node_nodejs.rb"

--- a/test/nodejs/test_yaml.rb
+++ b/test/nodejs/test_yaml.rb
@@ -1,0 +1,20 @@
+require 'test/unit'
+require 'nodejs'
+require 'nodejs/yaml'
+
+class TestYAML < Test::Unit::TestCase
+  YAMLDOC = <<~YAML
+    ---
+    string: hello world
+    array: [1,2,3]
+  YAML
+
+  YAMLSTRUCT = {
+    "string" => "hello world",
+    "array" => [1,2,3]
+  }
+
+  def test_should_parse_yaml
+    assert_equal(YAML.load(YAMLDOC), YAMLSTRUCT)
+  end
+end


### PR DESCRIPTION
Due to the course of time, nodejs/yaml has broken. This PR:
- restores the functionality
- adds a YAML.load method
- adds minitest tests, so it wouldn't break again

This PR has been sponsored by Ribose Inc. ref: plurimath/plurimath#159