### PR TITLE
Regexp.escape: Cast to String or drop exception.

### DIFF
--- a/opal/corelib/regexp.rb
+++ b/opal/corelib/regexp.rb
@@ -18,7 +18,10 @@ class ::Regexp < `RegExp`
     end
 
     def escape(string)
-      `Opal.escape_regexp(string)`
+      %x{
+        string = $coerce_to(string, #{::String}, 'to_str');
+        return Opal.escape_regexp(string);
+      }
     end
 
     def last_match(n = nil)


### PR DESCRIPTION
This matches MRI behavior more closely and lets me run one of the libraries that depends on it dropping a Ruby exception.

This PR has been sponsored by Ribose Inc. ref: plurimath/plurimath#159