### PR TITLE
Speed up {Array,Hash}#hash and a couple of Hash operations

### DIFF
--- a/opal/corelib/array.rb
+++ b/opal/corelib/array.rb
@@ -1296,10 +1296,12 @@ class ::Array < `Array`
       }
 
       try {
-        values = $hash_ids.values();
-        for (item of values) {
-          if (#{eql?(`item`)}) {
-            return $opal32_add(result, 0x01010101);
+        if (!top) {
+          values = $hash_ids.values();
+          for (item of values) {
+            if (#{eql?(`item`)}) {
+              return $opal32_add(result, 0x01010101);
+            }
           }
         }
 

--- a/opal/corelib/array.rb
+++ b/opal/corelib/array.rb
@@ -1282,28 +1282,28 @@ class ::Array < `Array`
       var top = ($hash_ids === undefined),
           result = $opal32_init(),
           hash_id = self.$object_id(),
-          item, i, key;
+          item, i, key, values;
 
       result = $opal32_add(result, 0xA);
       result = $opal32_add(result, self.length);
 
       if (top) {
-        $hash_ids = Object.create(null);
+        $hash_ids = new Map();
       }
       // return early for recursive structures
-      else if ($hash_ids[hash_id]) {
+      else if ($hash_ids.has(hash_id)) {
         return $opal32_add(result, 0x01010101);
       }
 
       try {
-        for (key in $hash_ids) {
-          item = $hash_ids[key];
+        values = $hash_ids.values();
+        for (item of values) {
           if (#{eql?(`item`)}) {
             return $opal32_add(result, 0x01010101);
           }
         }
 
-        $hash_ids[hash_id] = self;
+        $hash_ids.set(hash_id, self);
 
         for (i = 0; i < self.length; i++) {
           item = self[i];

--- a/opal/corelib/hash.rb
+++ b/opal/corelib/hash.rb
@@ -493,29 +493,29 @@ class ::Hash < `Map`
       var top = ($hash_ids === undefined),
           hash_id = self.$object_id(),
           result = $opal32_init(),
-          key, item, i,
+          key, item, i, values,
           size = self.size, ary = new Int32Array(size);
 
       result = $opal32_add(result, 0x4);
       result = $opal32_add(result, size);
 
       if (top) {
-        $hash_ids = Object.create(null);
+        $hash_ids = new Map();
       }
-      else if ($hash_ids[hash_id]) {
+      else if ($hash_ids.has(hash_id)) {
         return $opal32_add(result, 0x01010101);
       }
 
       try {
-        for (key in $hash_ids) {
-          item = $hash_ids[key];
+        values = $hash_ids.values();
+        for (item of values) {
           if (#{eql?(`item`)}) {
             return $opal32_add(result, 0x01010101);
           }
         }
 
-        $hash_ids[hash_id] = self;
-        i = 0
+        $hash_ids.set(hash_id, self);
+        i = 0;
 
         $hash_each(self, false, function(key, value) {
           ary[i] = [0x70414952, key, value].$hash();

--- a/opal/corelib/hash.rb
+++ b/opal/corelib/hash.rb
@@ -106,13 +106,14 @@ class ::Hash < `Map`
         return false;
       }
 
-      return $hash_each(self, true, function(key, value) {
-        var other_value = $hash_get(other, key);
-        if (other_value === undefined || !value['$eql?'](other_value)) {
-          return [true, false];
+      var entry, entries = self.entries(), other_value;
+      for (entry of entries) {
+        other_value = $hash_get(other, entry[0]);
+        if (other_value === undefined || !entry[1]['$eql?'](other_value)) {
+          return false;
         }
-        return [false, true];
-      });
+      }
+      return true;
     }
   end
 
@@ -493,7 +494,7 @@ class ::Hash < `Map`
       var top = ($hash_ids === undefined),
           hash_id = self.$object_id(),
           result = $opal32_init(),
-          key, item, i, values,
+          key, item, i, values, entry, entries,
           size = self.size, ary = new Int32Array(size);
 
       result = $opal32_add(result, 0x4);
@@ -519,11 +520,11 @@ class ::Hash < `Map`
         $hash_ids.set(hash_id, self);
         i = 0;
 
-        $hash_each(self, false, function(key, value) {
-          ary[i] = [0x70414952, key, value].$hash();
+        entries = self.entries();
+        for (entry of entries) {
+          ary[i] = [0x70414952, entry[0], entry[1]].$hash();
           i++;
-          return [false, false];
-        });
+        }
 
         ary = ary.sort();
 

--- a/opal/corelib/hash.rb
+++ b/opal/corelib/hash.rb
@@ -187,12 +187,13 @@ class ::Hash < `Map`
 
   def assoc(object)
     %x{
-      return $hash_each(self, nil, function(key, value) {
-        if (#{`key` == object}) {
-          return [true, [key, value]];
+      var entry, entries = self.entries();
+      for (entry of entries) {
+        if (#{`entry[0]` == object}) {
+          return [entry[0], entry[1]];
         }
-        return [false, nil];
-      });
+      }
+      return nil;
     }
   end
 
@@ -478,12 +479,13 @@ class ::Hash < `Map`
 
   def has_value?(value)
     %x{
-      return $hash_each(self, false, function(key, val) {
+      var val, values = self.values();
+      for (val of values) {
         if (#{`val` == value}) {
-          return [true, true];
+          return true;
         }
-        return [false, false];
-      });
+      }
+      return false;
     }
   end
 
@@ -543,12 +545,13 @@ class ::Hash < `Map`
 
   def index(object)
     %x{
-      return $hash_each(self, nil, function(key, value) {
-        if (#{`value` == object}) {
-          return [true, key];
+      var entry, entries = self.entries();
+      for (entry of entries) {
+        if (#{`entry[1]` == object}) {
+          return entry[0];
         }
-        return [false, nil];
-      });
+      }
+      return nil;
     }
   end
 
@@ -683,12 +686,13 @@ class ::Hash < `Map`
 
   def rassoc(object)
     %x{
-      return $hash_each(self, nil, function(key, value) {
-        if (#{`value` == object}) {
-          return [true, [key, value]];
+      var entry, entries = self.entries();
+      for (entry of entries) {
+        if (#{`entry[1]` == object}) {
+          return [entry[0], entry[1]];
         }
-        return [false, nil];
-      });
+      }
+      return nil;
     }
   end
 
@@ -823,14 +827,7 @@ class ::Hash < `Map`
   end
 
   def to_a
-    %x{
-      var result = [];
-
-      return $hash_each(self, result, function(key, value) {
-        result.push([key, value]);
-        return [false, result];
-      });
-    }
+    `Array.from(self.entries())`
   end
 
   def to_h(&block)

--- a/opal/corelib/hash.rb
+++ b/opal/corelib/hash.rb
@@ -106,8 +106,8 @@ class ::Hash < `Map`
         return false;
       }
 
-      var entry, entries = self.entries(), other_value;
-      for (entry of entries) {
+      var entry, other_value;
+      for (entry of self) {
         other_value = $hash_get(other, entry[0]);
         if (other_value === undefined || !entry[1]['$eql?'](other_value)) {
           return false;
@@ -187,8 +187,8 @@ class ::Hash < `Map`
 
   def assoc(object)
     %x{
-      var entry, entries = self.entries();
-      for (entry of entries) {
+      var entry;
+      for (entry of self) {
         if (#{`entry[0]` == object}) {
           return [entry[0], entry[1]];
         }
@@ -496,7 +496,7 @@ class ::Hash < `Map`
       var top = ($hash_ids === undefined),
           hash_id = self.$object_id(),
           result = $opal32_init(),
-          key, item, i, values, entry, entries,
+          key, item, i, values, entry,
           size = self.size, ary = new Int32Array(size);
 
       result = $opal32_add(result, 0x4);
@@ -522,8 +522,7 @@ class ::Hash < `Map`
         $hash_ids.set(hash_id, self);
         i = 0;
 
-        entries = self.entries();
-        for (entry of entries) {
+        for (entry of self) {
           ary[i] = [0x70414952, entry[0], entry[1]].$hash();
           i++;
         }
@@ -545,8 +544,8 @@ class ::Hash < `Map`
 
   def index(object)
     %x{
-      var entry, entries = self.entries();
-      for (entry of entries) {
+      var entry;
+      for (entry of self) {
         if (#{`entry[1]` == object}) {
           return entry[0];
         }
@@ -686,8 +685,8 @@ class ::Hash < `Map`
 
   def rassoc(object)
     %x{
-      var entry, entries = self.entries();
-      for (entry of entries) {
+      var entry;
+      for (entry of self) {
         if (#{`entry[1]` == object}) {
           return [entry[0], entry[1]];
         }

--- a/opal/corelib/hash.rb
+++ b/opal/corelib/hash.rb
@@ -826,7 +826,7 @@ class ::Hash < `Map`
   end
 
   def to_a
-    `Array.from(self.entries())`
+    `Array.from(self)`
   end
 
   def to_h(&block)

--- a/opal/corelib/hash.rb
+++ b/opal/corelib/hash.rb
@@ -507,10 +507,12 @@ class ::Hash < `Map`
       }
 
       try {
-        values = $hash_ids.values();
-        for (item of values) {
-          if (#{eql?(`item`)}) {
-            return $opal32_add(result, 0x01010101);
+        if (!top) {
+          values = $hash_ids.values();
+          for (item of values) {
+            if (#{eql?(`item`)}) {
+              return $opal32_add(result, 0x01010101);
+            }
           }
         }
 


### PR DESCRIPTION
I have a use case where Hash#key? computing hashes for a not too large Hash/Array combo takes ~ 3 seconds, for the combination if things going on 10 seconds are wasted.
Using a Map instead of Object.create(null) for $hash_ids seems to reduce that to a 11ms for Hash#key? and the combination ~100ms or so.

Have not tried other use cases or anything else, let see result of the actions ...