### PR TITLE
Fix a performance regression introduced by freezing support.

### DIFF
--- a/opal/corelib/kernel.rb
+++ b/opal/corelib/kernel.rb
@@ -1,4 +1,4 @@
-# helpers: truthy, coerce_to, respond_to, Opal, deny_frozen_access, freeze, freeze_props, jsid
+# helpers: truthy, coerce_to, respond_to, Opal, deny_frozen_access, freeze, freeze_props, jsid, each_ivar
 # use_strict: true
 # backtick_javascript: true
 
@@ -369,18 +369,14 @@ module ::Kernel
 
   def instance_variables
     %x{
-      var result = [], ivar;
+      var result = [], name;
 
-      for (var name in self) {
-        if (self.hasOwnProperty(name) && name.charAt(0) !== '$') {
-          if (name.substr(-1) === '$') {
-            ivar = name.slice(0, name.length - 1);
-          } else {
-            ivar = name;
-          }
-          result.push('@' + ivar);
+      $each_ivar(self, function(name) {
+        if (name.substr(-1) === '$') {
+          name = name.slice(0, name.length - 1);
         }
-      }
+        result.push('@' + name);
+      });
 
       return result;
     }

--- a/opal/corelib/module.rb
+++ b/opal/corelib/module.rb
@@ -1,4 +1,4 @@
-# helpers: truthy, coerce_to, const_set, Object, return_ivar, assign_ivar, ivar, deny_frozen_access, freeze, prop, jsid
+# helpers: truthy, coerce_to, const_set, Object, return_ivar, assign_ivar, ivar, deny_frozen_access, freeze, prop, jsid, each_ivar
 # backtick_javascript: true
 
 class ::Module
@@ -744,11 +744,11 @@ class ::Module
     %x{
       var result = [];
 
-      for (var name in self) {
-        if (self.hasOwnProperty(name) && name.charAt(0) !== '$' && name !== 'constructor' && !#{consts.include?(`name`)}) {
+      $each_ivar(self, function(name) {
+        if (name !== 'constructor' && !#{consts.include?(`name`)}) {
           result.push('@' + name);
         }
-      }
+      });
 
       return result;
     }

--- a/opal/corelib/proc.rb
+++ b/opal/corelib/proc.rb
@@ -1,4 +1,4 @@
-# helpers: slice
+# helpers: slice, each_ivar
 # backtick_javascript: true
 
 class ::Proc < `Function`
@@ -181,11 +181,9 @@ class ::Proc < `Function`
             return original_proc.apply(this, arguments);
           };
 
-      for (var prop in self) {
-        if (self.hasOwnProperty(prop)) {
-          proc[prop] = self[prop];
-        }
-      }
+      $each_ivar(self, function(prop) {
+        proc[prop] = self[prop];
+      });
 
       return proc;
     }


### PR DESCRIPTION
In particular, this has been found whenever codebase uses freeze a lot, for instance opal compiled by opal.

In addition, this fixes a possible performance problem of codebases that use `instance_variables` method.