### PR TITLE
Remove `String#untaint` from exe/opal-build

### DIFF
--- a/exe/opal-build
+++ b/exe/opal-build
@@ -71,7 +71,7 @@ else
   lib_name = ARGV.first
 
   output = options[:output] ? File.open(options[:output], 'w') : $stdout
-  output.puts Opal::Builder.build(lib_name.dup.untaint)
+  output.puts Opal::Builder.build(lib_name.dup)
 end
 
 


### PR DESCRIPTION
`String#untaint` was deprecated in Ruby 2.x and removed in 3.2