### PR TITLE
`#hash` now returns integers

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,6 +32,7 @@ module.exports = {
     "Proxy": "readonly",
     "Reflect": "readonly",
     "Uint8Array": "readonly",
+    "Int32Array": "readonly",
     "WeakRef": "readonly",
     "Map": "readonly",
   }

--- a/opal/corelib/complex.rb
+++ b/opal/corelib/complex.rb
@@ -180,7 +180,7 @@ class ::Complex < ::Numeric
   end
 
   def hash
-    "Complex:#{@real}:#{@imag}"
+    [::Complex, @real, @imag].hash
   end
 
   def infinite?

--- a/opal/corelib/enumerator/arithmetic_sequence.rb
+++ b/opal/corelib/enumerator/arithmetic_sequence.rb
@@ -153,7 +153,7 @@ class ::Enumerator
     end
 
     def hash
-      [self.begin, self.end, step, exclude_end?].hash
+      [ArithmeticSequence, self.begin, self.end, step, exclude_end?].hash
     end
 
     def inspect

--- a/opal/corelib/range.rb
+++ b/opal/corelib/range.rb
@@ -315,7 +315,7 @@ class ::Range
   end
 
   def hash
-    [@begin, @end, @excl].hash
+    [::Range, @begin, @end, @excl].hash
   end
 
   alias == eql?

--- a/opal/corelib/rational.rb
+++ b/opal/corelib/rational.rb
@@ -244,7 +244,7 @@ class ::Rational < ::Numeric
   end
 
   def hash
-    "Rational:#{@num}:#{@den}"
+    [::Rational, @num, @den].hash
   end
 
   def inspect

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -2942,6 +2942,20 @@
     return array;
   }
 
+  // Opal32-checksum algorithm for #hash
+  // -----------------------------------
+  Opal.opal32_init = $return_val(0x4f70616c);
+
+  function $opal32_ror(n, d) {
+    return (n << d)|(n >>> (32 - d));
+  };
+
+  Opal.opal32_add = function(hash, next) {
+    hash ^= next;
+    hash = $opal32_ror(hash, 1);
+    return hash;
+  };
+
   // Initialization
   // --------------
   Opal.BasicObject = BasicObject = $allocate_class('BasicObject', null);

--- a/opal/corelib/string.rb
+++ b/opal/corelib/string.rb
@@ -1,4 +1,4 @@
-# helpers: coerce_to, respond_to, global_multiline_regexp, prop
+# helpers: coerce_to, respond_to, global_multiline_regexp, prop, opal32_init, opal32_add
 # backtick_javascript: true
 
 require 'corelib/comparable'
@@ -29,6 +29,18 @@ class ::String < `String`
             var id = Opal.uid();
             string_id_map.set(self, id);
             return id;
+          }
+        end
+
+        def hash
+          %x{
+            var hash = $opal32_init(), i, length = self.length;
+            hash = $opal32_add(hash, 0x5);
+            hash = $opal32_add(hash, length);
+            for (i = 0; i < length; i++) {
+              hash = $opal32_add(hash, self.charCodeAt(i));
+            }
+            return hash;
           }
         end
       }

--- a/opal/corelib/struct.rb
+++ b/opal/corelib/struct.rb
@@ -130,7 +130,7 @@ class ::Struct
   end
 
   def hash
-    Hash.new(`self.$$data`).hash
+    [self.class, to_a].hash
   end
 
   def [](name)

--- a/opal/corelib/time.rb
+++ b/opal/corelib/time.rb
@@ -389,7 +389,7 @@ class ::Time < `Date`
   end
 
   def hash
-    `'Time:' + self.getTime()`
+    [::Time, `self.getTime()`].hash
   end
 
   def inspect


### PR DESCRIPTION
This is a followup to opal/opal#2576. The idea is to ensure that `#hash` return integers, as Ruby does. We use a very lightweight hashing algorithm we have created for this purpose, called `Opal32` which should most of the time return unique values.