### PR TITLE
Hash < Map V3

### DIFF
--- a/docs/bridging.md
+++ b/docs/bridging.md
@@ -91,9 +91,9 @@ With bridging creating equivalent Ruby and JavaScript objects, no explicit type 
 
 ## Bridged Classes in Corelib
 
-Opal's core library bridges several commonly used JavaScript classes, including `Array`, `Boolean`, `Number` (think: `Float` which also may act as an `Integer`), `Proc`, `Time`, `RegExp`, and `String`, allowing interaction with these JavaScript instances as their Ruby equivalents.
+Opal's core library bridges several commonly used JavaScript classes, including `Array`, `Boolean`, `Number` (think: `Float` which also may act as an `Integer`), `Proc`, `Time`, `RegExp`, and `String`, allowing interaction with these JavaScript instances as their Ruby equivalents. Also `Hash` bridges the Javascript `Map` class and works very well between Javascript and Opal if primitives of the Javascript types "string", "number" and "symbol" (which must be global, generated with `Symbol.for()`) are used as keys. When other types or objects are used as keys, there may be issues retrieving the Map entries from each language, because the original references of the objects that have been used as keys are required for retrieval. When using a `Map` with object keys passed from Javascript as Hash in Opal, calling `Hash#rehash` may resolve issues and make entries accessible.
 
-However, Opal doesn't bridge common JavaScript classes like `Hash` and `Set` due to significant differences in behavior and interfaces between Ruby and JavaScript.
+However, Opal doesn't bridge common JavaScript classes like `Set` due to significant differences in behavior and interfaces between Ruby and JavaScript.
 
 ## Drawbacks
 

--- a/docs/compiled_ruby.md
+++ b/docs/compiled_ruby.md
@@ -612,7 +612,8 @@ myHash.$fetch('z','');
 myHash.$update(Opal.hash({b: 20, c: 30}));
 // output of $inspect: {"a"=>10, "b"=>20, "c"=>30}
 myHash.$to_n(); // provided by the Native module
-// output: {"a": 10, "b": 20, "c": 30} aka a standard JavaScript object
+// output: Map(2) {'b' => 20, 'c' => 30}
+// aka a standard JavaScript Map
 ```
 
 NOTE: Be aware `Hash#to_n` produces a duplicate copy of the hash.

--- a/lib/opal/nodes/args/extract_kwoptarg.rb
+++ b/lib/opal/nodes/args/extract_kwoptarg.rb
@@ -21,7 +21,7 @@ module Opal
 
           add_temp lvar_name
 
-          line "#{lvar_name} = $kwargs.$$smap[#{key_name.to_s.inspect}];"
+          line "#{lvar_name} = $kwargs.get(#{key_name.to_s.inspect});"
 
           return if default_value.children[1] == :undefined
 

--- a/lib/opal/nodes/hash.rb
+++ b/lib/opal/nodes/hash.rb
@@ -34,7 +34,7 @@ module Opal
         if has_kwsplat
           compile_merge
         elsif simple_keys?
-          compile_hash2
+          compile_map
         else
           compile_hash
         end
@@ -91,9 +91,8 @@ module Opal
 
       # Compiles a hash without kwsplats
       # and containing **only** string/symbols as keys.
-      def compile_hash2
+      def compile_map
         hash_obj, hash_keys = {}, []
-        helper :hash2
 
         keys.size.times do |idx|
           key = keys[idx].children[0].to_s.inspect
@@ -103,11 +102,14 @@ module Opal
 
         hash_keys.each_with_index do |key, idx|
           push ', ' unless idx == 0
-          push "#{key}: "
-          push hash_obj[key]
+          push "[#{key}", ', ', hash_obj[key], ']'
         end
 
-        wrap "$hash2([#{hash_keys.join ', '}], {", '})'
+        if hash_keys.empty?
+          push '(new Map())'
+        else
+          wrap '(new Map([', ']))'
+        end
       end
     end
 

--- a/opal/corelib/hash.rb
+++ b/opal/corelib/hash.rb
@@ -1,4 +1,4 @@
-# helpers: yield1, hash, hash_init, hash_get, hash_put, hash_delete, deny_frozen_access, freeze
+# helpers: yield1, hash, hash_clone, hash_delete, hash_each, hash_get, hash_put, deny_frozen_access, freeze
 # backtick_javascript: true
 
 require 'corelib/enumerable'
@@ -6,12 +6,10 @@ require 'corelib/enumerable'
 # ---
 # Internal properties:
 #
-# - $$map         [JS::Object<String => hash-bucket>] the hash table for ordinary keys
-# - $$smap        [JS::Object<String => hash-bucket>] the hash table for string keys
-# - $$keys        [Array<hash-bucket>] the list of all keys
+# - $$keys     [Map<key-array>] optional Map of key arrays, used when objects are used as keys
 # - $$proc        [Proc,null,nil] the default proc used for missing keys
-# - hash-bucket   [JS::Object] an element of a linked list that holds hash values, keys are `{key:,key_hash:,value:,next:}`
-class ::Hash
+# - key-array   [JS::Map] an element of a array that holds objects used as keys, `{ key_hash => [objects...] }`
+class ::Hash < `Map`
   include ::Enumerable
 
   # Mark all hash instances as valid hashes (used to check keyword args, etc)
@@ -70,8 +68,6 @@ class ::Hash
     %x{
       var hash = new self.$$constructor();
 
-      $hash_init(hash);
-
       hash.$$none = nil;
       hash.$$proc = nil;
 
@@ -107,27 +103,17 @@ class ::Hash
         return false;
       }
 
-      if (self.$$keys.length !== other.$$keys.length) {
+      if (self.size !== other.size) {
         return false;
       }
 
-      for (var i = 0, keys = self.$$keys, length = keys.length, key, value, other_value; i < length; i++) {
-        key = keys[i];
-
-        if (key.$$is_string) {
-          value = self.$$smap[key];
-          other_value = other.$$smap[key];
-        } else {
-          value = key.value;
-          other_value = $hash_get(other, key.key);
-        }
-
+      return $hash_each(self, true, function(key, value) {
+        var other_value = $hash_get(other, key);
         if (other_value === undefined || !value['$eql?'](other_value)) {
-          return false;
-        }
-      }
-
-      return true;
+          return [true, false];
+        } 
+        return [false, true];
+      });
     }
   end
 
@@ -135,8 +121,8 @@ class ::Hash
     other = ::Opal.coerce_to!(other, ::Hash, :to_hash)
 
     %x{
-      if (self.$$keys.length < other.$$keys.length) {
-        return false
+      if (self.size < other.size) {
+        return false;
       }
     }
 
@@ -160,8 +146,8 @@ class ::Hash
     other = ::Opal.coerce_to!(other, ::Hash, :to_hash)
 
     %x{
-      if (self.$$keys.length <= other.$$keys.length) {
-        return false
+      if (self.size <= other.size) {
+        return false;
       }
     }
 
@@ -201,21 +187,12 @@ class ::Hash
 
   def assoc(object)
     %x{
-      for (var i = 0, keys = self.$$keys, length = keys.length, key; i < length; i++) {
-        key = keys[i];
-
-        if (key.$$is_string) {
-          if (#{`key` == object}) {
-            return [key, self.$$smap[key]];
-          }
-        } else {
-          if (#{`key.key` == object}) {
-            return [key.key, key.value];
-          }
+      return $hash_each(self, nil, function(key, value) {
+        if (#{`key` == object}) {
+          return [true, [key, value]];
         }
-      }
-
-      return nil;
+        return [false, nil];
+      });
     }
   end
 
@@ -223,19 +200,18 @@ class ::Hash
     %x{
       $deny_frozen_access(self);
 
-      $hash_init(self);
+      self.clear();
+      if (self.$$keys)
+        self.$$keys.clear();
+
       return self;
     }
   end
 
   def clone
     %x{
-      var hash = new self.$$class();
-
-      $hash_init(hash);
-      Opal.hash_clone(self, hash);
-
-      return hash;
+      var hash = self.$class().$new();
+      return $hash_clone(self, hash);
     }
   end
 
@@ -243,22 +219,12 @@ class ::Hash
     %x{
       var hash = $hash();
 
-      for (var i = 0, keys = self.$$keys, length = keys.length, key, value, obj; i < length; i++) {
-        key = keys[i];
-
-        if (key.$$is_string) {
-          value = self.$$smap[key];
-        } else {
-          value = key.value;
-          key = key.key;
-        }
-
+      return $hash_each(self, hash, function(key, value) {
         if (value !== nil) {
           $hash_put(hash, key, value);
         }
-      }
-
-      return hash;
+        return [false, hash];
+      });
     }
   end
 
@@ -266,28 +232,15 @@ class ::Hash
     %x{
       $deny_frozen_access(self);
 
-      var changes_were_made = false;
+      var result = nil;
 
-      for (var i = 0, keys = self.$$keys, length = keys.length, key, value, obj; i < length; i++) {
-        key = keys[i];
-
-        if (key.$$is_string) {
-          value = self.$$smap[key];
-        } else {
-          value = key.value;
-          key = key.key;
-        }
-
+      return $hash_each(self, result, function(key, value) {
         if (value === nil) {
-          if ($hash_delete(self, key) !== undefined) {
-            changes_were_made = true;
-            length--;
-            i--;
-          }
+          $hash_delete(self, key);
+          result = self;
         }
-      }
-
-      return changes_were_made ? self : nil;
+        return [false, result];
+      });
     }
   end
 
@@ -295,24 +248,13 @@ class ::Hash
     %x{
       $deny_frozen_access(self);
 
-      var i, ii, key, keys = self.$$keys, identity_hash;
+      if (!self.$$by_identity) {
+        self.$$by_identity = true;
 
-      if (self.$$by_identity) return self;
-      if (self.$$keys.length === 0) {
-        self.$$by_identity = true
-        return self;
+        if (self.size !== 0)
+          Opal.hash_rehash(self);
       }
 
-      identity_hash = #{ {}.compare_by_identity };
-      for(i = 0, ii = keys.length; i < ii; i++) {
-        key = keys[i];
-        if (!key.$$is_string) key = key.key;
-        $hash_put(identity_hash, key, $hash_get(self, key));
-      }
-
-      self.$$by_identity = true;
-      self.$$map = identity_hash.$$map;
-      self.$$smap = identity_hash.$$smap;
       return self;
     }
   end
@@ -397,27 +339,13 @@ class ::Hash
     %x{
       $deny_frozen_access(self);
 
-      for (var i = 0, keys = self.$$keys, length = keys.length, key, value, obj; i < length; i++) {
-        key = keys[i];
-
-        if (key.$$is_string) {
-          value = self.$$smap[key];
-        } else {
-          value = key.value;
-          key = key.key;
-        }
-
-        obj = block(key, value);
-
+      return $hash_each(self, self, function(key, value) {
+        var obj = block(key, value);
         if (obj !== false && obj !== nil) {
-          if ($hash_delete(self, key) !== undefined) {
-            length--;
-            i--;
-          }
+          $hash_delete(self, key);
         }
-      }
-
-      return self;
+        return [false, self];
+      });
     }
   end
 
@@ -441,20 +369,10 @@ class ::Hash
     return enum_for(:each) { size } unless block
 
     %x{
-      for (var i = 0, keys = self.$$keys.slice(), length = keys.length, key, value; i < length; i++) {
-        key = keys[i];
-
-        if (key.$$is_string) {
-          value = self.$$smap[key];
-        } else {
-          value = key.value;
-          key = key.key;
-        }
-
+      return $hash_each(self, self, function(key, value) {
         $yield1(block, [key, value]);
-      }
-
-      return self;
+        return [false, self];
+      });
     }
   end
 
@@ -462,13 +380,10 @@ class ::Hash
     return enum_for(:each_key) { size } unless block
 
     %x{
-      for (var i = 0, keys = self.$$keys.slice(), length = keys.length, key; i < length; i++) {
-        key = keys[i];
-
-        block(key.$$is_string ? key : key.key);
-      }
-
-      return self;
+      return $hash_each(self, self, function(key, value) {
+        block(key);
+        return [false, self];
+      });
     }
   end
 
@@ -476,18 +391,15 @@ class ::Hash
     return enum_for(:each_value) { size } unless block
 
     %x{
-      for (var i = 0, keys = self.$$keys.slice(), length = keys.length, key; i < length; i++) {
-        key = keys[i];
-
-        block(key.$$is_string ? self.$$smap[key] : key.value);
-      }
-
-      return self;
+      return $hash_each(self, self, function(key, value) {
+        block(value);
+        return [false, self];
+      });
     }
   end
 
   def empty?
-    `self.$$keys.length === 0`
+    `self.size === 0`
   end
 
   def except(*keys)
@@ -529,32 +441,22 @@ class ::Hash
     %x{
       var result = [];
 
-      for (var i = 0, keys = self.$$keys, length = keys.length, key, value; i < length; i++) {
-        key = keys[i];
-
-        if (key.$$is_string) {
-          value = self.$$smap[key];
-        } else {
-          value = key.value;
-          key = key.key;
-        }
-
+      return $hash_each(self, result, function(key, value) {
         result.push(key);
 
         if (value.$$is_array) {
           if (level === 1) {
             result.push(value);
-            continue;
+            return [false, result];
           }
 
           result = result.concat(#{`value`.flatten(`level - 2`)});
-          continue;
+          return [false, result];
         }
 
         result.push(value);
-      }
-
-      return result;
+        return [false, result];
+      });
     }
   end
 
@@ -570,15 +472,12 @@ class ::Hash
 
   def has_value?(value)
     %x{
-      for (var i = 0, keys = self.$$keys, length = keys.length, key; i < length; i++) {
-        key = keys[i];
-
-        if (#{`(key.$$is_string ? self.$$smap[key] : key.value)` == value}) {
-          return true;
+      return $hash_each(self, false, function(key, val) {
+        if (#{`val` == value}) {
+          return [true, true];
         }
-      }
-
-      return false;
+        return [false, false];
+      });
     }
   end
 
@@ -607,15 +506,10 @@ class ::Hash
 
         Opal.hash_ids[hash_id] = self;
 
-        for (var i = 0, keys = self.$$keys, length = keys.length; i < length; i++) {
-          key = keys[i];
-
-          if (key.$$is_string) {
-            result.push([key, self.$$smap[key].$hash()]);
-          } else {
-            result.push([key.key_hash, key.value.$hash()]);
-          }
-        }
+        $hash_each(self, false, function(key, value) {
+          result.push([key, value.$hash()]);
+          return [false, false];
+        });
 
         return result.sort().join();
 
@@ -629,22 +523,12 @@ class ::Hash
 
   def index(object)
     %x{
-      for (var i = 0, keys = self.$$keys, length = keys.length, key, value; i < length; i++) {
-        key = keys[i];
-
-        if (key.$$is_string) {
-          value = self.$$smap[key];
-        } else {
-          value = key.value;
-          key = key.key;
-        }
-
+      return $hash_each(self, nil, function(key, value) {
         if (#{`value` == object}) {
-          return key;
+          return [true, key];
         }
-      }
-
-      return nil;
+        return [false, nil];
+      });
     }
   end
 
@@ -689,21 +573,13 @@ class ::Hash
 
         inspect_ids[hash_id] = true;
 
-        for (var i = 0, keys = self.$$keys, length = keys.length, key, value; i < length; i++) {
-          key = keys[i];
-
-          if (key.$$is_string) {
-            value = self.$$smap[key];
-          } else {
-            value = key.value;
-            key = key.key;
-          }
-
-          key = #{Opal.inspect(`key`)}
+        $hash_each(self, false, function(key, value) {
           value = #{Opal.inspect(`value`)}
-
+          key = #{Opal.inspect(`key`)}
+          
           result.push(key + '=>' + value);
-        }
+          return [false, false];
+        })
 
         return '{' + result.join(', ') + '}';
       }
@@ -717,20 +593,10 @@ class ::Hash
     %x{
       var hash = $hash();
 
-      for (var i = 0, keys = self.$$keys, length = keys.length, key, value; i < length; i++) {
-        key = keys[i];
-
-        if (key.$$is_string) {
-          value = self.$$smap[key];
-        } else {
-          value = key.value;
-          key = key.key;
-        }
-
+      return $hash_each(self, hash, function(key, value) {
         $hash_put(hash, value, key);
-      }
-
-      return hash;
+        return [false, hash];
+      });
     }
   end
 
@@ -740,50 +606,23 @@ class ::Hash
     %x{
       $deny_frozen_access(self);
 
-      for (var i = 0, keys = self.$$keys, length = keys.length, key, value, obj; i < length; i++) {
-        key = keys[i];
-
-        if (key.$$is_string) {
-          value = self.$$smap[key];
-        } else {
-          value = key.value;
-          key = key.key;
-        }
-
+      return $hash_each(self, self, function(key, value) {
         obj = block(key, value);
 
         if (obj === false || obj === nil) {
-          if ($hash_delete(self, key) !== undefined) {
-            length--;
-            i--;
-          }
+          $hash_delete(self, key);
         }
-      }
-
-      return self;
+        return [false, self];
+      });
     }
   end
 
   def keys
-    %x{
-      var result = [];
-
-      for (var i = 0, keys = self.$$keys, length = keys.length, key; i < length; i++) {
-        key = keys[i];
-
-        if (key.$$is_string) {
-          result.push(key);
-        } else {
-          result.push(key.key);
-        }
-      }
-
-      return result;
-    }
+    `Array.from(self.keys())`
   end
 
   def length
-    `self.$$keys.length`
+    `self.size`
   end
 
   def merge(*others, &block)
@@ -793,44 +632,28 @@ class ::Hash
   def merge!(*others, &block)
     %x{
       $deny_frozen_access(self);
-      var i, j, other, other_keys, length, key, value, other_value;
+
+      var i, j, other;
       for (i = 0; i < others.length; ++i) {
         other = #{::Opal.coerce_to!(`others[i]`, ::Hash, :to_hash)};
-        other_keys = other.$$keys, length = other_keys.length;
 
         if (block === nil) {
-          for (j = 0; j < length; j++) {
-            key = other_keys[j];
-
-            if (key.$$is_string) {
-              other_value = other.$$smap[key];
-            } else {
-              other_value = key.value;
-              key = key.key;
-            }
-
-            $hash_put(self, key, other_value);
-          }
+          $hash_each(other, false, function(key, value) {
+            $hash_put(self, key, value);
+            return [false, false];
+          });
         } else {
-          for (j = 0; j < length; j++) {
-            key = other_keys[j];
+          $hash_each(other, false, function(key, value) {
+            var val = $hash_get(self, key);
 
-            if (key.$$is_string) {
-              other_value = other.$$smap[key];
-            } else {
-              other_value = key.value;
-              key = key.key;
+            if (val === undefined) {
+              $hash_put(self, key, value);
+              return [false, false];
             }
 
-            value = $hash_get(self, key);
-
-            if (value === undefined) {
-              $hash_put(self, key, other_value);
-              continue;
-            }
-
-            $hash_put(self, key, block(key, value, other_value));
-          }
+            $hash_put(self, key, block(key, val, value));
+            return [false, false];
+          });
         }
       }
 
@@ -840,22 +663,12 @@ class ::Hash
 
   def rassoc(object)
     %x{
-      for (var i = 0, keys = self.$$keys, length = keys.length, key, value; i < length; i++) {
-        key = keys[i];
-
-        if (key.$$is_string) {
-          value = self.$$smap[key];
-        } else {
-          value = key.value;
-          key = key.key;
-        }
-
+      return $hash_each(self, nil, function(key, value) {
         if (#{`value` == object}) {
-          return [key, value];
+          return [true, [key, value]];
         }
-      }
-
-      return nil;
+        return [false, nil];
+      });
     }
   end
 
@@ -873,24 +686,14 @@ class ::Hash
     %x{
       var hash = $hash();
 
-      for (var i = 0, keys = self.$$keys, length = keys.length, key, value, obj; i < length; i++) {
-        key = keys[i];
-
-        if (key.$$is_string) {
-          value = self.$$smap[key];
-        } else {
-          value = key.value;
-          key = key.key;
-        }
-
+      return $hash_each(self, hash, function(key, value) {
         obj = block(key, value);
 
         if (obj === false || obj === nil) {
           $hash_put(hash, key, value);
         }
-      }
-
-      return hash;
+        return [false, hash]
+      });
     }
   end
 
@@ -900,30 +703,17 @@ class ::Hash
     %x{
       $deny_frozen_access(self);
 
-      var changes_were_made = false;
+      var result = nil;
 
-      for (var i = 0, keys = self.$$keys, length = keys.length, key, value, obj; i < length; i++) {
-        key = keys[i];
-
-        if (key.$$is_string) {
-          value = self.$$smap[key];
-        } else {
-          value = key.value;
-          key = key.key;
-        }
-
+      return $hash_each(self, result, function(key, value) {
         obj = block(key, value);
 
         if (obj !== false && obj !== nil) {
-          if ($hash_delete(self, key) !== undefined) {
-            changes_were_made = true;
-            length--;
-            i--;
-          }
+          $hash_delete(self, key);
+          result = self;
         }
-      }
-
-      return changes_were_made ? self : nil;
+        return [false, result];
+      });
     }
   end
 
@@ -933,20 +723,12 @@ class ::Hash
     other = ::Opal.coerce_to!(other, ::Hash, :to_hash)
 
     %x{
-      $hash_init(self);
+      self.$clear();
 
-      for (var i = 0, other_keys = other.$$keys, length = other_keys.length, key, value, other_value; i < length; i++) {
-        key = other_keys[i];
-
-        if (key.$$is_string) {
-          other_value = other.$$smap[key];
-        } else {
-          other_value = key.value;
-          key = key.key;
-        }
-
-        $hash_put(self, key, other_value);
-      }
+      $hash_each(other, false, function(key, value) {
+        $hash_put(self, key, value);
+        return [false, false];
+      });
     }
 
     if other.default_proc
@@ -964,24 +746,14 @@ class ::Hash
     %x{
       var hash = $hash();
 
-      for (var i = 0, keys = self.$$keys, length = keys.length, key, value, obj; i < length; i++) {
-        key = keys[i];
-
-        if (key.$$is_string) {
-          value = self.$$smap[key];
-        } else {
-          value = key.value;
-          key = key.key;
-        }
-
+      return $hash_each(self, hash, function(key, value) {
         obj = block(key, value);
 
         if (obj !== false && obj !== nil) {
           $hash_put(hash, key, value);
         }
-      }
-
-      return hash;
+        return [false, hash];
+      });
     }
   end
 
@@ -993,46 +765,25 @@ class ::Hash
 
       var result = nil;
 
-      for (var i = 0, keys = self.$$keys, length = keys.length, key, value, obj; i < length; i++) {
-        key = keys[i];
-
-        if (key.$$is_string) {
-          value = self.$$smap[key];
-        } else {
-          value = key.value;
-          key = key.key;
-        }
-
+      return $hash_each(self, result, function(key, value) {
         obj = block(key, value);
 
         if (obj === false || obj === nil) {
-          if ($hash_delete(self, key) !== undefined) {
-            length--;
-            i--;
-          }
+          $hash_delete(self, key);
           result = self;
         }
-      }
-
-      return result;
+        return [false, result];
+      });
     }
   end
 
   def shift
     %x{
       $deny_frozen_access(self);
-      var keys = self.$$keys,
-          key;
 
-      if (keys.length > 0) {
-        key = keys[0];
-
-        key = key.$$is_string ? key : key.key;
-
-        return [key, $hash_delete(self, key)];
-      }
-
-      return nil;
+      return $hash_each(self, nil, function(key, value) {
+        return [true, [key, $hash_delete(self, key)]];
+      });
     }
   end
 
@@ -1054,25 +805,12 @@ class ::Hash
 
   def to_a
     %x{
-      var keys = self.$$keys;
-      var length = keys.length;
-      var result = new Array(length);
-      var key, value;
-
-      for (var i = 0; i < length; i++) {
-        key = keys[i];
-
-        if (key.$$is_string) {
-          value = self.$$smap[key];
-        } else {
-          value = key.value;
-          key = key.key;
-        }
-
-        result[i] = [key, value];
-      }
-
-      return result;
+      var result = [];
+      
+      return $hash_each(self, result, function(key, value) {
+        result.push([key, value]);
+        return [false, result];
+      });
     }
   end
 
@@ -1084,10 +822,9 @@ class ::Hash
         return self;
       }
 
-      var hash = new Opal.Hash();
+      var hash = new Map();
 
-      $hash_init(hash);
-      Opal.hash_clone(self, hash);
+      $hash_clone(self, hash);
 
       return hash;
     }
@@ -1115,22 +852,11 @@ class ::Hash
     %x{
       var result = $hash();
 
-      for (var i = 0, keys = self.$$keys, length = keys.length, key, value; i < length; i++) {
-        key = keys[i];
-
-        if (key.$$is_string) {
-          value = self.$$smap[key];
-        } else {
-          value = key.value;
-          key = key.key;
-        }
-
-        key = $yield1(block, key);
-
+      return $hash_each(self, result, function(key, value) {
+        key = block(key);
         $hash_put(result, key, value);
-      }
-
-      return result;
+        return [false, result];
+      });
     }
   end
 
@@ -1140,26 +866,12 @@ class ::Hash
     %x{
       $deny_frozen_access(self);
 
-      var keys = Opal.slice(self.$$keys),
-          i, length = keys.length, key, value, new_key;
-
-      for (i = 0; i < length; i++) {
-        key = keys[i];
-
-        if (key.$$is_string) {
-          value = self.$$smap[key];
-        } else {
-          value = key.value;
-          key = key.key;
-        }
-
-        new_key = $yield1(block, key);
-
+      return $hash_each(self, self, function(key, value) {
+        var new_key = block(key);
         $hash_delete(self, key);
         $hash_put(self, new_key, value);
-      }
-
-      return self;
+        return [false, self];
+      });
     }
   end
 
@@ -1169,22 +881,10 @@ class ::Hash
     %x{
       var result = $hash();
 
-      for (var i = 0, keys = self.$$keys, length = keys.length, key, value; i < length; i++) {
-        key = keys[i];
-
-        if (key.$$is_string) {
-          value = self.$$smap[key];
-        } else {
-          value = key.value;
-          key = key.key;
-        }
-
-        value = $yield1(block, value);
-
-        $hash_put(result, key, value);
-      }
-
-      return result;
+      return $hash_each(self, result, function(key, value) {
+        $hash_put(result, key, block(value));
+        return [false, result];
+      });
     }
   end
 
@@ -1194,41 +894,15 @@ class ::Hash
     %x{
       $deny_frozen_access(self);
 
-      for (var i = 0, keys = self.$$keys, length = keys.length, key, value; i < length; i++) {
-        key = keys[i];
-
-        if (key.$$is_string) {
-          value = self.$$smap[key];
-        } else {
-          value = key.value;
-          key = key.key;
-        }
-
-        value = $yield1(block, value);
-
-        $hash_put(self, key, value);
-      }
-
-      return self;
+      return $hash_each(self, self, function(key, value) {
+        $hash_put(self, key, block(value));
+        return [false, self];
+      });
     }
   end
 
   def values
-    %x{
-      var result = [];
-
-      for (var i = 0, keys = self.$$keys, length = keys.length, key; i < length; i++) {
-        key = keys[i];
-
-        if (key.$$is_string) {
-          result.push(self.$$smap[key]);
-        } else {
-          result.push(key.value);
-        }
-      }
-
-      return result;
-    }
+    `Array.from(self.values())`
   end
 
   alias dup clone

--- a/opal/corelib/string.rb
+++ b/opal/corelib/string.rb
@@ -25,7 +25,7 @@ class ::String < `String`
       var opts = args[args.length-1];
       str = $coerce_to(str, #{::String}, 'to_str');
       if (opts && opts.$$is_hash) {
-        if (opts.$$smap.encoding) str = str.$force_encoding(opts.$$smap.encoding);
+        if (opts.has('encoding')) str = str.$force_encoding(opts.get('encoding').value);
       }
       str = new self.$$constructor(str);
       if (!str.$initialize.$$pristine) #{`str`.initialize(*args)};

--- a/spec/filters/unsupported/hash.rb
+++ b/spec/filters/unsupported/hash.rb
@@ -10,4 +10,5 @@ opal_unsupported_filter "Hash" do
   fails "Hash#to_proc the returned proc passed as a block to instance_exec always retrieves the original hash's values" # Expected nil == 1 to be truthy but was false
   fails "Hash#to_proc the returned proc raises ArgumentError if not passed exactly one argument" # Expected ArgumentError but no exception was raised (nil was returned)
   fails "Hash#to_s does not raise if inspected result is not default external encoding" # Mock 'utf_16be' expected to receive inspect("any_args") exactly 1 times but received it 0 times
+  fails "Hash#[] compares key via hash" # Mock '0' expected to receive hash("any_args") exactly 1 times but received it 0 times (performance optimization)
 end

--- a/spec/opal/core/hash/internals_spec.rb
+++ b/spec/opal/core/hash/internals_spec.rb
@@ -7,42 +7,42 @@ describe 'Hash' do
       @h = {'a' => 123, 'b' => 456}
     end
 
-    it 'stores keys directly as strings in the `keys` array' do
-      `#@h.$$keys.length`.should == 2
-      `#@h.$$keys[0]`.should == 'a'
-      `#@h.$$keys[1]`.should == 'b'
+    it 'stores keys directly as strings in the `Map`' do
+      `#@h.size`.should == 2
+      `Array.from(#@h.keys())[0]`.should == 'a'
+      `Array.from(#@h.keys())[1]`.should == 'b'
 
       @h['c'] = 789
 
-      `#@h.$$keys.length`.should == 3
-      `#@h.$$keys[2]`.should == 'c'
+      `#@h.size`.should == 3
+      `Array.from(#@h.keys())[2]`.should == 'c'
     end
 
-    it 'stores values directly as objects in the `smap` object by their corresponding string key' do
-      `Object.keys(#@h.$$smap).length`.should == 2
-      `#@h.$$smap['a']`.should == 123
-      `#@h.$$smap['b']`.should == 456
+    it 'stores values directly as objects in the `Map`' do
+      `Array.from(#@h.values()).length`.should == 2
+      `Array.from(#@h.values())[0]`.should == 123
+      `Array.from(#@h.values())[1]`.should == 456
 
       @h['c'] = 789
 
-      `Object.keys(#@h.$$smap).length`.should == 3
-      `#@h.$$smap['c']`.should == 789
+      `Array.from(#@h.values()).length`.should == 3
+      `Array.from(#@h.values())[2]`.should == 789
     end
 
-    it 'does not use the `map` object' do
-      `Object.keys(#@h.$$map).length`.should == 0
+    it 'does not use the `Map.$$keys`' do
+      `(#@h.$$keys === undefined)`.should == true
 
       @h['c'] = 789
 
-      `Object.keys(#@h.$$map).length`.should == 0
+      `(#@h.$$keys === undefined)`.should == true
     end
 
-    it 'uses the `map` object when an object key is added' do
-      `Object.keys(#@h.$$map).length`.should == 0
+    it 'uses the `Map.$$keys` object when an object key is added' do
+      `(#@h.$$keys === undefined)`.should == true
 
       @h[Object.new] = 789
 
-      `Object.keys(#@h.$$map).length`.should == 1
+      `#@h.$$keys.size`.should == 1
     end
 
     it 'converts string objects to values when used to delete keys' do
@@ -60,57 +60,10 @@ describe 'Hash' do
       @h = {@obj1 => 123, @obj2 => 456}
     end
 
-    it 'uses a data structure called "bucket", which is a wrapper object with `key`, `key_hash`, `value`, and `next` properties' do
-      bucket = `#@h.$$keys[0]`
-      `#{bucket}.key`.should == @obj1
-      `#{bucket}.key_hash`.should == @obj1.hash
-      `#{bucket}.value`.should == 123
-      `#{bucket}.next === undefined`.should == true
-    end
-
-    it 'stores keys in the `keys` array as "bucket" objects' do
-      `#@h.$$keys.length`.should == 2
-      `#@h.$$keys[0].key`.should == @obj1
-      `#@h.$$keys[1].key`.should == @obj2
-
-      obj3 = Object.new
-      @h[obj3] = 789
-
-      `#@h.$$keys.length`.should == 3
-      `#@h.$$keys[2].key`.should == obj3
-    end
-
-    it 'stores values in the `map` object as "bucket" objects by #hash string of their corresponding object key' do
-      `Object.keys(#@h.$$map).length`.should == 2
-      `#@h.$$map[#{@obj1.hash}].value`.should == 123
-      `#@h.$$map[#{@obj2.hash}].value`.should == 456
-
-      obj3 = Object.new
-      @h[obj3] = 789
-
-      `Object.keys(#@h.$$map).length`.should == 3
-      `#@h.$$map[#{obj3.hash}].value`.should == 789
-    end
-
-    it 'keeps a pointer to the same "bucket" object in the `keys` array and in the `map` object' do
-      `#@h.$$map[#{@obj1.hash}] === #@h.$$keys[0]`.should == true
-      `#@h.$$map[#{@obj2.hash}] === #@h.$$keys[1]`.should == true
-    end
-
-    it 'does not use the `smap` object' do
-      `Object.keys(#@h.$$smap).length`.should == 0
-
-      @h[Object.new] = 789
-
-      `Object.keys(#@h.$$smap).length`.should == 0
-    end
-
-    it 'uses the `smap` object when a string key is added' do
-      `Object.keys(#@h.$$smap).length`.should == 0
-
-      @h['c'] = 789
-
-      `Object.keys(#@h.$$smap).length`.should == 1
+    it 'uses a `Map.$$keys` to keep references of objects to be used as keys' do
+      keys = `Array.from(#@h.$$keys.entries())`
+      `#{keys}[0][1][0]`.should == @obj1
+      `#{keys}[0][0]`.should == @obj1.hash
     end
 
     it 'allows multiple keys that #hash to the same value to be stored in the Hash' do
@@ -128,45 +81,41 @@ describe 'Hash' do
       @mock3.should_receive(:hash).at_least(1).and_return('hhh')
       @mock3.should_receive(:eql?).exactly(2).and_return(false)
 
-      `Object.keys(#@hash.$$map).length`.should == 0
-      `#@hash.$$keys.length`.should == 0
+      `#@hash.size`.should == 0
+      `(#@hash.$$keys === undefined)`.should == true
 
       @hash[@mock1] = 123
-      `Object.keys(#@hash.$$map).length`.should == 1
-      `#@hash.$$keys.length`.should == 1
-      `#@hash.$$keys[0] === #@hash.$$map['hhh']`.should == true
-      `#@hash.$$keys[0].key`.should == @mock1
-      `#@hash.$$keys[0].key_hash`.should == @mock1.hash
-      `#@hash.$$keys[0].value`.should == 123
-      `#@hash.$$keys[0].next === undefined`.should == true
+      `#@hash.$$keys.size`.should == 1
+      keys = `Array.from(#@hash.$$keys.entries())`
+      `#{keys}[0][1].length`.should == 1
+      `#{keys}[0][1][0]`.should == @mock1
+      `#{keys}[0][0]`.should == @mock1.hash
+      `#@hash.get(#@mock1)`.should == 123
 
       @hash[@mock2] = 456
-      `Object.keys(#@hash.$$map).length`.should == 1
-      `#@hash.$$keys.length`.should == 2
-      `#@hash.$$keys[1] === #@hash.$$map['hhh'].next`.should == true
-      `#@hash.$$keys[1].key`.should == @mock2
-      `#@hash.$$keys[1].key_hash`.should == @mock2.hash
-      `#@hash.$$keys[1].value`.should == 456
-      `#@hash.$$keys[1].next === undefined`.should == true
+      `#@hash.$$keys.size`.should == 1
+      keys = `Array.from(#@hash.$$keys.entries())`
+      `#{keys}[0][1].length`.should == 2
+      `#{keys}[0][1][1]`.should == @mock2
+      `#{keys}[0][0]`.should == @mock2.hash
+      `#@hash.get(#@mock2)`.should == 456
 
       @hash[@mock3] = 789
-      `Object.keys(#@hash.$$map).length`.should == 1
-      `#@hash.$$keys.length`.should == 3
-      `#@hash.$$keys[2] === #@hash.$$map['hhh'].next.next`.should == true
-      `#@hash.$$keys[2].key`.should == @mock3
-      `#@hash.$$keys[2].key_hash`.should == @mock3.hash
-      `#@hash.$$keys[2].value`.should == 789
-      `#@hash.$$keys[2].next === undefined`.should == true
+      `#@hash.$$keys.size`.should == 1
+      keys = `Array.from(#@hash.$$keys.entries())`
+      `#{keys}[0][1].length`.should == 3
+      `#{keys}[0][1][2]`.should == @mock3
+      `#{keys}[0][0]`.should == @mock3.hash
+      `#@hash.get(#@mock3)`.should == 789
 
       obj = Object.new
       @hash[obj] = 999
-      `Object.keys(#@hash.$$map).length`.should == 2
-      `#@hash.$$keys.length`.should == 4
-      `#@hash.$$keys[3] === #@hash.$$map[#{obj.hash}]`.should == true
-      `#@hash.$$keys[3].key`.should == obj
-      `#@hash.$$keys[3].key_hash`.should == obj.hash
-      `#@hash.$$keys[3].value`.should == 999
-      `#@hash.$$keys[3].next === undefined`.should == true
+      `#@hash.$$keys.size`.should == 2
+      keys = `Array.from(#@hash.$$keys.entries())`
+      `#{keys}[1][1].length`.should == 1
+      `#{keys}[1][1][0]`.should == obj
+      `#{keys}[1][0]`.should == obj.hash
+      `#@hash.get(#{obj})`.should == 999
     end
 
     it 'correctly updates internal data structures when deleting keys' do
@@ -197,145 +146,142 @@ describe 'Hash' do
         @obj1  => 'xyz'
       }
 
-      `Opal.hasOwnProperty.call(#@hash.$$map, 'hhh')`.should == true
-      `Opal.hasOwnProperty.call(#@hash.$$map, #{@obj1.hash})`.should == true
-      `Opal.hasOwnProperty.call(#@hash.$$smap, 'a')`.should == true
-      `Opal.hasOwnProperty.call(#@hash.$$smap, 'b')`.should == true
-      `Opal.hasOwnProperty.call(#@hash.$$smap, 'c')`.should == true
+      `#@hash.$$keys.has('hhh')`.should == true
+      `#@hash.$$keys.has(#{@obj1.hash})`.should == true
+      `#@hash.has('a')`.should == true
+      `#@hash.has('b')`.should == true
+      `#@hash.has('c')`.should == true
 
-      `#@hash.$$keys.length`.should == 8
-      `Object.keys(#@hash.$$map).length`.should == 2
-      `Object.keys(#@hash.$$smap).length`.should == 3
+      `#@hash.size`.should == 8
+      `#@hash.$$keys.size`.should == 2
 
-      `#@hash.$$keys[0].key`.should == @mock1
-      `#@hash.$$keys[1]`.should == 'a'
-      `#@hash.$$keys[2].key`.should == @mock2
-      `#@hash.$$keys[3]`.should == 'b'
-      `#@hash.$$keys[4].key`.should == @mock3
-      `#@hash.$$keys[5].key`.should == @mock4
-      `#@hash.$$keys[6]`.should == 'c'
-      `#@hash.$$keys[7].key`.should == @obj1
+      keys = `Array.from(#@hash.keys())`
+      keys[0].should == @mock1
+      keys[1].should == 'a'
+      keys[2].should == @mock2
+      keys[3].should == 'b'
+      keys[4].should == @mock3
+      keys[5].should == @mock4
+      keys[6].should == 'c'
+      keys[7].should == @obj1
 
-      `#@hash.$$map['hhh'] === #@hash.$$keys[0]`.should == true
-      `#@hash.$$keys[0].next === #@hash.$$keys[2]`.should == true
-      `#@hash.$$keys[2].next === #@hash.$$keys[4]`.should == true
-      `#@hash.$$keys[4].next === #@hash.$$keys[5]`.should == true
-      `#@hash.$$keys[5].next === undefined`.should == true
+      keys = `Array.from(#@hash.$$keys.values())[0]`
+      `#{keys}.length`.should == 4
+      keys[0].should == @mock1
+      keys[1].should == @mock2
+      keys[2].should == @mock3
+      keys[3].should == @mock4
+      keys = `Array.from(#@hash.$$keys.values())[1]`
+      `#{keys}.length`.should == 1
+      keys[0].should == @obj1
 
       @hash.delete @mock2
 
-      `#@hash.$$keys.length`.should == 7
-      `Object.keys(#@hash.$$map).length`.should == 2
-      `Object.keys(#@hash.$$smap).length`.should == 3
+      `#@hash.size`.should == 7
+      keys = `Array.from(#@hash.$$keys.values())[0]`
+      `#{keys}.length`.should == 3
+      keys[0].should == @mock1
+      keys[1].should == @mock3
+      keys[2].should == @mock4
 
-      `#@hash.$$keys[0].key`.should == @mock1
-      `#@hash.$$keys[1]`.should == 'a'
-      `#@hash.$$keys[2]`.should == 'b'
-      `#@hash.$$keys[3].key`.should == @mock3
-      `#@hash.$$keys[4].key`.should == @mock4
-      `#@hash.$$keys[5]`.should == 'c'
-      `#@hash.$$keys[6].key`.should == @obj1
-
-      `#@hash.$$map['hhh'] === #@hash.$$keys[0]`.should == true
-      `#@hash.$$keys[0].next === #@hash.$$keys[3]`.should == true
-      `#@hash.$$keys[3].next === #@hash.$$keys[4]`.should == true
-      `#@hash.$$keys[4].next === undefined`.should == true
+      keys = `Array.from(#@hash.keys())`
+      keys[0].should == @mock1
+      keys[1].should == 'a'
+      keys[2].should == 'b'
+      keys[3].should == @mock3
+      keys[4].should == @mock4
+      keys[5].should == 'c'
+      keys[6].should == @obj1
 
       @hash.delete @mock4
 
-      `#@hash.$$keys.length`.should == 6
-      `Object.keys(#@hash.$$map).length`.should == 2
-      `Object.keys(#@hash.$$smap).length`.should == 3
+      `#@hash.size`.should == 6
+      keys = `Array.from(#@hash.$$keys.values())[0]`
+      `#{keys}.length`.should == 2
+      keys[0].should == @mock1
+      keys[1].should == @mock3
 
-      `#@hash.$$keys[0].key`.should == @mock1
-      `#@hash.$$keys[1]`.should == 'a'
-      `#@hash.$$keys[2]`.should == 'b'
-      `#@hash.$$keys[3].key`.should == @mock3
-      `#@hash.$$keys[4]`.should == 'c'
-      `#@hash.$$keys[5].key`.should == @obj1
-
-      `#@hash.$$map['hhh'] === #@hash.$$keys[0]`.should == true
-      `#@hash.$$keys[0].next === #@hash.$$keys[3]`.should == true
-      `#@hash.$$keys[3].next === undefined`.should == true
+      keys = `Array.from(#@hash.keys())`
+      keys[0].should == @mock1
+      keys[1].should == 'a'
+      keys[2].should == 'b'
+      keys[3].should == @mock3
+      keys[4].should == 'c'
+      keys[5].should == @obj1
 
       @hash.delete @mock1
 
-      `#@hash.$$keys.length`.should == 5
-      `Object.keys(#@hash.$$map).length`.should == 2
-      `Object.keys(#@hash.$$smap).length`.should == 3
+      `#@hash.size`.should == 5
+      keys = `Array.from(#@hash.$$keys.values())[0]`
+      `#{keys}.length`.should == 1
+      keys[0].should == @mock3
 
-      `#@hash.$$keys[0]`.should == 'a'
-      `#@hash.$$keys[1]`.should == 'b'
-      `#@hash.$$keys[2].key`.should == @mock3
-      `#@hash.$$keys[3]`.should == 'c'
-      `#@hash.$$keys[4].key`.should == @obj1
-
-      `#@hash.$$map['hhh'] === #@hash.$$keys[2]`.should == true
-      `#@hash.$$keys[2].next === undefined`.should == true
+      keys = `Array.from(#@hash.keys())`
+      keys[0].should == 'a'
+      keys[1].should == 'b'
+      keys[2].should == @mock3
+      keys[3].should == 'c'
+      keys[4].should == @obj1
 
       @hash.delete @mock3
 
-      `#@hash.$$keys.length`.should == 4
-      `Object.keys(#@hash.$$map).length`.should == 1
-      `Object.keys(#@hash.$$smap).length`.should == 3
+      `#@hash.size`.should == 4
+      `#@hash.$$keys.size`.should == 1
+      keys = `Array.from(#@hash.$$keys.values())[0]`
+      `#{keys}.length`.should == 1
+      keys[0].should == @obj1
 
-      `#@hash.$$keys[0]`.should == 'a'
-      `#@hash.$$keys[1]`.should == 'b'
-      `#@hash.$$keys[2]`.should == 'c'
-      `#@hash.$$keys[3].key`.should == @obj1
-
-      `#@hash.$$map['hhh'] === undefined`.should == true
+      keys = `Array.from(#@hash.keys())`
+      keys[0].should == 'a'
+      keys[1].should == 'b'
+      keys[2].should == 'c'
+      keys[3].should == @obj1
 
       @hash.delete @obj1
 
-      `#@hash.$$keys.length`.should == 3
-      `Object.keys(#@hash.$$map).length`.should == 0
-      `Object.keys(#@hash.$$smap).length`.should == 3
+      `#@hash.size`.should == 3
+      `#@hash.$$keys.size`.should == 0
 
-      `#@hash.$$keys[0]`.should == 'a'
-      `#@hash.$$keys[1]`.should == 'b'
-      `#@hash.$$keys[2]`.should == 'c'
+      keys = `Array.from(#@hash.keys())`
+      keys[0].should == 'a'
+      keys[1].should == 'b'
+      keys[2].should == 'c'
 
-      `#@hash.$$map[#{@obj1.hash}] === undefined`.should == true
+      `#@hash.$$keys.get(#{@obj1.hash}) === undefined`.should == true
 
       @hash.delete 'b'
 
-      `#@hash.$$keys.length`.should == 2
-      `Object.keys(#@hash.$$map).length`.should == 0
-      `Object.keys(#@hash.$$smap).length`.should == 2
+      `#@hash.size`.should == 2
+      `#@hash.$$keys.size`.should == 0
 
-      `#@hash.$$keys[0]`.should == 'a'
-      `#@hash.$$keys[1]`.should == 'c'
-      `#@hash.$$smap['a']`.should == 'abc'
-      `#@hash.$$smap['b'] === undefined`.should == true
-      `#@hash.$$smap['c']`.should == 'ghi'
+      keys = `Array.from(#@hash.keys())`
+      keys[0].should == 'a'
+      keys[1].should == 'c'
+
+      `#@hash.get('a')`.should == 'abc'
+      `#@hash.get('b') === undefined`.should == true
+      `#@hash.get('c')`.should == 'ghi'
 
       @hash.delete 'c'
 
-      `#@hash.$$keys.length`.should == 1
-      `Object.keys(#@hash.$$map).length`.should == 0
-      `Object.keys(#@hash.$$smap).length`.should == 1
+      `#@hash.size`.should == 1
+      `#@hash.$$keys.size`.should == 0
 
-      `#@hash.$$keys[0]`.should == 'a'
-      `#@hash.$$smap['a']`.should == 'abc'
-      `#@hash.$$smap['b'] === undefined`.should == true
-      `#@hash.$$smap['c'] === undefined`.should == true
+      keys = `Array.from(#@hash.keys())`
+      keys[0].should == 'a'
+
+      `#@hash.get('a')`.should == 'abc'
+      `#@hash.get('b') === undefined`.should == true
+      `#@hash.get('c') === undefined`.should == true
 
       @hash.delete 'a'
 
-      `#@hash.$$keys.length`.should == 0
-      `Object.keys(#@hash.$$map).length`.should == 0
-      `Object.keys(#@hash.$$smap).length`.should == 0
+      `#@hash.size`.should == 0
+      `#@hash.$$keys.size`.should == 0
 
-      `#@hash.$$smap['a'] === undefined`.should == true
-      `#@hash.$$smap['b'] === undefined`.should == true
-      `#@hash.$$smap['c'] === undefined`.should == true
-
-      `Opal.hasOwnProperty.call(#@hash.$$map, 'hhh')`.should == false
-      `Opal.hasOwnProperty.call(#@hash.$$map, #{@obj1.hash})`.should == false
-      `Opal.hasOwnProperty.call(#@hash.$$smap, 'a')`.should == false
-      `Opal.hasOwnProperty.call(#@hash.$$smap, 'b')`.should == false
-      `Opal.hasOwnProperty.call(#@hash.$$smap, 'c')`.should == false
+      `#@hash.get('a') === undefined`.should == true
+      `#@hash.get('b') === undefined`.should == true
+      `#@hash.get('c') === undefined`.should == true
     end
   end
 end

--- a/spec/opal/stdlib/native/hash_spec.rb
+++ b/spec/opal/stdlib/native/hash_spec.rb
@@ -38,6 +38,32 @@ describe Hash do
     expect(h).to eq(expected_hash)
   end
 
+  it 'turns a native JS Map into a hash' do
+    obj = %x{
+      new Map([ ['a', 1],
+                ['b', "two"],
+                ['c', new Map([['d', 1]])],
+                ['e', [{f: 'g',h: [null]}]] ]);
+    }
+
+    h = Hash.new(obj)
+    expected_hash = {
+      a: 1,
+      b: "two",
+      c: {
+        d: 1,
+      },
+      e: [
+        {
+          f: 'g',
+          h: [nil],
+        },
+      ],
+    }
+
+    expect(h).to eq(expected_hash)
+  end
+
   it 'turns Object.create(null) JS objects into a hash' do
     %x{
       var obj = Object.create(null);
@@ -56,14 +82,14 @@ describe Hash do
     it 'converts a hash with native objects as values' do
       obj = { 'a_key' => `{ key: 1 }` }
       native = obj.to_n
-      `#{native}.a_key.key`.should == 1
+      `#{native}.get('a_key').key`.should == 1
     end
 
     it 'passes Ruby objects that cannot be converted' do
       object = Object.new
       hash = { foo: object }
       native = hash.to_n
-      expect(`#{native}.foo`).to eq object
+      expect(`#{native}.get('foo')`).to eq object
     end
   end
 end

--- a/stdlib/json.rb
+++ b/stdlib/json.rb
@@ -38,7 +38,7 @@ module JSON
           if (!value) return nil;
 
           if (value.$$is_array) {
-            arr = #{`options.array_class`.new};
+            arr = #{`Opal.hash_get(options, 'array_class')`.new};
 
             for (i = 0, ii = value.length; i < ii; i++) {
               #{`arr`.push(`to_opal(value[i], options)`)};
@@ -47,7 +47,7 @@ module JSON
             return arr;
           }
           else {
-            hash = #{`options.object_class`.new};
+            hash = #{`Opal.hash_get(options, 'object_class')`.new};
 
             for (k in value) {
               if ($hasOwn.call(value, k)) {
@@ -55,7 +55,7 @@ module JSON
               }
             }
 
-            if (!options.parse && (klass = #{`hash`[JSON.create_id]}) != nil) {
+            if (!Opal.hash_get(options, 'parse') && (klass = #{`hash`[JSON.create_id]}) != nil) {
               return #{::Object.const_get(`klass`).json_create(`hash`)};
             }
             else {
@@ -97,7 +97,7 @@ module JSON
     options[:object_class] ||= Hash
     options[:array_class]  ||= Array
 
-    `to_opal(js_object, options.$$smap)`
+    `to_opal(js_object, options)`
   end
 
   def self.generate(obj, options = {})
@@ -157,18 +157,10 @@ class Hash
     %x{
       var result = [];
 
-      for (var i = 0, keys = self.$$keys, length = keys.length, key, value; i < length; i++) {
-        key = keys[i];
-
-        if (key.$$is_string) {
-          value = self.$$smap[key];
-        } else {
-          value = key.value;
-          key = key.key;
-        }
-
+      Opal.hash_each(self, false, function(key, value) {
         result.push(#{`key`.to_s.to_json} + ':' + #{`value`.to_json});
-      }
+        return [false, false];
+      });
 
       return '{' + result.join(',') + '}';
     }


### PR DESCRIPTION
Building on V2 #2563 , but there where 2 issues in general when using `Hash < Map`, one issue is, that keys of a Map are references and the second issue are hash collisions, where previously buckets where used as linked list of items with the same hash.

However, if two different objects have the same hash, they still have different references, so we can use that together with the "keys are references" feature of Map and use the objects as keys directly.

Now of course they would become unreachable, so we also use a $$keys Map internally, on demand, to map hash_keys of objects to the actual objects that are used as keys, basically mapping hash_keys to references, this way keeping objects reachable.

So we can directly map keys to values, no more buckets are needed.

This further simplifies Hash code overall.

Primitives "string", "number" and "symbol" (must be global) are directly used as keys.

Now with this a ruby Hash can be exchanged with a Javascript Map freely, those primitive types above are directly accessible, like in V2, but now also objects as keys are directly accessible from JS ... by reference.

Not sure how JS is supposed to have a reference to Opal Ruby objects or the other way around, how practical that is, if it ever gets used that way, but it works.

If a Hash is passed to JS, modified by JS and received back from JS, and it has Object keys added or modified by JS, calling Hash#rehash may be advisable to keep Objects accessible, but also may fail, if a JS object used as key doesn't have a .$hash() function.

In other words, if a Opal Ruby Hash is passed to JS, within JS as Map it behaves like Hash#compare_by_identity