### PR TITLE
Add an option to use Prism parser

### DIFF
--- a/lib/opal/cli.rb
+++ b/lib/opal/cli.rb
@@ -75,6 +75,8 @@ module Opal
         @file = @stdin
       end
 
+      Opal::Parser.use_prism if options.delete(:prism)
+
       raise ArgumentError, "unknown options: #{options.inspect}" unless @options.empty?
     end
 

--- a/lib/opal/cli_options.rb
+++ b/lib/opal/cli_options.rb
@@ -200,6 +200,10 @@ module Opal
         options[:file] = file
       end
 
+      on('--prism', '(experimental) Use Prism as a parser') do
+        options[:prism] = true
+      end
+
       on('-V', '(deprecated; always enabled) Enable inline Operators') do
         warn '* -V is deprecated and has no effect'
         options[:inline_operators] = true

--- a/lib/opal/nodes/x_string.rb
+++ b/lib/opal/nodes/x_string.rb
@@ -46,8 +46,8 @@ module Opal
       # Check if there's only one child or if they're all part of
       # the same line (e.g. because of interpolations)
       def self.single_line?(children)
-        (children.size == 1) || children.none? do |c|
-          c.type == :str && c.loc.expression.source.end_with?("\n")
+        (children.size == 1 && children[0].type != :str) || children.none? do |c|
+          c.type == :str && c.loc.expression.source.include?("\n")
         end
       end
 

--- a/lib/opal/parser/default_config.rb
+++ b/lib/opal/parser/default_config.rb
@@ -28,11 +28,10 @@ module Opal
         super(Opal::AST::Builder.new)
       end
 
-      def parse(source_buffer)
-        parsed = super || ::Opal::AST::Node.new(:nil)
-        wrapped = ::Opal::AST::Node.new(:top, [parsed])
-        rewriten = rewrite(wrapped)
-        rewriten
+      def modify_ast(ast)
+        ast ||= ::Opal::AST::Node.new(:nil)
+        wrapped = ::Opal::AST::Node.new(:top, [ast])
+        rewrite(wrapped)
       end
 
       def rewrite(node)
@@ -41,10 +40,17 @@ module Opal
     end
 
     class << self
-      attr_accessor :default_parser_class
+      def default_parser_class
+        @default_parser_class ||= WithRubyLexer
+      end
 
       def default_parser
         default_parser_class.default_parser
+      end
+
+      def use_prism
+        require 'opal/parser/with_prism'
+        @default_parser_class = WithPrism
       end
     end
   end

--- a/lib/opal/parser/with_prism.rb
+++ b/lib/opal/parser/with_prism.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'prism'
+require 'prism/translation/parser'
+
+class Opal::Parser::WithPrism < ::Prism::Translation::Parser
+  include Opal::Parser::DefaultConfig
+
+  def build_ast(program, offset_cache)
+    modify_ast(super)
+  end
+end

--- a/lib/opal/parser/with_ruby_lexer.rb
+++ b/lib/opal/parser/with_ruby_lexer.rb
@@ -2,5 +2,8 @@
 
 class Opal::Parser::WithRubyLexer < Parser::Ruby32
   include Opal::Parser::DefaultConfig
-  Opal::Parser.default_parser_class = self
+
+  def parse(source_buffer)
+    modify_ast(super)
+  end
 end

--- a/opal.gemspec
+++ b/opal.gemspec
@@ -31,10 +31,11 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.3'
+  spec.required_ruby_version = '>= 2.7'
 
   spec.add_dependency 'ast', '>= 2.3.0'
-  spec.add_dependency 'parser', ['~> 3.0', '>= 3.0.3.2']
+  spec.add_dependency 'parser', '~>3.2'
+  spec.add_dependency 'prism', '~> 0.22'
 
   spec.add_development_dependency 'sourcemap', '~> 0.1.0'
   spec.add_development_dependency 'rake', '~> 13.0'


### PR DESCRIPTION
Ruby 3.3 introduced Prism parser, and it is also released as a gem.
The latest version of Prism includes `Prism::Tarnslaion::Parser`, a wrapper class to make Prism compatible with parser gem (`whitequark/parser`).

This PR tries to replace the current parser (`Parser::Ruby32`) with `Prism::Tranlation::Parser`.
Since this is just an experiment, the default parser remains to be that of parser gem. Instead I added `--prism` CLI option to switch the parser.

Here are some advantages with Prism:
- Compile becomes faster
- Parser gem-related issue (#1703) is resolved

Todo:
- [ ] Support using Prism in opalopal
  - Prism can be run in JavaScript through wasm
- [ ] Run tests with Prism

cc: @kddnewton 