### PR TITLE
Fix typo in `Opal.hash_put`

### DIFF
--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -2284,7 +2284,7 @@
           object;
 
       for (var i=0; i<objects.length; i++) {
-        object = objects[0];
+        object = objects[i];
         if (key === object || key['$eql?'](object)) {
           hash.set(object, value);
           return;


### PR DESCRIPTION
I just found a typo and fixed it.
Without this PR, below script gives a different result from CRuby, which seems to be a rare case.

```ruby
class Foo
  attr_reader :n

  def initialize(n)
    @n = n
  end

  def hash
    @n % 10
  end

  def eql?(other)
    @n == other.n
  end
end

obj1 = Foo.new(1)
obj2 = Foo.new(11)
obj3 = Foo.new(11)

hash = {}
hash[obj1] = 'obj1'
hash[obj2] = 'obj2'
hash[obj3] = 'obj3'

p hash[obj3]
```

- Result
  - CRuby: `"obj3"`
  - Opal (master): `"obj2"`