### PR TITLE
Add base64 to gemspec, fixing Warning

### DIFF
--- a/opal.gemspec
+++ b/opal.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3'
 
   spec.add_dependency 'ast', '>= 2.3.0'
+  spec.add_dependency 'base64', '>= 0.2.0'
   spec.add_dependency 'parser', ['~> 3.0', '>= 3.0.3.2']
 
   spec.add_development_dependency 'sourcemap', '~> 0.1.0'


### PR DESCRIPTION
fixing: /usr/local/lib/ruby/gems/3.3.0/bundler/gems/opal-fcb2c903b56f/lib/opal/source_map/map.rb:3: warning: base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec.