### PR TITLE
corelib/runtime/truthy: break early if we passed a literal true

### DIFF
--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -183,7 +183,9 @@
   // -----
 
   var $truthy = Opal.truthy = function(val) {
-    return false !== val && nil !== val && undefined !== val && null !== val && (!(val instanceof Boolean) || true === val.valueOf());
+    if (true === val)
+      return true;
+    return false !== val && nil !== val && undefined !== val && null !== val;
   };
 
   Opal.falsy = function(val) {


### PR DESCRIPTION
Also I'm removing the whole instanceof and valueOf check, since apparently it's not required anymore