### PR TITLE
Improve instance variable performance

### DIFF
--- a/opal/corelib/kernel.rb
+++ b/opal/corelib/kernel.rb
@@ -372,7 +372,7 @@ module ::Kernel
       var result = [], name;
 
       $each_ivar(self, function(name) {
-        if (name.substr(-1) === '$') {
+        if (name[name.length-1] === '$') {
           name = name.slice(0, name.length - 1);
         }
         result.push('@' + name);


### PR DESCRIPTION
This patch improves $each_ivar, with positive effects on Up! benchmark results for the env.to_s benchmark:
from 8328.87 req/s to 13105.05 req/s, thats ~50% up. Probably has positive effects on other apps too.