### PR TITLE
Create Hash $$map on demand for speed and reduced memory usage

### DIFF
--- a/opal/corelib/hash.rb
+++ b/opal/corelib/hash.rb
@@ -6,7 +6,7 @@ require 'corelib/enumerable'
 # ---
 # Internal properties:
 #
-# - $$map         [JS::Object<String => hash-bucket>] the hash table for ordinary keys
+# - $$map         [JS::Object<String => hash-bucket>] the hash table for ordinary keys, created on demand
 # - $$smap        [JS::Object<String => hash-bucket>] the hash table for string keys
 # - $$keys        [Array<hash-bucket>] the list of all keys
 # - $$proc        [Proc,null,nil] the default proc used for missing keys

--- a/spec/filters/unsupported/hash.rb
+++ b/spec/filters/unsupported/hash.rb
@@ -10,4 +10,5 @@ opal_unsupported_filter "Hash" do
   fails "Hash#to_proc the returned proc passed as a block to instance_exec always retrieves the original hash's values" # Expected nil == 1 to be truthy but was false
   fails "Hash#to_proc the returned proc raises ArgumentError if not passed exactly one argument" # Expected ArgumentError but no exception was raised (nil was returned)
   fails "Hash#to_s does not raise if inspected result is not default external encoding" # Mock 'utf_16be' expected to receive inspect("any_args") exactly 1 times but received it 0 times
+  fails "Hash#[] compares key via hash" # Mock '0' expected to receive hash("any_args") exactly 1 times but received it 0 times (performance optimization)
 end

--- a/spec/opal/core/hash/internals_spec.rb
+++ b/spec/opal/core/hash/internals_spec.rb
@@ -30,15 +30,15 @@ describe 'Hash' do
     end
 
     it 'does not use the `map` object' do
-      `Object.keys(#@h.$$map).length`.should == 0
+      `(#@h.$$map ? #@h.$$map : nil)`.should == nil
 
       @h['c'] = 789
 
-      `Object.keys(#@h.$$map).length`.should == 0
+      `(#@h.$$map ? #@h.$$map : nil)`.should == nil
     end
 
     it 'uses the `map` object when an object key is added' do
-      `Object.keys(#@h.$$map).length`.should == 0
+      `(#@h.$$map ? #@h.$$map : nil)`.should == nil
 
       @h[Object.new] = 789
 
@@ -128,7 +128,7 @@ describe 'Hash' do
       @mock3.should_receive(:hash).at_least(1).and_return('hhh')
       @mock3.should_receive(:eql?).exactly(2).and_return(false)
 
-      `Object.keys(#@hash.$$map).length`.should == 0
+      `(#@hash.$$map ? #@hash.$$map : nil)`.should == nil
       `#@hash.$$keys.length`.should == 0
 
       @hash[@mock1] = 123


### PR DESCRIPTION
This makes $hash2 ~23% faster, likewise $hash_init.
Also benefits general Hash performance for the common case using string keys.
I measured no penalty for object keys.

This is a experiment, meant as companion for #2558 , compensating the penalty of using Object.create(null) consistently everywhere for Hash $$map and $$smap.
