### PR TITLE
Hash optimize internal each usage and improve js interoperability

### DIFF
--- a/opal/corelib/hash.rb
+++ b/opal/corelib/hash.rb
@@ -222,12 +222,12 @@ class ::Hash < `Map`
     %x{
       var hash = new Map();
 
-      return $hash_each(self, hash, function(key, value) {
-        if (value !== nil) {
+      self.forEach((value, key, s) => {
+        if (value !== nil && value != null)
           $hash_put(hash, key, value);
-        }
-        return [false, hash];
       });
+
+      return hash;
     }
   end
 
@@ -238,7 +238,7 @@ class ::Hash < `Map`
       var result = nil;
 
       return $hash_each(self, result, function(key, value) {
-        if (value === nil) {
+        if (value === nil || value == null) {
           $hash_delete(self, key);
           result = self;
         }
@@ -709,14 +709,15 @@ class ::Hash < `Map`
     %x{
       var hash = new Map();
 
-      return $hash_each(self, hash, function(key, value) {
+      self.forEach((value, key, s) => {
         var obj = block(key, value);
 
         if (obj === false || obj === nil) {
           $hash_put(hash, key, value);
         }
-        return [false, hash]
       });
+
+      return hash;
     }
   end
 
@@ -769,14 +770,15 @@ class ::Hash < `Map`
     %x{
       var hash = new Map();
 
-      return $hash_each(self, hash, function(key, value) {
+      self.forEach((value, key, s) => {
         var obj = block(key, value);
 
         if (obj !== false && obj !== nil) {
           $hash_put(hash, key, value);
         }
-        return [false, hash];
       });
+
+      return hash;
     }
   end
 
@@ -868,7 +870,7 @@ class ::Hash < `Map`
     %x{
       var result = new Map();
 
-      return $hash_each(self, result, function(key, value) {
+      self.forEach((value, key, s) => {
         var new_key;
         if (keys_hash !== nil)
           new_key = $hash_get(keys_hash, key);
@@ -877,8 +879,9 @@ class ::Hash < `Map`
         if (new_key === undefined)
           new_key = key // key not modified
         $hash_put(result, new_key, value);
-        return [false, result];
       });
+
+      return result;
     }
   end
 
@@ -913,10 +916,9 @@ class ::Hash < `Map`
     %x{
       var result = new Map();
 
-      return $hash_each(self, result, function(key, value) {
-        $hash_put(result, key, block(value));
-        return [false, result];
-      });
+      self.forEach((value, key, s) => $hash_put(result, key, block(value)));
+
+      return result;
     }
   end
 

--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -2374,10 +2374,8 @@
 
   function $hash_delete_stage2(hash, key) {
     var value = hash.get(key);
-    if (value !== undefined) {
-      hash.delete(key);
-      return value;
-    }
+    hash.delete(key);
+    return value;
   }
 
   Opal.hash_delete = function(hash, key) {

--- a/spec/opal/core/hash_spec.rb
+++ b/spec/opal/core/hash_spec.rb
@@ -7,4 +7,12 @@ describe 'Hash' do
     h.delete(k)
     h.inspect.should == '{}'
   end
+
+  it 'compacts nil and JavaScript null and undefined values' do
+    h = { a: nil, b: `null`, c: `undefined`, d: 1 }
+    expect(h.size).to eq 4
+    expect(h.compact.size).to eq 1
+    h.compact!
+    expect(h.size).to eq 1
+  end
 end


### PR DESCRIPTION
For case, where a new Hash is created from self without modifying self there is no need to use the $hash_each helper, self.forEach is sufficient. This avoids creating a extra Array, which is not needed, and thus should benefit memory usage and performance.

Also for #compact and #compact!:
If #compact(!) is called on a Map passed from JS with `null` values, i would expect #compact(!) to remove those too.
So this PR adds a `null` check.