### PR TITLE
Optimize `Opal.instance_methods`

### DIFF
--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -940,7 +940,7 @@
   };
 
   Opal.instance_methods = function(mod) {
-    var exclude = [], results = [], ancestors = $ancestors(mod);
+    var processed = Object.create(null), results = [], ancestors = $ancestors(mod);
 
     for (var i = 0, l = ancestors.length; i < l; i++) {
       var ancestor = ancestors[i],
@@ -955,18 +955,18 @@
       for (var j = 0, ll = props.length; j < ll; j++) {
         var prop = props[j];
 
+        if (processed[prop]) {
+          continue;
+        }
         if (Opal.is_method(prop)) {
-          var method_name = prop.slice(1),
-              method = proto[prop];
+          var method = proto[prop];
 
-          if (method.$$stub && exclude.indexOf(method_name) === -1) {
-            exclude.push(method_name);
-          }
-
-          if (!method.$$stub && results.indexOf(method_name) === -1 && exclude.indexOf(method_name) === -1) {
+          if (!method.$$stub) {
+            var method_name = prop.slice(1);
             results.push(method_name);
           }
         }
+        processed[prop] = true;
       }
     }
 


### PR DESCRIPTION
Avoid `Array.prototype.indexOf`, which does linear search.

This improves performance of `Module#instance_methods` and `Object#methods` much.

```console
$ # on master
$ time bin/opal -e '2000.times { String.instance_methods }'

real    0m3.197s
user    0m2.642s
sys     0m0.217s
$ time bin/opal -e '2000.times { "".methods }'

real    0m3.217s
user    0m2.639s
sys     0m0.247s

$ # on this branch
$ time bin/opal -e '2000.times { String.instance_methods }'

real    0m1.367s
user    0m0.995s
sys     0m0.175s
$ time bin/opal -e '2000.times { "".methods }'

real    0m1.371s
user    0m1.039s
sys     0m0.126s