### PR TITLE
Experiment: Compile method names without special characters.

### DIFF
--- a/lib/opal/nodes/call.rb
+++ b/lib/opal/nodes/call.rb
@@ -199,7 +199,7 @@ module Opal
       end
 
       def method_jsid
-        mid_to_jsid meth.to_s
+        mid_to_jsid_call meth.to_s
       end
 
       # Used to generate the code to use this sexp as an ivar var reference

--- a/lib/opal/nodes/def.rb
+++ b/lib/opal/nodes/def.rb
@@ -82,7 +82,7 @@ module Opal
 
       def wrap_with_definition
         helper :def
-        wrap "$def(#{scope.self}, '$#{mid}', ", ')'
+        wrap "$def(#{scope.self}, '#{mid_to_jsid mid}', ", ')'
 
         unshift "\n#{current_indent}" unless expr?
       end

--- a/lib/opal/nodes/defined.rb
+++ b/lib/opal/nodes/defined.rb
@@ -93,7 +93,7 @@ module Opal
 
       def compile_defined_send(node)
         recv, method_name, *args = *node
-        mid = mid_to_jsid(method_name.to_s)
+        mid = mid_to_jsid_call(method_name.to_s)
 
         if recv
           recv_code = compile_defined(recv)
@@ -116,7 +116,7 @@ module Opal
         meth_tmp = scope.new_temp
         push "(((#{meth_tmp} = #{recv_value_tmp}#{mid}) && !#{meth_tmp}.$$stub)"
 
-        push " || #{recv_value_tmp}['$respond_to_missing?']('#{method_name}'))"
+        push " || #{recv_value_tmp}.$respond_to_missing$Q('#{method_name}'))"
 
         args.each do |arg|
           case arg.type

--- a/lib/opal/nodes/definitions.rb
+++ b/lib/opal/nodes/definitions.rb
@@ -11,7 +11,13 @@ module Opal
 
       def compile
         children.each do |child|
-          line "Opal.udef(#{scope.self}, '$' + ", expr(child), ');'
+          case child.type
+          when :str, :sym
+            line "Opal.udef(#{scope.self}, \"#{mid_to_jsid child.children.first}\");"
+          else
+            helper :jsid
+            line "Opal.udef(#{scope.self}, $jsid(", expr(child), '));'
+          end
         end
       end
     end

--- a/lib/opal/nodes/defs.rb
+++ b/lib/opal/nodes/defs.rb
@@ -10,7 +10,7 @@ module Opal
 
       def wrap_with_definition
         helper :defs
-        unshift '$defs(', expr(recvr), ", '$#{mid}', "
+        unshift '$defs(', expr(recvr), ", '#{mid_to_jsid mid}', "
         push ')'
       end
     end

--- a/lib/opal/nodes/helpers.rb
+++ b/lib/opal/nodes/helpers.rb
@@ -13,17 +13,43 @@ module Opal
         Opal::Rewriters::JsReservedWords.valid_name?(name)
       end
 
-      # Converts a ruby method name into its javascript equivalent for
-      # a method/function call. All ruby method names get prefixed with
-      # a '$', and if the name is a valid javascript identifier, it will
-      # have a '.' prefix (for dot-calling), otherwise it will be
-      # wrapped in brackets to use reference notation calling.
+      # This content is then replicated in opal/corelib/runtime.js
+      MID_TO_JSID_COMMON={
+        "<": "$lt$",
+        ">": "$gt$",
+        "<=": "$lte$",
+        ">=": "$gte$",
+        "==": "$cmp$",
+        "!=": "$ncmp$",
+        "<=>": "$spcshp$",
+        "===": "$casecmp$",
+        "+@": "$unplus$",
+        "+": "$plus$",
+        "-@": "$unminus$",
+        "-": "$minus$",
+        "~": "$like$",
+        "=~": "$likecmp$",
+        "!~": "$likencmp$",
+        "!": "$not$",
+        "*": "$mult$",
+        "**": "$pow$",
+        "/": "$div$",
+        "%": "$rest$",
+        "&": "$and$",
+        "|": "$or$",
+        "^": "$xor$",
+        "<<": "$shl$",
+        ">>": "$shr$",
+        "[]": "$index$",
+        "[]=": "$indexset$",
+      }
+
       def mid_to_jsid(mid)
-        if %r{\=|\+|\-|\*|\/|\!|\?|<|\>|\&|\||\^|\%|\~|\[|`} =~ mid.to_s
-          "['$#{mid}']"
-        else
-          '.$' + mid
-        end
+        MID_TO_JSID_COMMON[mid.to_sym] || '$' + mid.to_s.sub("?", "$Q").sub("!", "$X").sub("=", "$S")
+      end
+
+      def mid_to_jsid_call(mid)
+        '.' + mid_to_jsid(mid)
       end
 
       def indent(&block)

--- a/lib/opal/nodes/variables.rb
+++ b/lib/opal/nodes/variables.rb
@@ -137,7 +137,7 @@ module Opal
 
       def handle_global_match
         with_temp do |tmp|
-          push "((#{tmp} = $gvars['~']) === nil ? nil : #{tmp}['$[]'](0))"
+          push "((#{tmp} = $gvars['~']) === nil ? nil : #{tmp}.$index$(0))"
         end
       end
 
@@ -183,7 +183,7 @@ module Opal
         helper :gvars
 
         with_temp do |tmp|
-          push "((#{tmp} = $gvars['~']) === nil ? nil : #{tmp}['$[]'](#{index}))"
+          push "((#{tmp} = $gvars['~']) === nil ? nil : #{tmp}.$index$(#{index}))"
         end
       end
     end

--- a/opal/corelib/comparable.rb
+++ b/opal/corelib/comparable.rb
@@ -35,7 +35,7 @@ module ::Comparable
     return true if equal?(other)
 
     %x{
-      if (self["$<=>"] == Opal.Kernel["$<=>"]) {
+      if (self.$spcshp$ == Opal.Kernel.$spcshp$) {
         return false;
       }
 

--- a/opal/corelib/hash.rb
+++ b/opal/corelib/hash.rb
@@ -108,7 +108,7 @@ class ::Hash < `Map`
 
       return $hash_each(self, true, function(key, value) {
         var other_value = $hash_get(other, key);
-        if (other_value === undefined || !value['$eql?'](other_value)) {
+        if (other_value === undefined || !value.$eql$Q(other_value)) {
           return [true, false];
         }
         return [false, true];
@@ -211,7 +211,7 @@ class ::Hash < `Map`
     %x{
       var hash = self.$class().$new();
       $hash_clone(self, hash);
-      return self["$frozen?"]() ? hash.$freeze() : hash;
+      return self.$frozen$Q() ? hash.$freeze() : hash;
     }
   end
 

--- a/opal/corelib/kernel.rb
+++ b/opal/corelib/kernel.rb
@@ -720,7 +720,7 @@ module ::Kernel
         return true;
       }
 
-      if (self['$respond_to_missing?'].$$pristine === true) {
+      if (self.$respond_to_missing$Q.$$pristine === true) {
         return false;
       } else {
         return #{respond_to_missing?(name, include_all)};

--- a/opal/corelib/module.rb
+++ b/opal/corelib/module.rb
@@ -184,7 +184,7 @@ class ::Module
             id   = $jsid(name + '='),
             ivar = $ivar(name);
 
-        var body = $assign_ivar(ivar)
+        var body = $assign_ivar(ivar);
 
         body.$$parameters = [['req']];
         body.$$arity = 1;
@@ -483,7 +483,7 @@ class ::Module
         var name = ensure_symbol_or_string(names[i]);
         $deny_frozen_access(self);
 
-        Opal.rdef(self, "$" + name);
+        Opal.rdef(self, $jsid(name));
       }
     }
 
@@ -732,7 +732,7 @@ class ::Module
         var name = ensure_symbol_or_string(names[i]);
         $deny_frozen_access(self);
 
-        Opal.udef(self, "$" + name);
+        Opal.udef(self, $jsid(name));
       }
     }
 
@@ -843,7 +843,7 @@ class ::Module
       var refine_modules = self.$$refine_modules, hash = #{{}};;
       if (typeof refine_modules === "undefined") return hash;
       for (var id in refine_modules) {
-        hash['$[]='](refine_modules[id].refined_class, refine_modules[id]);
+        hash.$indexset$(refine_modules[id].refined_class, refine_modules[id]);
       }
       return hash;
     }

--- a/opal/corelib/string.rb
+++ b/opal/corelib/string.rb
@@ -673,7 +673,7 @@ class ::String < `String`
           escaped = self.replace(escapable, function (chr) {
             if (meta[chr]) return meta[chr];
             chr = chr.charCodeAt(0);
-            if (chr <= 0xff && (self.encoding["$binary?"]() || self.internal_encoding["$binary?"]())) {
+            if (chr <= 0xff && (self.encoding.$binary$Q() || self.internal_encoding.$binary$Q())) {
               return '\\x' + ('00' + chr.toString(16).toUpperCase()).slice(-2);
             } else {
               return '\\u' + ('0000' + chr.toString(16).toUpperCase()).slice(-4);

--- a/tasks/performance.rake
+++ b/tasks/performance.rake
@@ -73,16 +73,27 @@ end
 $failures = []
 
 ASCIIDOCTOR_REPO_BASE = ENV['ASCIIDOCTOR_REPO_BASE'] || 'https://github.com/asciidoctor'
+ASCIIDOCTOR_JS_REPO_BASE = ENV['ASCIIDOCTOR_JS_REPO_BASE'] || 'https://github.com/hmdne'
 ASCIIDOCTOR_COMMIT = '869e8236'
-ASCIIDOCTOR_JS_COMMIT = '053fa0d3'
+ASCIIDOCTOR_JS_COMMIT = '9d0d5ea'
 # Selected asciidoctor versions were working on Aug 19 2021, feel free to update.
 S = OS.path_sep
+
+prepare_repo = ->(url:, commit:, dir:) {
+  [
+    "git clone #{url} >#{OS.dev_null} 2>&1",
+    "pushd #{dir}",
+      "git remote set-url origin #{url} >#{OS.dev_null} 2>&1",
+      "git fetch --all >#{OS.dev_null} 2>&1",
+      "git checkout #{commit} >#{OS.dev_null} 2>&1",
+    "popd",
+  ]
+}
+
 ASCIIDOCTOR_PREPARE = OS.bash_c(
   "pushd tmp#{S}performance",
-  "git clone #{ASCIIDOCTOR_REPO_BASE}/asciidoctor >#{OS.dev_null} 2>&1",
-  "pushd asciidoctor", "git checkout #{ASCIIDOCTOR_COMMIT} >#{OS.dev_null} 2>&1", "popd",
-  "git clone #{ASCIIDOCTOR_REPO_BASE}/asciidoctor.js >#{OS.dev_null} 2>&1",
-  "pushd asciidoctor.js", "git checkout #{ASCIIDOCTOR_JS_COMMIT} >#{OS.dev_null} 2>&1", "popd",
+  *prepare_repo.(url: "#{ASCIIDOCTOR_REPO_BASE}/asciidoctor", commit: ASCIIDOCTOR_COMMIT, dir: 'asciidoctor'),
+  *prepare_repo.(url: "#{ASCIIDOCTOR_JS_REPO_BASE}/asciidoctor.js", commit: ASCIIDOCTOR_JS_COMMIT, dir: 'asciidoctor.js'),
   "erb ../../tasks/performance/asciidoctor_test.rb.erb > asciidoctor_test.rb",
   "popd"
 )


### PR DESCRIPTION
This makes us compile names like "eql?" into "$eql$Q". This would allow us to refer to each method without a need of array access operator.

This is a performance improvement experiment. Ultimately, unfortunately, mostly a failed one. But perhaps it can be taken apart.