### PR TITLE
Compat regression fix: `Hash#to_n` should return a JS object

### DIFF
--- a/spec/opal/stdlib/native/hash_spec.rb
+++ b/spec/opal/stdlib/native/hash_spec.rb
@@ -82,14 +82,14 @@ describe Hash do
     it 'converts a hash with native objects as values' do
       obj = { 'a_key' => `{ key: 1 }` }
       native = obj.to_n
-      `#{native}.get('a_key').key`.should == 1
+      `#{native}.a_key.key`.should == 1
     end
 
     it 'passes Ruby objects that cannot be converted' do
       object = Object.new
       hash = { foo: object }
       native = hash.to_n
-      expect(`#{native}.get('foo')`).to eq object
+      expect(`#{native}.foo`).to eq object
     end
   end
 end

--- a/stdlib/native.rb
+++ b/stdlib/native.rb
@@ -587,14 +587,14 @@ unless Hash.method_defined? :_initialize
       }
     end
 
-    # @return a JavaScript Map but calling #to_n on
+    # @return a JavaScript object, in turn also calling #to_n on
     # all keys and values.
     def to_n
       %x{
-        var result = new Map();
+        var result = {};
 
         Opal.hash_each(self, false, function(key, value) {
-          result.set(#{Native.try_convert(`key`, `key`)} , #{Native.try_convert(`value`, `value`)});
+          result[#{Native.try_convert(`key`, `key`)}] = #{Native.try_convert(`value`, `value`)};
           return [false, false];
         });
 


### PR DESCRIPTION
Before we have merged a Hash->Map patchset, `Hash#to_n` used to return a JS object, then it returned Map. `#to_n` is an API of the `native` library, so it is called by the unwrapping part. Let's suppose a sample JS library, that is often called like this inside JS:

```js
combomizer.enhance("feature", { fast: true })
```

This sample is very similar to how Ruby kwargs work, or at least used to, or still work this way in Opal. Such a code was represented in Opal this way:

```ruby
combomizer = Native(`js_combomizer`)
combomizer.enhance("feature", fast: true)
```

Or... without kwargs, the second line becomes:

```ruby
combomizer.enhance("feature", {fast: true})
```

After the Hash->Map patchset, this code has changed its behavior, now passing hash as a Map, which is breaking compatibility assumptions. From what I know, Map is very rarely used in JS and the JS libraries can be assumed to never expect a Map, but a JS Object.

This commit restores previous behavior of `Hash#to_n` returning a JS object, like before.

Thanks to Jean-Eric Godard (@jeezs) for reporting this bug.