### PR TITLE
Fix several `%{}` which were intended to be `%x{}`

### DIFF
--- a/opal/corelib/object_space.rb
+++ b/opal/corelib/object_space.rb
@@ -55,7 +55,7 @@ module ::ObjectSpace
   end
 
   def undefine_finalizer(obj)
-    %{
+    %x{
       var id = #{obj.__id__};
       registry.unregister(obj);
       delete_callers(id);

--- a/opal/corelib/string/encoding.rb
+++ b/opal/corelib/string/encoding.rb
@@ -400,7 +400,7 @@ class ::String
   end
 
   def initialize_copy(other)
-    %{
+    %x{
       self.encoding = other.encoding;
       self.internal_encoding = other.internal_encoding;
     }

--- a/stdlib/deno/file.rb
+++ b/stdlib/deno/file.rb
@@ -193,7 +193,7 @@ class File < IO
 
   def self.readable?(path)
     return false unless exist? path
-    %{
+    %x{
       try {
         Deno.openSync(path, {read: true}).close();
         return true;

--- a/stdlib/nodejs/file.rb
+++ b/stdlib/nodejs/file.rb
@@ -203,14 +203,14 @@ class File < IO
 
   def self.readable?(path)
     return false unless exist? path
-    %{
-        try {
-          __fs__.accessSync(path, __fs__.R_OK);
-          return true;
-        } catch (error) {
-          return false;
-        }
+    %x{
+      try {
+        __fs__.accessSync(path, __fs__.R_OK);
+        return true;
+      } catch (error) {
+        return false;
       }
+    }
   end
 
   def self.size(path)


### PR DESCRIPTION
I found some cases where JavaScript code was accidentally embeded as a normal string with `%{}`, not `%x{}`.