### PR TITLE
Do not skip `$truthy` when lhs is self

### DIFF
--- a/lib/opal/nodes/literal.rb
+++ b/lib/opal/nodes/literal.rb
@@ -5,18 +5,22 @@ require 'opal/nodes/base'
 module Opal
   module Nodes
     class ValueNode < Base
-      handle :true, :false, :self, :nil
+      handle :true, :false, :nil
 
       def compile
-        if type == :self
-          push scope.self
-        else
-          push type.to_s
-        end
+        push type.to_s
       end
 
       def self.truthy_optimize?
         true
+      end
+    end
+
+    class SelfNode < Base
+      handle :self
+
+      def compile
+        push scope.self
       end
     end
 

--- a/spec/lib/compiler_spec.rb
+++ b/spec/lib/compiler_spec.rb
@@ -214,6 +214,10 @@ RSpec.describe Opal::Compiler do
           expect_compiled("foo = 42 if Test > 4").to include("if ($truthy($rb_gt($$('Test'), 4))) ")
         end
 
+        it 'adds nil check for self' do
+          expect_compiled("foo = 42 if self > 4").to include("if ($truthy($rb_gt(self, 4))) ")
+        end
+
         it 'converts each == call inside if to an $eqeq wrapper, which does a truthy check' do
           expect_compiled('foo = 42 if 2 == 3').to include("if ($eqeq(2, 3))")
           expect_compiled('foo = 42 if 2.5 == 3.5').to include("if ($eqeq(2.5, 3.5))")


### PR DESCRIPTION
`self < foo` will not necessarily return boolean (e.g. `Module#<` may return nil), so we cannot skip `$truthy`.