### PR TITLE
Implement --directory CLI option

### DIFF
--- a/docs/directory_mode.md
+++ b/docs/directory_mode.md
@@ -1,0 +1,84 @@
+# Directory Mode
+
+By default, `Opal::Builder` and `opal` CLI tool build all the dependencies, then concatenate all the resulting JavaScript into a single file, possibly with a concatenated source map. This used to be a robust idea, before introduction of protocols like HTTP/2, HTTP/3 and before Rails 7. This also kind of duplicates the work of JavaScript bundlers and makes their work a little bit more difficult.
+
+Since Opal 2.0, we have introduced a directory mode, which builds the resulting JavaScript into a directory instead of building a single file. It also duplicates the source files into this resulting directory and we debundle the source maps. **It is now, along with the ESM mode, the recommended way to build your Opal project and we will explore the ways to make it the default in some future major release.**
+
+This results in a much more readable output.
+
+## `opal` CLI tool
+
+Let's say your input file is `my_program.rb` containing the following source:
+
+```ruby
+require "json"
+
+puts "Hello world!".to_json
+```
+
+To compile it in regular, concatenated mode, to a file named `my_program.js` you would issue the following command:
+
+```bash
+opal -c my_program.rb > my_program.js
+```
+
+To compile it to a directory, you need to specify `--directory` option.
+
+```bash
+opal --directory -c my_program.rb -O my_program
+```
+
+In `my_program` directory you will find files, most notably, an `index.js` entrypoint file, which you can run in Node. Do note, that we use `require()` function to load the dependent programs, which doesn't work in browsers - this is the CommonJS output, which is the default. Therefore, we recommend to also add an `--esm` option:
+
+```bash
+opal --esm --directory -c my_program.rb -O my_program
+```
+
+Now, we get almost the same output, except that our entrypoint is named `index.mjs`, which as before, can be ran in Node. In addition, as convenience, we also build `index.html` which you can run directly in your favorite browser.
+
+As in the default mode, instead of outputting your compiled program to a directory, you can use a runner, like `node` (node that not all the runners are supported yet):
+
+```bash
+opal --esm --directory -Rnode my_program.rb
+```
+
+This command should simply output the following:
+
+```
+"Hello world!"
+```
+
+## `Opal::Builder`
+
+If you build your program with `Opal::Builder` class, for instance in your Rake task, its semantics in the directory mode also change slightly. For instance, you may have a code like this:
+
+```ruby
+builder = Opal::Builder.new
+builder.append_paths __dir__
+builder.build_require "opal", load: true
+builder.build "my_program.rb"
+File.binwrite("my_program.js", builder.to_s)
+```
+
+To use the directory mode and ESM, build your program like follows:
+
+```ruby
+builder = Opal::Builder.new(compiler_options: {esm: true, directory: true})
+builder.append_paths __dir__
+builder.build_require "opal", load: true
+builder.build "my_program.rb"
+builder.compile_to_directory "my_program"
+```
+
+To set compiler options, you can also use global variables:
+
+```ruby
+Opal::Config.esm = true
+Opal::Config.directory = true
+```
+
+Note two differences: you can't use `#to_s` anymore and you need to define the correct compiler options.
+
+## Sprockets
+
+Unfortunately, the Sprockets pipeline is not supported with directory mode. While we intend to support the Sprockets pipeline for the foreseeable future, it's mostly in a maintenance stage and new features like directory mode won't be supported. We recommend you to migrate to any pipeline that uses `Opal::Builder` under the hood.

--- a/lib/opal/builder.rb
+++ b/lib/opal/builder.rb
@@ -6,6 +6,7 @@ require 'opal/config'
 require 'opal/cache'
 require 'opal/builder_scheduler'
 require 'opal/project'
+require 'opal/builder/directory'
 require 'set'
 
 module Opal
@@ -176,6 +177,7 @@ module Opal
     end
 
     include Project::Collection
+    include Builder::Directory
 
     attr_reader :processed
 
@@ -212,6 +214,13 @@ module Opal
       else
         path
       end
+    end
+
+    # Output method #compiled_source aims to replace #to_s
+    def compiled_source(with_source_map: true)
+      compiled_source = to_s
+      compiled_source += "\n" + source_map.to_data_uri_comment if with_source_map
+      compiled_source
     end
 
     private

--- a/lib/opal/builder/directory.rb
+++ b/lib/opal/builder/directory.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+module Opal
+  class Builder
+    # This module is included into Builder, provides abstracted data about a new
+    # paradigm of compiling Opal applications into a directory.
+    module Directory
+      def version_prefix
+        "opal/#{Opal::VERSION_MAJOR_MINOR}"
+      end
+
+      def source_prefix
+        'opal/src'
+      end
+
+      # Output method #compile_to_directory depends on a directory compiler
+      # option being set, so that imports are generated correctly.
+      def compile_to_directory(dir = nil, single_file: nil, with_source_map: true)
+        raise ArgumentError, 'no directory provided' if dir.nil? && single_file.nil?
+
+        catch(:file) do
+          index = []
+
+          processed.each do |file|
+            module_name = Compiler.module_name(file.filename)
+            last_segment_name = File.basename(module_name)
+            depth = module_name.split('/').length - 1
+            file_name = Pathname(file.filename).cleanpath.to_s
+
+            index << module_name if file.options[:load] || !file.options[:requirable]
+
+            compiled_filename = "#{version_prefix}/#{module_name}.#{output_extension}"
+            try_building_single_file(dir, compiled_filename, single_file) do
+              compiled_source = file.to_s
+              compiled_source += "\n//# sourceMappingURL=./#{last_segment_name}.map" if with_source_map
+              compiled_source
+            end
+
+            if with_source_map
+              source_map_filename = "#{version_prefix}/#{module_name}.map"
+              try_building_single_file(dir, source_map_filename, single_file) do
+                # Correct the map to point to source files and remove embedded source
+                source_map = file.source_map.to_h.dup
+                source_map[:sourceRoot] = "./#{'../' * depth}../../#{source_prefix}"
+                source_map[:sources] = [file_name]
+                source_map.delete(:sourcesContent)
+                source_map.to_json
+              end
+
+              source_filename = "#{source_prefix}/#{file_name}"
+              try_building_single_file(dir, source_filename, single_file) do
+                file.original_source
+              end
+            end
+          end
+
+          compile_index(dir, index: index, single_file: single_file)
+        end
+      end
+
+      private
+
+      # Generates executable index files
+      def compile_index(dir = nil, index:, single_file: nil)
+        index = index.map { |i| "./#{version_prefix}/#{i}.#{output_extension}" }
+
+        if !esm?
+          try_building_single_file(dir, 'index.js', single_file) do
+            index.map { |i| "require(#{i.to_json});" }.join("\n") + "\n"
+          end
+        else
+          try_building_single_file(dir, 'index.mjs', single_file) do
+            index.map { |i| "import #{i.to_json};" }.join("\n") + "\n"
+          end
+
+          try_building_single_file(dir, 'index.html', single_file) do
+            <<~HTML
+              <!doctype html>
+              <html>
+              <head>
+                <meta charset='utf-8'>
+                <title>Opal application</title>
+              </head>
+              <body>
+                #{index.map { |i| "<script type='module' src='#{i}'></script>" }.join("\n  ")}
+              </body>
+              </html>
+            HTML
+          end
+        end
+      end
+
+      # A helper method to either generate a single file or write a file to
+      # a specified location.
+      def try_building_single_file(dir, file, single_file, &_block)
+        if !single_file
+          FileUtils.mkdir_p(File.dirname("#{dir}/#{file}"))
+          File.binwrite("#{dir}/#{file}", yield)
+        elsif single_file == file
+          throw :file, yield
+        end
+      end
+    end
+  end
+end

--- a/lib/opal/builder_processors.rb
+++ b/lib/opal/builder_processors.rb
@@ -19,6 +19,8 @@ module Opal
       end
       attr_reader :source, :filename, :options, :requires, :required_trees, :autoloads, :abs_path
 
+      alias original_source source
+
       def to_s
         source.to_s
       end

--- a/lib/opal/cli.rb
+++ b/lib/opal/cli.rb
@@ -61,6 +61,11 @@ module Opal
         [key, value]
       end.compact.to_h
 
+      # directory is both a runner and compiler option
+      @directory = @compiler_options[:directory]
+      @runner_options[:directory] = @directory
+      @output = File.open(@output, 'w') if @output.is_a?(String) && !@directory
+
       if @lib_only
         raise ArgumentError, 'no libraries to compile' if @requires.empty?
         raise ArgumentError, "can't accept evals, file, or extra arguments in `library only` mode" if @argv.any? || @evals.any?
@@ -191,6 +196,7 @@ module Opal
         use_strict
         parse_comments
         esm
+        directory
       ]
     end
 

--- a/lib/opal/cli_options.rb
+++ b/lib/opal/cli_options.rb
@@ -108,8 +108,8 @@ module Opal
         options[:runner] = :compiler
       end
 
-      on('-o', '--output FILE', 'Output JavaScript to FILE') do |file|
-        options[:output] = File.open(file, 'w')
+      on('-o', '--output FILE', 'Output JavaScript to FILE (or directory if --directory enabled)') do |file|
+        options[:output] = file
       end
 
       on('-P', '--map FILE', 'Output source map to FILE') do |file|
@@ -154,6 +154,10 @@ module Opal
 
       on('--esm', 'Wraps compiled bundle as for ES6 module') do
         options[:esm] = true
+      end
+
+      on('--directory', 'Builds the program as a directory of JS files') do
+        options[:directory] = true
       end
 
       on('-A', '--arity-check', 'Enable arity check') do

--- a/lib/opal/cli_runners/compiler.rb
+++ b/lib/opal/cli_runners/compiler.rb
@@ -14,19 +14,24 @@ class Opal::CliRunners::Compiler
     @map_file        = @options[:map_file]
     @output          = data.fetch(:output)
     @watch           = @options[:watch]
+    @directory       = @options[:directory]
   end
 
   def compile
     builder = @builder_factory.call
-    compiled_source = builder.to_s
-    compiled_source += "\n" + builder.source_map.to_data_uri_comment unless @options[:no_source_map]
 
-    rewind_output if @watch
+    if @directory
+      builder.compile_to_directory(@output, with_source_map: !@options[:no_source_map])
+    else
+      compiled_source = builder.compiled_source(with_source_map: !@options[:no_source_map])
 
-    @output.puts compiled_source
-    @output.flush
+      rewind_output if @watch
 
-    File.write(@map_file, builder.source_map.to_json) if @map_file
+      @output.puts compiled_source
+      @output.flush
+
+      File.write(@map_file, builder.source_map.to_json) if @map_file
+    end
 
     builder
   end

--- a/lib/opal/cli_runners/mini_racer.rb
+++ b/lib/opal/cli_runners/mini_racer.rb
@@ -16,7 +16,7 @@ module Opal
 
         # MiniRacer doesn't like to fork. Let's build Opal first
         # in a forked environment.
-        code = builder.to_s + "\n" + builder.source_map.to_data_uri_comment
+        code = builder.compiled_source
 
         v8 = ::MiniRacer::Context.new
         v8.attach('prompt', ->(_msg = '') { $stdin.gets&.chomp })

--- a/lib/opal/cli_runners/server.rb
+++ b/lib/opal/cli_runners/server.rb
@@ -51,7 +51,7 @@ module Opal
       end
 
       def build_app(builder)
-        app = App.new(builder: builder, main: 'cli-runner')
+        app = Opal::SimpleServer.new(builder: builder, main: 'cli-runner')
 
         if static_folder
           not_found = [404, {}, []]
@@ -64,17 +64,6 @@ module Opal
         end
 
         app
-      end
-
-      class App < SimpleServer
-        def initialize(options = {})
-          @builder = options.fetch(:builder)
-          super
-        end
-
-        def builder(_)
-          @builder.call
-        end
       end
     end
   end

--- a/lib/opal/cli_runners/system_runner.rb
+++ b/lib/opal/cli_runners/system_runner.rb
@@ -1,53 +1,70 @@
 # frozen_string_literal: true
 
 require 'tempfile'
+require 'tmpdir'
+require 'fileutils'
 
-# Generic runner that will resort to calling an external program.
-#
-# @option :options [Hash,nil] :env a hash of options to be used as env in the
-#   call to system.
-# @option :options [true,false] :debug enabling debug mode will write the
-#   compiled JavaScript file in the current working directory.
-# @yield tempfile [File] Gives a file to the block, its #path can be used to
-#   construct the command
-# @yieldreturn command [Array<String>] the command to be used in the system call
-SystemRunner = ->(data, &block) {
-  options  = data[:options] || {}
-  builder  = data.fetch(:builder).call
-  output   = data.fetch(:output)
+module Opal
+  VirtualFileObject = Struct.new(:path, keyword_init: true)
 
-  env      = options.fetch(:env, {})
-  debug    = options.fetch(:debug, false) || RUBY_ENGINE == 'opal'
+  # Generic runner that will resort to calling an external program.
+  #
+  # @option :options [Hash,nil] :env a hash of options to be used as env in the
+  #   call to system.
+  # @option :options [true,false] :debug enabling debug mode will write the
+  #   compiled JavaScript file in the current working directory.
+  # @yield tempfile [File] Gives a file to the block, its #path can be used to
+  #   construct the command
+  # @yieldreturn command [Array<String>] the command to be used in the system call
+  SystemRunner = ->(data, &block) do
+    options  = data[:options] || {}
+    builder  = data.fetch(:builder).call
+    output   = data.fetch(:output)
 
-  code = builder.to_s
-  # Temporary issue with UTF-8, Base64 and source maps
-  code += "\n" + builder.source_map.to_data_uri_comment unless RUBY_ENGINE == 'opal'
+    env      = options.fetch(:env, {})
+    debug    = options.fetch(:debug, false) || RUBY_ENGINE == 'opal'
 
-  ext = builder.output_extension
+    ext = builder.output_extension
 
-  tempfile =
-    if debug
-      File.new("opal-nodejs-runner.#{ext}", 'wb')
+    if options[:directory]
+      tempdir = Dir.mktmpdir('opal-system-runner-')
+      builder.compile_to_directory(tempdir, with_source_map: !options[:no_source_map])
+      cmd = block.call(
+        VirtualFileObject.new(path: File.join(tempdir, "index.#{ext}"))
+      )
     else
-      Tempfile.new(['opal-system-runner', ".#{ext}"], mode: File::BINARY)
+      # Temporary issue with UTF-8, Base64, source maps and opalopal
+      code = builder.compiled_source(
+        with_source_map: !(options[:no_source_map] || RUBY_ENGINE == 'opal')
+      )
+
+      tempfile =
+        if debug
+          File.new("opal-system-runner.#{ext}", 'wb')
+        else
+          Tempfile.new(['opal-system-runner', ".#{ext}"], mode: File::BINARY)
+        end
+
+      tempfile.write code
+      cmd = block.call tempfile
     end
 
-  tempfile.write code
-  cmd = block.call tempfile
-  tempfile.close
-
-  if RUBY_PLATFORM == 'opal'
-    # Opal doesn't support neither `out:` nor `IO.try_convert` nor `open3`
-    system(env, *cmd)
-    $?.exitstatus
-  elsif IO.try_convert(output) && RUBY_PLATFORM != 'java'
-    system(env, *cmd, out: output)
-    $?.exitstatus
-  else
-    # JRuby (v9.2) doesn't support using `out:` to redirect output.
-    require 'open3'
-    captured_output, status = Open3.capture2(env, *cmd)
-    output.write captured_output
-    status.exitstatus
+    if RUBY_PLATFORM == 'opal'
+      # Opal doesn't support neither `out:` nor `IO.try_convert` nor `open3`
+      system(env, *cmd)
+      $?.exitstatus
+    elsif IO.try_convert(output) && RUBY_PLATFORM != 'java'
+      system(env, *cmd, out: output)
+      $?.exitstatus
+    else
+      # JRuby (v9.2) doesn't support using `out:` to redirect output.
+      require 'open3'
+      captured_output, status = Open3.capture2(env, *cmd)
+      output.write captured_output
+      status.exitstatus
+    end
+  ensure
+    tempfile.close if tempfile
+    FileUtils.remove_entry(tempdir) if tempdir && !debug
   end
-}
+end

--- a/lib/opal/compiler.rb
+++ b/lib/opal/compiler.rb
@@ -183,6 +183,12 @@ module Opal
     # Enables JavaScript's strict mode (i.e., adds 'use strict'; statement)
     compiler_option :use_strict, default: false, as: :use_strict?, magic_comment: true
 
+    # @!method directory?
+    #
+    # Builds a JavaScript file that is aimed to reside as part of a directory
+    # for an import map build or something similar.
+    compiler_option :directory, default: false, as: :directory?
+
     # @!method parse_comments?
     #
     # Adds comments for every method definition

--- a/lib/opal/config.rb
+++ b/lib/opal/config.rb
@@ -98,6 +98,11 @@ module Opal
     # @return [true, false]
     config_option :esm, false, compiler_option: :esm
 
+    # Build a program as a directory; don't bundle
+    #
+    # @return [true, false]
+    config_option :directory, false, compiler_option: :directory
+
     # Set the error severity for when a require can't be parsed at compile time.
     #
     # @example

--- a/lib/opal/nodes/top.rb
+++ b/lib/opal/nodes/top.rb
@@ -68,14 +68,18 @@ module Opal
       end
 
       def module_name
-        Opal::Compiler.module_name(compiler.file).inspect
+        Opal::Compiler.module_name(compiler.file)
       end
 
       def definition
         if compiler.requirable?
-          unshift "Opal.modules[#{module_name}] = "
-        elsif compiler.esm? && !compiler.no_export?
+          unshift "Opal.modules[#{module_name.inspect}] = "
+        elsif compiler.esm? && !compiler.no_export? && !compiler.directory?
           unshift 'export default '
+        end
+
+        if compiler.directory?
+          imports
         end
       end
 
@@ -100,12 +104,33 @@ module Opal
             # require absolute paths from CLI. For other cases
             # we can expect the module names to be normalized
             # already.
-            line "Opal.load_normalized(#{module_name});"
+            line "Opal.load_normalized(#{module_name.inspect});"
           end
         elsif compiler.eval?
           line "})(Opal, self);"
         else
           line "});\n"
+        end
+      end
+
+      # Generate import/require statements
+      def imports
+        imports = compiler.requires
+
+        unshift "\n" unless imports.empty?
+
+        # Check how many directories we have to go up
+        depth = module_name.delete_prefix('./').count("/")
+
+        imports.reverse_each do |req|
+          ref = depth == 0 ? "./" : ("../" * depth)
+          mod = "#{ref}#{Compiler.module_name(req)}.#{compiler.esm? ? 'mjs' : 'js'}"
+
+          if compiler.esm?
+            unshift "import #{mod.inspect};\n"
+          else
+            unshift "require(#{mod.inspect});\n"
+          end
         end
       end
 

--- a/lib/opal/version.rb
+++ b/lib/opal/version.rb
@@ -4,4 +4,7 @@ module Opal
   # WHEN RELEASING:
   # Remember to update RUBY_ENGINE_VERSION in opal/corelib/constants.rb too!
   VERSION = '2.0.0dev'
+
+  # Only major and minor parts of version
+  VERSION_MAJOR_MINOR = VERSION.split('.').first(2).join('.').freeze
 end

--- a/spec/lib/simple_server_spec.rb
+++ b/spec/lib/simple_server_spec.rb
@@ -6,51 +6,121 @@ RSpec.describe Opal::SimpleServer do
 
   attr_accessor :app
 
-  before do
-    Opal.append_path "#{__dir__}/fixtures"
-    self.app = described_class.new(main: 'console')
+  # Ensure that each `get` call leads to a new rack session.
+  def get(path)
+    rack_test_session(nil).get(path)
   end
 
-  it 'serves opal assets' do
-    response = get '/assets/console.js'
-    expect(response.body).to start_with(Opal::Builder.build('console').to_s)
-  end
+  shared_examples "simple server" do
+    before do
+      Opal.append_path "#{__dir__}/fixtures"
+      self.app = described_class.new(main: 'console')
+    end
 
-  it 'serves index for all non opal paths' do
-    %w[/ /foo /foo/bar/baz].each do |path|
-      response = get path
-      expect(response.body).to include('<html>')
-      expect(response.body).to include('<script')
-      expect(response.body).to include('src="/assets/console.js')
-      expect(response.headers['Content-type']).to eq('text/html')
+    it 'serves opal assets' do
+      response = get "/assets/console.#{ext}#{sub_console}"
+      expect(response.body).to include('self["native"].trace()')
+    end
+
+    it 'serves index for all non opal paths' do
+      %w[/ /foo /foo/bar/baz].each do |path|
+        response = get path
+        expect(response.body).to include('<html>')
+        expect(response.body).to include('<script')
+        expect(response.body).to include("src=\"/assets/console.#{ext}#{index}\"")
+        expect(response.body).to include('type="module"') if esm?
+        expect(response.body).not_to include('type="module"') unless esm?
+        expect(response.headers['Content-type']).to eq('text/html')
+      end
+    end
+
+    it 'serves the source map as data uri' do
+      response = get "/assets/console.#{ext}#{sub_console}"
+      if directory?
+        expect(response.body).to include("\n//# sourceMappingURL=./console.map")
+        source_map = get("/assets/console.mjs/opal/#{Opal::VERSION_MAJOR_MINOR}/console.map").body
+        expect(source_map).to include("../../opal/src")
+        expect(source_map).to include("console.rb")
+      else
+        expect(response.body).to include("\n//# sourceMappingURL=data:application/json;base64,")
+        base64_map = response.body.split("\n//# sourceMappingURL=data:application/json;base64,").last
+        expect(Base64.decode64(base64_map)).to eq(Opal::Builder.build('console').source_map.to_json)
+      end
+    end
+
+    it 'takes a :prefix option to set the assets prefix' do
+      self.app = described_class.new(main: 'opal', prefix: 'foo')
+      expect(get("/foo/console.#{ext}#{sub_console}").body).to include('self["native"].trace()')
+      self.app = described_class.new(main: 'opal', prefix: '/foo')
+      expect(get("/foo/console.#{ext}#{sub_console}").body).to include('self["native"].trace()')
+    end
+
+    it 'takes a :main option to set the main asset' do
+      self.app = described_class.new(main: 'opal_file')
+      expect(get('/').body).to include("src=\"/assets/opal_file.#{ext}")
+    end
+
+    it 'respects config set in Opal::Config' do
+      Opal::Config.arity_check_enabled = false
+      self.app = described_class.new(main: 'console')
+      expect(get("/assets/console.#{ext}#{sub_console}").body).not_to include('$$parameters: []')
+
+      Opal::Config.arity_check_enabled = true
+      self.app = described_class.new(main: 'console')
+      expect(get("/assets/console.#{ext}#{sub_console}").body).to include('$$parameters: []')
+    end
+
+    it 'supports a custom Builder' do
+      builder = Opal::Builder.new
+      builder.build('console')
+      builder.build_str('1312312313', '(test)')
+      self.app = described_class.new(main: 'console', builder: builder)
+      expect(get("/assets/console.#{ext}#{sub_console}").body).to include('self["native"].trace()')
+      expect(get("/assets/console.#{ext}#{sub_test}").body).to include('1312312313')
+    end
+
+    it 'supports a custom Builder given as a proc' do
+      pr = ->() do
+        builder = Opal::Builder.new
+        builder.build('console')
+        builder.build_str('1312312313', '(test)')
+        builder
+      end
+      self.app = described_class.new(main: 'console', builder: pr)
+      expect(get("/assets/console.#{ext}#{sub_console}").body).to include('self["native"].trace()')
+      expect(get("/assets/console.#{ext}#{sub_test}").body).to include('1312312313')
     end
   end
 
-  it 'serves the source map as data uri' do
-    response = get '/assets/console.js'
-    expect(response.body).to include("\n//# sourceMappingURL=data:application/json;base64,")
-    base64_map = response.body.split("\n//# sourceMappingURL=data:application/json;base64,").last
-    expect(Base64.decode64(base64_map)).to eq(Opal::Builder.build('console').source_map.to_json)
+  context "in non-directory, non-ESM mode" do
+    before(:each) do
+      Opal::Config.esm = false
+      Opal::Config.directory = false
+    end
+
+    let(:ext) { "js" }
+    let(:index) { "" }
+    let(:sub_console) { "" }
+    let(:sub_test) { "" }
+    let(:directory?) { false }
+    let(:esm?) { false }
+
+    include_examples "simple server"
   end
 
-  it 'takes a :prefix option to set the assets prefix' do
-    self.app = described_class.new(main: 'opal', prefix: 'foo')
-    expect(get('/foo/console.js').body).to start_with(Opal::Builder.build('console').to_s)
-    self.app = described_class.new(main: 'opal', prefix: '/foo')
-    expect(get('/foo/console.js').body).to start_with(Opal::Builder.build('console').to_s)
-  end
+  context "in directory, ESM mode" do
+    before(:each) do
+      Opal::Config.esm = true
+      Opal::Config.directory = true
+    end
 
-  it 'takes a :main option to set the main asset' do
-    self.app = described_class.new(main: 'foo')
-    expect(get('/').body).to include('src="/assets/foo.js')
-  end
+    let(:ext) { "mjs" }
+    let(:index) { "/index.mjs" }
+    let(:sub_console) { "/opal/#{Opal::VERSION_MAJOR_MINOR}/console.mjs" }
+    let(:sub_test) { "/opal/#{Opal::VERSION_MAJOR_MINOR}/(test).mjs" }
+    let(:directory?) { true }
+    let(:esm?) { true }
 
-  it 'respects config set in Opal::Config' do
-    Opal::Config.arity_check_enabled = false
-    expect(get('/assets/console.js').body).not_to include('$$parameters: []')
-
-    Opal::Config.arity_check_enabled = true
-    self.app = described_class.new(main: 'console')
-    expect(get('/assets/console.js').body).to include('$$parameters: []')
+    include_examples "simple server"
   end
 end


### PR DESCRIPTION
As of now, it only works for the compiler runner and system runner (ie. Node) but nothing prevents us to make it work for other runners in the future as well.

This aims to produce an output that is more easily digestible by modern JS bundlers and that may work better for import maps. This is also a starting point for full ESM support.

This is partially extracted from #2502 (and I intend to split #2502 into some more separate branches, to make it more digestible).