### PR TITLE
Fix Typo in `Running tests` Section of `README.md` File

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,12 +145,7 @@ The test suite can be run using:
 
     $ bundle exec rake
 
-This will command will run all RSpec and MSpec examples in sequence.
-
-#### Automated runs
-
-A `Guardfile` with decent mappings between specs and lib/corelib/stdlib files is in place.
-Run `bundle exec guard -i` to start `guard`.
+This command will run all RSpec and MSpec examples in sequence.
 
 
 ### MSpec
@@ -169,6 +164,11 @@ visit `http://localhost:9292/` in any web browser.
 
     $ rake rspec
 
+
+### Automated runs
+
+A `Guardfile` with decent mappings between specs and lib/corelib/stdlib files is in place.
+Run `bundle exec guard -i` to start `guard`.
 
 ## Code Overview
 


### PR DESCRIPTION
## Changes
* Removed the duplicated word `will` from the last sentence of `Running tests` section, which's inside `README.md` file.
   
   **Note:** The `README.md` noted above is the one inside Repo Root Folder, On the `master` Branch, which can be view by [clicking here](https://github.com/opal/opal/blob/master/README.md).

## Screenshot(s)
![image](https://github.com/opal/opal/assets/70659536/82544c8d-1e36-4edd-9e0e-8c902721fdf7)
*Picture1: A screenshot to provide some context*