### PR TITLE
`String#{r,l,}strip`: Make them work like in MRI

### DIFF
--- a/opal/corelib/string.rb
+++ b/opal/corelib/string.rb
@@ -724,7 +724,7 @@ class ::String < `String`
   end
 
   def lstrip
-    `self.replace(/^[\u0000\s]*/, '')`
+    `self.replace(/^[\x00\x09\x0a-\x0d\x20]*/, '')`
   end
 
   def ascii_only?
@@ -1023,7 +1023,7 @@ class ::String < `String`
   end
 
   def rstrip
-    `self.replace(/[\s\u0000]*$/, '')`
+    `self.replace(/[\x00\x09\x0a-\x0d\x20]*$/, '')`
   end
 
   def scan(pattern, no_matchdata: false, &block)
@@ -1201,7 +1201,7 @@ class ::String < `String`
   end
 
   def strip
-    `self.replace(/^[\s\u0000]*|[\s\u0000]*$/g, '')`
+    `self.replace(/^[\x00\x09\x0a-\x0d\x20]*|[\x00\x09\x0a-\x0d\x20]*$/g, '')`
   end
 
   def sub(pattern, replacement = undefined, &block)

--- a/spec/opal/core/string_spec.rb
+++ b/spec/opal/core/string_spec.rb
@@ -26,3 +26,38 @@ describe 'Encoding' do
     end
   end
 end
+
+describe 'strip methods' do
+  def strip_cases(before, after, method)
+    before = before ? 1 : 0
+    after = after ? 1 : 0
+
+    it 'strip spaces' do
+      "#{"  " * before}ABC#{"  " * after}".send(method).should == "ABC"
+    end
+
+    it 'strips NUL bytes' do
+      "#{"\0" * before}ABC#{"\0" * after}".send(method).should == "ABC"
+    end
+
+    it "doesn't strip NBSPs" do
+      "#{"\u{a0}" * before}ABC#{"\u{a0}" * after}".send(method).should != "ABC"
+    end
+
+    it "strips all other supported whitespace characters" do
+      "#{"\r\n\t\v\f" * before}ABC#{"\r\n\t\v\f" * after}".send(method).should == "ABC"
+    end
+  end
+
+  describe '#lstrip' do
+   strip_cases true, false, :lstrip
+  end
+
+  describe '#rstrip' do
+    strip_cases false, true, :rstrip
+  end
+
+  describe '#strip' do
+    strip_cases true, true, :strip
+  end
+end


### PR DESCRIPTION
Before this patch, we have noticed that NBSP characters are stripped by those methods which is not what MRI does.

Those methods now fully follow MRI's behavior.

This fixes #2611

This PR has been sponsored by Ribose Inc.