### PR TITLE
Split documentation of Native into a separate document

### DIFF
--- a/docs/compiled_ruby.md
+++ b/docs/compiled_ruby.md
@@ -1,4 +1,4 @@
-# Compiled Ruby Code
+# Compiled Ruby Code and Raw JavaScript Interfaces
 
 ## Generated JavaScript
 
@@ -239,6 +239,15 @@ a special syntax for inlining JavaScript code. This is done with
 x-strings or "backticks", as their Ruby use has no useful translation
 in the browser.
 
+To make x-strings a tool to embed JavaScript, you must add a necessary
+magic comment on the top of your program:
+
+```ruby
+# backtick_javascript: true
+```
+
+Sample code:
+
 ```ruby
 `window.title`
 # => "Opal: Ruby to JavaScript compiler"
@@ -267,63 +276,6 @@ end
 
 X-Strings also have the ability to automatically return their value,
 as used by this example.
-
-
-### Native Module
-
-_Reposted from: [Mikamayhem](http://dev.mikamai.com/post/79398725537/using-native-javascript-objects-from-opal)_
-
-Opal standard lib (stdlib) includes a `Native` module. To use it, you need to download and reference `native.js`. You can find the latest minified one from the CDN [here](http://cdn.opalrb.com/opal/current/native.min.js).
-
-Let's see how it works and wrap `window`:
-
-```ruby
-require 'native'
-
-win = Native(`window`) # equivalent to Native::Object.new(`window`)
-```
-
-To access a Native-wrapped global JavaScript object, we can also use `$$`, after
-we have the `native` module required.
-
-Now what if we want to access one of its properties?
-
-```ruby
-win[:location][:href]                         # => "http://dev.mikamai.com/"
-win[:location][:href] = "http://mikamai.com/" # will bring you to mikamai.com
-```
-
-And what about methods?
-
-```ruby
-win.alert('hey there!')
-```
-
-So let’s do something more interesting:
-
-```ruby
-class << win
-  # A cross-browser window close method (works in IE!)
-  def close!
-    %x{
-      return (#@native.open('', '_self', '') && #@native.close()) ||
-             (#@native.opener = null && #@native.close()) ||
-             (#@native.opener = '' && #@native.close());
-    }
-  end
-
-  # let's assign href directly
-  def href= url
-    self[:location][:href] = url
-  end
-end
-```
-
-That’s all for now, bye!
-
-```ruby
-win.close!
-```
 
 ### Calling JavaScript Methods
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,10 @@ Everything you need to know to install Opal and create your first application.
 
 ## Using JavaScript Features from Ruby
 
+#### [Interfacing with JavaScript](js_interface.html)
+
+Discover how to access JavaScript environment from Ruby code.
+
 #### [Async](async.html)
 
 Learn more about JavaScript `async`/`await` support in Opal and how you can use it to avoid explicit callbacks and promises.
@@ -84,9 +88,10 @@ How to make your gem work in Opal and differentiate code for the JavaScript envi
 
 A very general overview of how the Opal compiler works.
 
-#### [Compiled Ruby](compiled_ruby.html)
+#### [Compiled Ruby and Raw JavaScript Interfaces](compiled_ruby.html)
 
-This guide documents how each part of Ruby is mapped to JavaScript internally.
+This guide documents how each part of Ruby is mapped to JavaScript internally. This guide also gives
+information on how to interface Ruby with JavaScript and vice-versa using raw interfaces.
 
 #### [Compiler File Loading Directives](compiler_directives.html)
 

--- a/docs/js_interface.md
+++ b/docs/js_interface.md
@@ -1,0 +1,68 @@
+# Interfacing with JavaScript
+
+## The `Native` Module Guide
+
+### Introduction
+
+This guide is dedicated to helping Ruby developers, from beginners to seasoned pros, to seamlessly work with JavaScript environments using Opal's `Native` module. We aim to provide a clear pathway for Rubyists to harness the power of JavaScript without stepping away from the comfort of Ruby syntax.
+
+### Getting Started with the `Native` Module
+
+#### Setting Up
+
+To start using the `Native` module in your project, require it at the beginning of your Ruby file:
+
+```ruby
+require 'native'
+```
+
+This line loads the `Native` module, granting you access to JavaScript's global objects, functions, and properties directly from Ruby.
+
+### Basics of `Native` Module Usage
+
+#### Accessing JavaScript Global Objects
+
+The global JavaScript object, typically `window` in a browser environment, can be referenced in Opal using the `$$` or `$global` variables:
+
+```ruby
+win = $$  # References the global JavaScript `window` object
+```
+
+#### Reading and Writing Properties
+
+Access and modify JavaScript object properties straightforwardly:
+
+```ruby
+# Access a property
+puts win[:location][:href]  # Output: the current page URL
+
+# Modify a property
+win[:location][:href] = "https://example.com"  # Redirects the browser to example.com
+```
+
+#### Calling JavaScript Methods
+
+Invoke methods on JavaScript objects with ease:
+
+```ruby
+win.alert('Hello, Opal!')
+```
+
+#### Enhancing JavaScript Objects with Ruby
+
+You can define Ruby methods on JavaScript objects for more complex interactions:
+
+```ruby
+class << win
+  def close!
+    close  # Calls the JavaScript close method on the window object
+  end
+
+  def href=(url)
+    self[:location][:href] = url
+  end
+end
+
+win.href = "https://example.com"  # Sets the page URL
+win.close!  # Closes the browser window
+```


### PR DESCRIPTION
And make it more visible, so that new users could find this information more easily.

Thanks to @AndyObtiva for suggestion.