### PR TITLE
Closure: Generate a JS object, not an Error

### DIFF
--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -3052,7 +3052,7 @@
   Object.seal(nil);
 
   Opal.thrower = function(type) {
-    var thrower = new Error('unexpected '+type);
+    var thrower = { message: 'unexpected '+type };
     thrower.$thrower_type = type;
     thrower.$throw = function(value) {
       if (value == null) value = nil;


### PR DESCRIPTION
This is so that we don't need to capture the stacktrace each time we want to use Ruby semantics of closures.

This should make Asciidoctor work ~15% faster.

Authored by: @merceroncode 