### PR TITLE
Lowercase response headers for rack 3.0 compatibility

### DIFF
--- a/lib/opal/simple_server.rb
+++ b/lib/opal/simple_server.rb
@@ -51,7 +51,7 @@ class Opal::SimpleServer
     asset = fetch_asset(path)
     [
       200,
-      { 'Content-Type' => 'application/javascript' },
+      { 'content-type' => 'application/javascript' },
       [asset[:data], "\n", asset[:map].to_data_uri_comment],
     ]
   end
@@ -99,6 +99,6 @@ class Opal::SimpleServer
       </html>
       HTML
     end
-    [200, { 'Content-Type' => 'text/html' }, [html]]
+    [200, { 'content-type' => 'text/html' }, [html]]
   end
 end


### PR DESCRIPTION
Lowercase all response headers beause in `rack` 3.0 _response header keys can no longer include uppercase characters._

```
> $ bundle exec rackup
Bundler is using a binstub that was created for a different gem (rackup).
You should run `bundle binstub rack` to work around a system/bundle conflict.
[2023-09-10 15:44:27] INFO  WEBrick 1.8.1
[2023-09-10 15:44:27] INFO  ruby 3.2.2 (2023-03-30) [arm64-darwin22]
[2023-09-10 15:44:27] INFO  WEBrick::HTTPServer#start: pid=16933 port=9292
Rack::Lint::LintError: uppercase character in header name: Content-Type (Rack::Lint::LintError)
  /Users/wilson/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/rack-3.0.8/lib/rack/lint.rb:653:in `block in check_headers'
  /Users/wilson/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/rack-3.0.8/lib/rack/lint.rb:637:in `each'
  /Users/wilson/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/rack-3.0.8/lib/rack/lint.rb:637:in `check_headers'
  /Users/wilson/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/rack-3.0.8/lib/rack/lint.rb:73:in `response'
  /Users/wilson/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/rack-3.0.8/lib/rack/lint.rb:35:in `call'
  /Users/wilson/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/rack-3.0.8/lib/rack/show_exceptions.rb:27:in `call'
  /Users/wilson/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/rack-3.0.8/lib/rack/common_logger.rb:43:in `call'
  /Users/wilson/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/rack-3.0.8/lib/rack/content_length.rb:20:in `call'
  /Users/wilson/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/rackup-2.1.0/lib/rackup/handler/webrick.rb:111:in `service'
  /Users/wilson/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/webrick-1.8.1/lib/webrick/httpserver.rb:140:in `service'
  /Users/wilson/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/webrick-1.8.1/lib/webrick/httpserver.rb:96:in `run'
  /Users/wilson/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/webrick-1.8.1/lib/webrick/server.rb:310:in `block in start_thread'
::1 - - [10/Sep/2023:15:44:35 +0700] "GET / HTTP/1.1" 500 63466 0.0115
Rack::Lint::LintError: uppercase character in header name: Content-Type (Rack::Lint::LintError)
  /Users/wilson/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/rack-3.0.8/lib/rack/lint.rb:653:in `block in check_headers'
  /Users/wilson/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/rack-3.0.8/lib/rack/lint.rb:637:in `each'
  /Users/wilson/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/rack-3.0.8/lib/rack/lint.rb:637:in `check_headers'
  /Users/wilson/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/rack-3.0.8/lib/rack/lint.rb:73:in `response'
  /Users/wilson/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/rack-3.0.8/lib/rack/lint.rb:35:in `call'
  /Users/wilson/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/rack-3.0.8/lib/rack/show_exceptions.rb:27:in `call'
  /Users/wilson/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/rack-3.0.8/lib/rack/common_logger.rb:43:in `call'
  /Users/wilson/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/rack-3.0.8/lib/rack/content_length.rb:20:in `call'
  /Users/wilson/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/rackup-2.1.0/lib/rackup/handler/webrick.rb:111:in `service'
  /Users/wilson/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/webrick-1.8.1/lib/webrick/httpserver.rb:140:in `service'
  /Users/wilson/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/webrick-1.8.1/lib/webrick/httpserver.rb:96:in `run'
  /Users/wilson/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/webrick-1.8.1/lib/webrick/server.rb:310:in `block in start_thread'
::1 - - [10/Sep/2023:15:44:35 +0700] "GET /favicon.ico HTTP/1.1" 500 62556 0.0219
```

https://github.com/rack/rack/blob/main/UPGRADE-GUIDE.md#rack-2--rack-3-compatibility