### PR TITLE
Improve string interpolation

### DIFF
--- a/lib/opal/nodes/literal.rb
+++ b/lib/opal/nodes/literal.rb
@@ -259,27 +259,14 @@ module Opal
       handle :dstr
 
       def compile
-        if children.length > 1 && children.first.type == :str
-          skip_empty = true
-        else
-          push '""'
+        helper :interpolate
+
+        push '$interpolate('
+        children.each_with_index do |part, index|
+          push ', ' unless index == 0
+          push expr(part)
         end
-
-        children.each do |part|
-          if skip_empty
-            skip_empty = false
-          else
-            push ' + '
-          end
-
-          if part.type == :str
-            push expr(part)
-          else
-            push '(', expr(part), ')'
-          end
-
-          wrap '(', ')' if recv?
-        end
+        push ')'
       end
     end
 

--- a/lib/opal/nodes/literal.rb
+++ b/lib/opal/nodes/literal.rb
@@ -259,14 +259,19 @@ module Opal
       handle :dstr
 
       def compile
-        helper :interpolate
+        if children.empty?
+          push '""'
+        else
+          helper :to_s
 
-        push '$interpolate('
-        children.each_with_index do |part, index|
-          push ', ' unless index == 0
-          push expr(part)
+          children.each_with_index do |part, index|
+            push ' + ' unless index == 0
+            push '$to_s(' unless part.type == :str
+            push expr(part)
+            push ')' unless part.type == :str
+          end
+          wrap '(', ')' if recv?
         end
-        push ')'
       end
     end
 

--- a/opal/corelib/kernel.rb
+++ b/opal/corelib/kernel.rb
@@ -818,7 +818,7 @@ module ::Kernel
   end
 
   def to_s
-    "#<#{self.class}:0x#{__id__.to_s(16)}>"
+    `Opal.to_s(self)`
   end
 
   def catch(tag = nil)

--- a/opal/corelib/kernel.rb
+++ b/opal/corelib/kernel.rb
@@ -818,7 +818,7 @@ module ::Kernel
   end
 
   def to_s
-    `Opal.to_s(self)`
+    `Opal.fallback_to_s(self)`
   end
 
   def catch(tag = nil)

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -2841,6 +2841,9 @@
 
   Opal.interpolate = function(...args) {
     return args.map(obj => {
+      if (obj == null) {
+        return String(obj);
+      }
       if (obj.$$is_string || typeof obj === 'string') {
         return obj;
       }

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -2835,21 +2835,28 @@
     return Opal.set_encoding(dup, "binary", "internal_encoding");
   }
 
-  Opal.to_s = function(obj) {
+  Opal.fallback_to_s = function(obj) {
     return `#<${obj.$$class.$to_s()}:0x${Opal.id(obj).toString(16)}>`
   }
 
-  Opal.interpolate = function(...args) {
-    return args.map(obj => {
-      if (obj == null) {
-        return String(obj);
+  Opal.to_s = function(obj) {
+    var stringified;
+    if (obj == null) {
+      return "`"+String(obj)+"`";
+    }
+    else if (typeof obj === 'string' || (typeof obj === 'object' && obj.$$is_string)) {
+      return obj;
+    }
+    else if (obj.$to_s != null && !obj.$to_s.$$stub) {
+      stringified = obj.$to_s();
+      if (typeof stringified !== 'string' && !stringified.$$is_string) {
+        stringified = Opal.fallback_to_s(obj);
       }
-      if (obj.$$is_string || typeof obj === 'string') {
-        return obj;
-      }
-      const stringified = obj.$to_s();
-      return stringified.$$is_string ? stringified : Opal.to_s(obj);
-    }).join('');
+      return stringified;
+    }
+    else {
+      return obj.toString();
+    }
   }
 
   Opal.last_promise = null;

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -2835,6 +2835,20 @@
     return Opal.set_encoding(dup, "binary", "internal_encoding");
   }
 
+  Opal.to_s = function(obj) {
+    return `#<${obj.$$class.$to_s()}:0x${Opal.id(obj).toString(16)}>`
+  }
+
+  Opal.interpolate = function(...args) {
+    return args.map(obj => {
+      if (obj.$$is_string || typeof obj === 'string') {
+        return obj;
+      }
+      const stringified = obj.$to_s();
+      return stringified.$$is_string ? stringified : Opal.to_s(obj);
+    }).join('');
+  }
+
   Opal.last_promise = null;
   Opal.promise_unhandled_exception = false;
 

--- a/spec/opal/core/language/string_spec.rb
+++ b/spec/opal/core/language/string_spec.rb
@@ -1,0 +1,19 @@
+describe "Ruby string interpolation" do
+  it "uses an internal representation when #to_s doesn't return a String" do
+    obj = Object.new
+    def obj.to_s
+      BasicObject.new
+    end
+
+    str = "#{obj}"
+    str.should be_an_instance_of(String)
+    str.should =~ /\A#<Object:0x[0-9a-fA-F]+>\z/
+  end
+
+  it "uses Ruby's to_s rather than JavaScript's toString" do
+    # Array.prototype.toString returns "1,2"
+    "#{[1, 2]}".should == "[1, 2]"
+    # Function.prototype.toString returns its source code
+    "#{-> {}}".should =~ /\A#<Proc:0x[0-9a-fA-F]+>\z/
+  end
+end


### PR DESCRIPTION
No longer use `+` for string concatenation and introduce `Opal.interpolate` to handle object stringification.

- Call `Object#to_s` directly, instead of depending on `Object.prototype.toString`.
  - Closes #2618
- Fall back to the default `Object#to_s` implementation if `Object#to_s` does not return a string.
  - Closes #1068