### PR TITLE
[WIP] [Experimental] Hash without $$smap

### DIFF
--- a/lib/opal/nodes/args/extract_kwoptarg.rb
+++ b/lib/opal/nodes/args/extract_kwoptarg.rb
@@ -21,7 +21,7 @@ module Opal
 
           add_temp lvar_name
 
-          line "#{lvar_name} = $kwargs.$$smap[#{key_name.to_s.inspect}];"
+          line "#{lvar_name} = ($kwargs.$$map[#{key_name.to_s.inspect}]) ? $kwargs.$$map[#{key_name.to_s.inspect}].value : undefined;"
 
           return if default_value.children[1] == :undefined
 

--- a/lib/opal/nodes/hash.rb
+++ b/lib/opal/nodes/hash.rb
@@ -103,11 +103,12 @@ module Opal
 
         hash_keys.each_with_index do |key, idx|
           push ', ' unless idx == 0
-          push "#{key}: "
+          push "#{key}: { key: #{key}, key_hash: #{key}, value: "
           push hash_obj[key]
+          push '}'
         end
 
-        wrap "$hash2([#{hash_keys.join ', '}], {", '})'
+        wrap "$hash2({", '})'
       end
     end
 

--- a/opal/corelib/string.rb
+++ b/opal/corelib/string.rb
@@ -25,7 +25,7 @@ class ::String < `String`
       var opts = args[args.length-1];
       str = $coerce_to(str, #{::String}, 'to_str');
       if (opts && opts.$$is_hash) {
-        if (opts.$$smap.encoding) str = str.$force_encoding(opts.$$smap.encoding);
+        if (opts.$$map.encoding) str = str.$force_encoding(opts.$$map.encoding.value);
       }
       str = new self.$$constructor(str);
       if (!str.$initialize.$$pristine) #{`str`.initialize(*args)};

--- a/stdlib/json.rb
+++ b/stdlib/json.rb
@@ -97,7 +97,7 @@ module JSON
     options[:object_class] ||= Hash
     options[:array_class]  ||= Array
 
-    `to_opal(js_object, options.$$smap)`
+    `to_opal(js_object, options.$$map)`
   end
 
   def self.generate(obj, options = {})
@@ -160,12 +160,8 @@ class Hash
       for (var i = 0, keys = self.$$keys, length = keys.length, key, value; i < length; i++) {
         key = keys[i];
 
-        if (key.$$is_string) {
-          value = self.$$smap[key];
-        } else {
-          value = key.value;
-          key = key.key;
-        }
+        value = key.value;
+        key = key.key;
 
         result.push(#{`key`.to_s.to_json} + ':' + #{`value`.to_json});
       }

--- a/stdlib/native.rb
+++ b/stdlib/native.rb
@@ -542,7 +542,7 @@ unless Hash.method_defined? :_initialize
         if (defaults != null &&
              (defaults.constructor === undefined ||
                defaults.constructor === Object)) {
-          var smap = self.$$smap,
+          var map = self.$$map,
               keys = self.$$keys,
               key, value;
 
@@ -563,9 +563,9 @@ unless Hash.method_defined? :_initialize
 
                 return #{Native(`item`)};
               });
-              smap[key] = value
+              map[key] = { key: key, key_hash: key, value: value }
             } else {
-              smap[key] = #{Native(`value`)};
+              map[key] = { key: key, key_hash: key, value: #{Native(`value`)} };
             }
 
             keys.push(key);
@@ -584,20 +584,16 @@ unless Hash.method_defined? :_initialize
       %x{
         var result = {},
             keys = self.$$keys,
-            smap = self.$$smap,
+            map = self.$$map,
             key, value;
 
         for (var i = 0, length = keys.length; i < length; i++) {
           key = keys[i];
 
-          if (key.$$is_string) {
-            value = smap[key];
-          } else {
-            key = key.key;
-            value = key.value;
-          }
+          key = key.key;
+          value = key.value;
 
-          result[key] = #{Native.try_convert(`value`, `value`)};
+          result[key] = { key: key, key_hash: key, value: #{Native.try_convert(`value`, `value`)} };
         }
 
         return result;


### PR DESCRIPTION
After the positive experience of #2561 this PR explores if the $$smap optimization of Hash is still justified.

It removes the $$smap completely, having one less Object.create(null), saving time and memory.

Also the code having less branches and smaller functions, may allow modern JS engines to optimize better and overall produce better results.

In addition this PR serves as guidance how to maybe implement Hash < Map in a better way than #2559 does, basically then using self as $$map while keeping $$keys.