### PR TITLE
[WIP] [Experimental] Use typeof instead of $has_own for Hash and speed

### DIFF
--- a/benchmark-ips/bm_hash_get.rb
+++ b/benchmark-ips/bm_hash_get.rb
@@ -1,0 +1,30 @@
+Benchmark.ips do |x|
+  %x{
+    var $has_own   = Object.hasOwn || $call.bind(Object.prototype.hasOwnProperty);
+
+    function hash_get_new(hash, key) {
+      if (key.$$is_string) {
+        if (typeof hash.$$smap[key] !== "undefined") {
+          return hash.$$smap[key];
+        }
+        return;
+      }
+    };
+
+    function hash_get_old(hash, key) {
+      if (key.$$is_string) {
+        if ($has_own(hash.$$smap, key)) {
+          return hash.$$smap[key];
+        }
+        return;
+      }
+    };
+  }
+
+  h = { value: 12 }
+
+  x.report('old_version') { `hash_get_old(h, 'value')` }
+  x.report('new_version') { `hash_get_new(h, 'value')` }
+
+  x.compare!
+end

--- a/lib/opal/nodes/hash.rb
+++ b/lib/opal/nodes/hash.rb
@@ -107,7 +107,7 @@ module Opal
           push hash_obj[key]
         end
 
-        wrap "$hash2([#{hash_keys.join ', '}], {", '})'
+        wrap "$hash2([#{hash_keys.join ', '}], Object.setPrototypeOf({", '}, null))'
       end
     end
 

--- a/lib/opal/nodes/hash.rb
+++ b/lib/opal/nodes/hash.rb
@@ -95,19 +95,23 @@ module Opal
         hash_obj, hash_keys = {}, []
         helper :hash2
 
-        keys.size.times do |idx|
-          key = keys[idx].children[0].to_s.inspect
-          hash_keys << key unless hash_obj.include? key
-          hash_obj[key] = expr(values[idx])
-        end
+        if keys.size > 0
+          keys.size.times do |idx|
+            key = keys[idx].children[0].to_s.inspect
+            hash_keys << key unless hash_obj.include? key
+            hash_obj[key] = expr(values[idx])
+          end
 
-        hash_keys.each_with_index do |key, idx|
-          push ', ' unless idx == 0
-          push "#{key}: "
-          push hash_obj[key]
-        end
+          hash_keys.each_with_index do |key, idx|
+            push ', ' unless idx == 0
+            push "#{key}: "
+            push hash_obj[key]
+          end
 
-        wrap "$hash2([#{hash_keys.join ', '}], Object.setPrototypeOf({", '}, null))'
+          wrap "$hash2([#{hash_keys.join ', '}], Object.setPrototypeOf({", '}, null))'
+        else
+          push '$hash2([], Object.create(null))' # faster than setPrototypeOf({}, null)
+        end
       end
     end
 

--- a/opal/corelib/hash.rb
+++ b/opal/corelib/hash.rb
@@ -6,7 +6,7 @@ require 'corelib/enumerable'
 # ---
 # Internal properties:
 #
-# - $$map         [JS::Object<String => hash-bucket>] the hash table for ordinary keys
+# - $$map         [JS::Object<String => hash-bucket>] the hash table for ordinary keys, created on demand
 # - $$smap        [JS::Object<String => hash-bucket>] the hash table for string keys
 # - $$keys        [Array<hash-bucket>] the list of all keys
 # - $$proc        [Proc,null,nil] the default proc used for missing keys

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -1834,7 +1834,7 @@
   //
   Opal.kwrestargs = function(given_args, used_args) {
     var keys      = [],
-        map       = {},
+        map       = Object.create(null),
         key           ,
         given_map = given_args.$$smap;
 
@@ -2553,7 +2553,7 @@
   // helper that can be used from methods
   function $deny_frozen_access(obj) {
     if (obj.$$frozen) {
-      $raise(Opal.FrozenError, "can't modify frozen " + (obj.$class()) + ": " + (obj), Opal.hash2(["receiver"], {"receiver": obj}));
+      $raise(Opal.FrozenError, "can't modify frozen " + (obj.$class()) + ": " + (obj), Opal.hash2(["receiver"], Object.setPrototypeOf({"receiver": obj}, null)));
     }
   };
   Opal.deny_frozen_access = $deny_frozen_access;
@@ -2929,7 +2929,7 @@
   // Primitives for handling parameters
   Opal.ensure_kwargs = function(kwargs) {
     if (kwargs == null) {
-      return Opal.hash2([], {});
+      return Opal.hash2([], Object.create(null));
     } else if (kwargs.$$is_hash) {
       return kwargs;
     } else {

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -1554,9 +1554,9 @@
       // call method missing with correct args (remove '$' prefix on method name)
       return this.$method_missing.apply(this, $prepend(method_name.slice(1), arguments));
     };
-  
+
     method_missing_stub.$$stub = true;
-  
+
     return method_missing_stub;
   };
 
@@ -2257,7 +2257,7 @@
 
   Opal.hash_put = function(hash, key, value) {
     if (key.$$is_string) {
-      if (!$has_own(hash.$$smap, key)) {
+      if (typeof hash.$$smap[key] === "undefined") {
         hash.$$keys.push(key);
       }
       hash.$$smap[key] = value;
@@ -2267,7 +2267,7 @@
     var key_hash, bucket, last_bucket;
     key_hash = hash.$$by_identity ? Opal.id(key) : key.$hash();
 
-    if (!$has_own(hash.$$map, key_hash)) {
+    if (typeof hash.$$map[key_hash] === "undefined") {
       bucket = {key: key, key_hash: key_hash, value: value};
       hash.$$keys.push(bucket);
       hash.$$map[key_hash] = bucket;
@@ -2295,7 +2295,7 @@
 
   Opal.hash_get = function(hash, key) {
     if (key.$$is_string) {
-      if ($has_own(hash.$$smap, key)) {
+      if (typeof hash.$$smap[key] !== "undefined") {
         return hash.$$smap[key];
       }
       return;
@@ -2304,7 +2304,7 @@
     var key_hash, bucket;
     key_hash = hash.$$by_identity ? Opal.id(key) : key.$hash();
 
-    if ($has_own(hash.$$map, key_hash)) {
+    if (typeof hash.$$map[key_hash] !== "undefined") {
       bucket = hash.$$map[key_hash];
 
       while (bucket) {
@@ -2322,7 +2322,7 @@
     if (key.$$is_string) {
       if (typeof key !== "string") key = key.valueOf();
 
-      if (!$has_own(hash.$$smap, key)) {
+      if (typeof hash.$$smap[key] === "undefined") {
         return;
       }
 
@@ -2346,7 +2346,7 @@
 
     var key_hash = key.$hash();
 
-    if (!$has_own(hash.$$map, key_hash)) {
+    if (typeof hash.$$map[key_hash] === "undefined") {
       return;
     }
 
@@ -2421,7 +2421,7 @@
 
       hash.$$keys[i].key_hash = key_hash;
 
-      if (!$has_own(hash.$$map, key_hash)) {
+      if (typeof hash.$$map[key_hash] === "undefined") {
         hash.$$map[key_hash] = hash.$$keys[i];
         continue;
       }
@@ -2938,7 +2938,7 @@
   }
 
   Opal.get_kwarg = function(kwargs, key) {
-    if (!$has_own(kwargs.$$smap, key)) {
+    if (typeof kwargs.$$smap[key] === "undefined") {
       $raise(Opal.ArgumentError, 'missing keyword: '+key);
     }
     return kwargs.$$smap[key];

--- a/spec/opal/core/hash/internals_spec.rb
+++ b/spec/opal/core/hash/internals_spec.rb
@@ -30,15 +30,15 @@ describe 'Hash' do
     end
 
     it 'does not use the `map` object' do
-      `Object.keys(#@h.$$map).length`.should == 0
+      `(#@h.$$map ? #@h.$$map : nil)`.should == nil
 
       @h['c'] = 789
 
-      `Object.keys(#@h.$$map).length`.should == 0
+      `(#@h.$$map ? #@h.$$map : nil)`.should == nil
     end
 
     it 'uses the `map` object when an object key is added' do
-      `Object.keys(#@h.$$map).length`.should == 0
+      `(#@h.$$map ? #@h.$$map : nil)`.should == nil
 
       @h[Object.new] = 789
 
@@ -128,7 +128,7 @@ describe 'Hash' do
       @mock3.should_receive(:hash).at_least(1).and_return('hhh')
       @mock3.should_receive(:eql?).exactly(2).and_return(false)
 
-      `Object.keys(#@hash.$$map).length`.should == 0
+      `(#@hash.$$map ? #@hash.$$map : nil)`.should == nil
       `#@hash.$$keys.length`.should == 0
 
       @hash[@mock1] = 123


### PR DESCRIPTION
As $$smap is mostly a Object.create(null) and it is completely in control of Opal it can be assumed, that all its props are "own", so checking for existence with typeof $$smap[prop] === "undefined" should be sufficient and multiple times faster than using $has_own.

There is one place, where regular Objects are used for $$smap, that is, when the compiler creates a $hash2 creating a regular {} inline object from context.

Lets see the effect first ...