### PR TITLE
Fix "Nebulab" sponsor logo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Support this project by becoming a sponsor. Your logo will show up here with a l
 
 ### Sponsored Contributions
 
-<a href="https://nebulab.it/?utm_source=github&utm_medium=sponsors" target="_blank"><img src="https://nebulab.com/assets/img/logo-nebulab_black.svg" alt="Nebulab Logo"></a>
+<a href="https://nebulab.it/?utm_source=github&utm_medium=sponsors" target="_blank"><img src="https://raw.githubusercontent.com/solidusio/brand/master/partners/Nebulab/logo-dark-light.svg" alt="Nebulab Logo"></a>
 
 
 ## License


### PR DESCRIPTION
The "Nebulab" sponsor logo image is broken, use [this](https://github.com/solidusio/solidus/blob/main/README.md?plain=1#L46C13-L46C106) instead.

**Before**
<img width="315" alt="Screenshot 2023-09-08 at 10 53 00" src="https://github.com/opal/opal/assets/4095923/4bb2616c-2136-4134-b0d6-bf09473b6284">

**After**
<img width="317" alt="Screenshot 2023-09-08 at 10 52 49" src="https://github.com/opal/opal/assets/4095923/f20ac3d5-8cb0-4cd3-8ae3-b014e99df68a">

Check it [here](https://github.com/opal/opal/blob/8c15a3cc24d4b1b7d241723e7abf5636778555fa/README.md#sponsored-contributions)
