### PR TITLE
Initial `fork()` support for Node.js

### DIFF
--- a/stdlib/nodejs.rb
+++ b/stdlib/nodejs.rb
@@ -1,5 +1,6 @@
 require 'nodejs/base'
 require 'nodejs/kernel'
+require 'nodejs/process'
 require 'nodejs/file'
 require 'nodejs/dir'
 require 'nodejs/io'

--- a/stdlib/nodejs/process.rb
+++ b/stdlib/nodejs/process.rb
@@ -1,0 +1,5 @@
+module ::Process
+  def self.pid
+    `Opal.Kernel.__process__.pid`
+  end
+end


### PR DESCRIPTION
Working, it may happen though, that the parent process exits before the child was able to read its javascript file. 
Happens with SystemRunner and its tempfile, which gets deleted when the parent exits. It will fork and then print:
`Error: Cannot find module '/tmp/opal-system-runner20240202-905467-v7fj7d.js'`

In ruby, such situation will still work, because fork relies on the image in memory. In node, the original javascript file is still required when forking.

That of course is not a issue at all, if the parent process keeps running anyway.

This updates the node requires in nodejs/kernel.rb to use the modern form.