### PR TITLE
Chrome runner fix: support code that contains `</script>`

### DIFF
--- a/lib/opal/cli_runners/chrome.rb
+++ b/lib/opal/cli_runners/chrome.rb
@@ -70,6 +70,10 @@ module Opal
         ext = builder.output_extension
         module_type = ' type="module"' if builder.esm?
 
+        # Some maps may contain `</script>` fragment (eg. in strings) which would close our
+        # `<script>` tag prematurely. For this case, we need to escape the `</script>` tag.
+        map_json = map.to_json.gsub(/(<\/scr)(ipt>)/i, '\1"+"\2')
+
         # Chrome can't handle huge data passed to `addScriptToEvaluateOnLoad`
         # https://groups.google.com/a/chromium.org/forum/#!topic/chromium-discuss/U5qyeX_ydBo
         # The only way is to create temporary files and pass them to chrome.
@@ -86,7 +90,7 @@ module Opal
             sourceMapSupport.install({
               retrieveSourceMap: function(path) {
                 return path.endsWith('/index.#{ext}') ? {
-                  url: './index.map', map: #{map.to_json}
+                  url: './index.map', map: #{map_json}
                 } : null;
               }
             });


### PR DESCRIPTION
This fixes an issue with an upcoming patch to Opal-RSpec. In particular, embedding JSON in a `<script>` tag is not foolproof, as it may contain a string literal containing `</script>` ending the script tag prematurely.