### PR TITLE
Unexpected return/break should raise LocalJumpError

### DIFF
--- a/lib/opal/nodes/closure.rb
+++ b/lib/opal/nodes/closure.rb
@@ -225,7 +225,11 @@ module Opal
             end
             line "throw $e;"
           end
-          line "} finally {", *catchers_without_eval_return.map { |type| "$t_#{type}.is_orphan = true;" }, "}"
+          line "}"
+
+          unless catchers_without_eval_return.empty?
+            push " finally {", *catchers_without_eval_return.map { |type| "$t_#{type}.is_orphan = true;" }, "}"
+          end
 
           unshift "return " if closure_is? SEND
 

--- a/lib/opal/nodes/defined.rb
+++ b/lib/opal/nodes/defined.rb
@@ -80,7 +80,7 @@ module Opal
         push '  if (Opal.rescue($err, [Opal.Exception])) {'
         push '    try {'
         push '      return false;'
-        push '    } finally { Opal.pop_exception() }'
+        push '    } finally { Opal.pop_exception($err); }'
         push '  } else { throw $err; }'
         push '}})())'
 

--- a/lib/opal/nodes/rescue.rb
+++ b/lib/opal/nodes/rescue.rb
@@ -211,7 +211,7 @@ module Opal
               line stmt(rescue_body)
             end
           end
-          line '} finally { Opal.pop_exception(); }'
+          line '} finally { Opal.pop_exception($err); }'
         end
         line '}'
       end

--- a/opal/corelib/error.rb
+++ b/opal/corelib/error.rb
@@ -316,6 +316,16 @@ class ::KeyError
   end
 end
 
+class ::LocalJumpError
+  attr_reader :exit_value, :reason
+
+  def initialize(message, exit_value = nil, reason = :noreason)
+    super message
+    @exit_value = exit_value
+    @reason = reason
+  end
+end
+
 module ::JS
   class Error
   end

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -119,9 +119,12 @@
 
   // @private
   // Pops an exception from the stack and updates `$!`.
-  Opal.pop_exception = function() {
+  Opal.pop_exception = function(rescued_exception) {
     var exception = Opal.exceptions.pop();
-    if (exception) {
+    if (exception === rescued_exception) {
+      // Current $! is raised in the rescue block, so we don't update it
+    }
+    else if (exception) {
       $gvars["!"] = exception;
       $gvars["@"] = exception.$backtrace();
     }

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -3027,13 +3027,18 @@
   Object.seal(nil);
 
   Opal.thrower = function(type) {
-    var thrower = { message: 'unexpected '+type };
-    thrower.$thrower_type = type;
-    thrower.$throw = function(value) {
-      if (value == null) value = nil;
-      thrower.$v = value;
-      throw thrower;
-    };
+    var thrower = {
+      $thrower_type: type,
+      $throw: function(value, called_from_lambda) {
+        if (value == null) value = nil;
+        if (this.is_orphan && !called_from_lambda) {
+          $raise(Opal.LocalJumpError, 'unexpected ' + type, value, type.$to_sym());
+        }
+        this.$v = value;
+        throw this;
+      },
+      is_orphan: false
+    }
     return thrower;
   };
 

--- a/spec/filters/bugs/exception.rb
+++ b/spec/filters/bugs/exception.rb
@@ -102,8 +102,6 @@ opal_filter "Exception" do
   fails "SystemExit #initialize accepts no arguments" # NoMethodError: undefined method `status' for #<SystemExit: SystemExit>
   fails "SystemExit sets the exit status and exits silently when raised when subclassed" # NoMethodError: undefined method `tmp' for #<MSpecEnv:0x9fe6a>
   fails "SystemExit sets the exit status and exits silently when raised" # NoMethodError: undefined method `tmp' for #<MSpecEnv:0x9fe6a>
-  fails_badly "LocalJumpError#exit_value returns the value given to return" # Expected LocalJumpError but got: Exception (unexpected return)
-  fails_badly "LocalJumpError#reason returns 'return' for a return" # Expected LocalJumpError but got: Exception (unexpected return)
   fails_badly "SystemExit#status returns the exit status"
   fails_badly "SystemExit#success? returns false if the process exited unsuccessfully"
   fails_badly "SystemExit#success? returns true if the process exited successfully"

--- a/spec/filters/bugs/language.rb
+++ b/spec/filters/bugs/language.rb
@@ -231,7 +231,7 @@ opal_filter "language" do
   fails "Predefined global $. can be assigned a Float" # Expected 123.5 == 123 to be truthy but was false
   fails "Predefined global $. raises TypeError if object can't be converted to an Integer" # Expected TypeError but no exception was raised (#<MockObject:0xa7e2c @name="bad-value", @null=nil> was returned)
   fails "Predefined global $. should call #to_int to convert the object to an Integer" # Expected #<MockObject:0xa7fde @name="good-value", @null=nil> == 321 to be truthy but was false
-  fails "Predefined global $/ changes $-0" # Expected nil  to be identical to "xyz" 
+  fails "Predefined global $/ changes $-0" # Expected nil  to be identical to "xyz"
   fails "Predefined global $/ does not call #to_str to convert the object to a String" # Expected TypeError but no exception was raised (#<MockObject>(#pretty_inspect raised #<TypeError: can't convert MockObject into String (MockObject#to_str gives NilClass)>) was returned)
   fails "Predefined global $/ raises a TypeError if assigned a boolean" # Expected TypeError but no exception was raised (#<TrueClass>(#pretty_inspect raised #<TypeError: no implicit conversion of TrueClass into String>) was returned)
   fails "Predefined global $/ raises a TypeError if assigned an Integer" # Expected TypeError but no exception was raised (#<Number>(#pretty_inspect raised #<TypeError: no implicit conversion of Number into String>) was returned)
@@ -342,12 +342,7 @@ opal_filter "language" do
   fails "self in a metaclass body (class << obj) raises a TypeError for symbols" # Expected TypeError but got: Exception (Cannot create property '$$meta' on string 'symbol')
   fails "self.send(:block_given?) returns false when a method defined by define_method is called with a block" # NoMethodError: undefined method `block_given?' for KernelSpecs::SelfBlockGiven
   fails "self.send(:block_given?) returns true if and only if a block is supplied" # NoMethodError: undefined method `block_given?' for KernelSpecs::SelfBlockGiven
-  fails "top-level constant lookup on a class does not search Object after searching other scopes" # Expected NameError but no exception was raised (Hash was returned)  
-  fails_badly "Executing break from within a block works when passing through a super call" # Expected to not get Exception 
-  fails_badly "The break statement in a captured block from a scope that has returned raises a LocalJumpError when calling the block from a method" # Expected LocalJumpError but got: Exception (unexpected break)
-  fails_badly "The break statement in a captured block from a scope that has returned raises a LocalJumpError when yielding to the block" # Expected LocalJumpError but got: Exception (unexpected break)
-  fails_badly "The break statement in a captured block when the invocation of the scope creating the block is still active raises a LocalJumpError when invoking the block from a method" # Expected LocalJumpError but got: Exception (unexpected break)
-  fails_badly "The break statement in a captured block when the invocation of the scope creating the block is still active raises a LocalJumpError when invoking the block from the scope creating the block" # Expected LocalJumpError but got: Exception (unexpected break)
-  fails_badly "The break statement in a captured block when the invocation of the scope creating the block is still active raises a LocalJumpError when yielding to the block" # Expected LocalJumpError but got: Exception (unexpected break)
+  fails "top-level constant lookup on a class does not search Object after searching other scopes" # Expected NameError but no exception was raised (Hash was returned)
+  fails_badly "Executing break from within a block works when passing through a super call" # Expected to not get Exception
   fails_badly "The break statement in a lambda created at the toplevel returns a value when invoking from a method" # NoMethodError: undefined method `tmp' for #<MSpecEnv:0xa5de4 @program=#<BreakSpecs::Lambda:0xa5ea6 @ensures=false>>
 end

--- a/spec/filters/bugs/proc.rb
+++ b/spec/filters/bugs/proc.rb
@@ -73,6 +73,5 @@ opal_filter "Proc" do
   fails "Proc.new with an associated block called on a subclass of Proc using a reified block parameter returns an instance of the subclass" # Expected Proc == #<Class:0x3fc3e> to be truthy but was false
   fails "Proc.new with an associated block calls initialize on the Proc object" # ArgumentError: [MyProc2.new] wrong number of arguments (given 2, expected 0)
   fails "Proc.new with an associated block returns a subclass of Proc" # Expected #<Proc:0x3fbfc> (Proc) to be kind of ProcSpecs::MyProc
-  fails "Proc.new without a block raises an ArgumentError when passed no block" # Expected ArgumentError (tried to create Proc object without a block) but got: ArgumentError (tried to create a Proc object without a block)  
-  fails_badly "Proc.new with an associated block raises a LocalJumpError when context of the block no longer exists" # Expected LocalJumpError but got: Exception (unexpected return)
+  fails "Proc.new without a block raises an ArgumentError when passed no block" # Expected ArgumentError (tried to create Proc object without a block) but got: ArgumentError (tried to create a Proc object without a block)
 end

--- a/spec/opal/language/predefined_spec.rb
+++ b/spec/opal/language/predefined_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe "Predefined global $!" do
+  it "should be set to the new exception after a throwing rescue" do
+    outer = StandardError.new 'outer'
+    inner = StandardError.new 'inner'
+
+    begin
+      begin
+        raise outer
+      rescue
+        $!.should == outer
+        raise inner
+      end
+    rescue
+      $!.should == inner
+    end
+    $!.should == nil
+  end
+end

--- a/spec/opal/language/yield_spec.rb
+++ b/spec/opal/language/yield_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+fixture = Class.new do
+  def single
+    yield 1
+    yield 2
+  end
+
+  def multiple
+    yield 1, 2
+    yield 3, 4
+  end
+end
+
+describe "The yield call" do
+  before :each do
+    ScratchPad.record []
+    @y = fixture.new
+  end
+
+  describe "taking a single argument" do
+    it "can yield to a lambda with return" do
+      lambda = -> i {
+        ScratchPad << i
+        return
+      }
+      @y.single(&lambda)
+      ScratchPad.recorded.should == [1, 2]
+    end
+  end
+
+  describe "taking multiple arguments" do
+    it "can yield to a lambda with return" do
+      lambda = -> i, j {
+        ScratchPad << i
+        ScratchPad << j
+        return
+      }
+      @y.multiple(&lambda)
+      ScratchPad.recorded.should == [1, 2, 3, 4]
+    end
+  end
+end


### PR DESCRIPTION
Orphaned `Proc` objects will throw `LocalJumpError` on return or break.
See https://ruby-doc.org/3.2.2/Proc.html#class-Proc-label-Orphaned+Proc

Some related bugs are fixed too.