### PR TITLE
Let opal build standalone applications via the --compile-to-exe option

### DIFF
--- a/examples/exe/create_apps.sh
+++ b/examples/exe/create_apps.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# Comment those below, which are not installed or available for your platform,
+# then execute this script to create some very simple apps.
+
+# with bun installed:
+bundle exec opal --compile-to-exe bun -o simple_bun ./simple.rb
+
+# with deno installed:
+bundle exec opal --compile-to-exe deno -o simple_deno ./simple.rb
+
+# with node installed:
+bundle exec opal --compile-to-exe node -o simple_node ./simple.rb
+
+# on macOS only:
+bundle exec opal --compile-to-exe osascript -o simple_osa ./simple.rb
+# execute the macOS app from the terminal as:
+# ./simple_osa.app/Contents/MacOS/applet
+
+# with quickjs installed:
+bundle exec opal --compile-to-exe quickjs -o simple_quickjs ./simple.rb
+
+# it also works with eval:
+bundle exec opal --compile-to-exe quickjs -o eval_app_quickjs -e 'puts "Hello from Opal in QuickJS!"'

--- a/examples/exe/simple.rb
+++ b/examples/exe/simple.rb
@@ -1,0 +1,1 @@
+puts "It works! Very cool app!"

--- a/lib/opal/cli.rb
+++ b/lib/opal/cli.rb
@@ -3,6 +3,7 @@
 require 'opal/requires'
 require 'opal/builder'
 require 'opal/cli_runners'
+require 'opal/exe_compiler'
 require 'stringio'
 
 module Opal
@@ -47,6 +48,7 @@ module Opal
       @rbrequires  = options.delete(:rbrequires) { [] }
       @no_cache    = options.delete(:no_cache)   { false }
       @stdin       = options.delete(:stdin)      { $stdin }
+      @exe_type    = options.delete(:exe_type)
 
       @debug_source_map = options.delete(:debug_source_map) { false }
 
@@ -104,6 +106,12 @@ module Opal
         argv: argv,
         builder: builder,
       )
+
+      if @exe_type && exit_status == 0
+        @exit_status = Opal::ExeCompiler.compile_exe(@exe_type, output)
+      end
+
+      @exit_status
     end
 
     def runner

--- a/lib/opal/cli_options.rb
+++ b/lib/opal/cli_options.rb
@@ -2,6 +2,7 @@
 
 require 'optparse'
 require 'opal/cli_runners'
+require 'opal/exe_compiler'
 
 module Opal
   class CLIOptions < OptionParser
@@ -15,6 +16,12 @@ module Opal
 
       on('--repl', 'Run the Opal REPL') do
         options[:repl] = true
+      end
+
+      on('--compile-to-exe RUNTIME', Opal::ExeCompiler::RUNTIMES, "Compiles and builds a standalone application with RUNTIME. The following RUNTIMEs are available: #{Opal::ExeCompiler::RUNTIMES.join(', ')}") do |type|
+        options[:exe_type] = type
+        options[:runner] = :compiler
+        options[:output] = "opal_#{type}_exe" unless options[:output]
       end
 
       on('-v', '--verbose', 'print version number, then turn on verbose mode') do
@@ -152,7 +159,7 @@ module Opal
         options[:use_strict] = true
       end
 
-      on('--esm', 'Wraps compiled bundle as for ES6 module') do
+      on('--esm', 'Wraps compiled bundle as ES6 module') do
         options[:esm] = true
       end
 

--- a/lib/opal/exe_compiler.rb
+++ b/lib/opal/exe_compiler.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'tmpdir'
+require 'opal/os'
+
+module Opal
+  class ExeCompiler
+    RUNTIMES = -> {
+      types = %w[bun deno node quickjs]
+      types << 'osascript' if OS.macos?
+      types.freeze
+    }.call
+
+    def self.compile_exe(type, src_out)
+      new(type, src_out).compile_exe
+    end
+
+    def initialize(type, src_out)
+      raise "Cannot compile exe: unsupported runtime type '#{type}'" unless RUNTIMES.include?(type)
+      if src_out.instance_of?(IO)
+        @out_path = "opal_#{type}_exe"
+      elsif src_out.is_a?(File)
+        @out_path = src_out.path
+      else
+        raise 'Cannot compile exe: source must be a file.'
+      end
+      @type, @source = type, src_out
+    end
+
+    def compile_exe
+      puts "Creating #{@out_path}:"
+      res = true
+      Dir.mktmpdir('opal-compile-exe-') do |dir|
+        src_path = File.join(dir, "#{File.basename(@out_path)}.js")
+        @source.flush
+        @source.fsync
+        @source.close
+        File.write(src_path, File.read(@source.path))
+        File.unlink(@source.path)
+        res = send("compile_#{@type}_exe".to_sym, src_path, dir)
+      end
+      puts 'Done.'
+      res ? 0 : 1
+    end
+
+    private
+
+    def append_exe_to_out_path_on_windows
+      if OS.windows? && !@out_path.downcase.end_with?('.exe')
+        @out_path << '.exe'
+      end
+    end
+
+    def compile_bun_exe(src_path, _dir)
+      system('bun', 'build', src_path, '--compile', '--outfile', @out_path)
+    end
+
+    def compile_deno_exe(src_path, _dir)
+      system('deno', 'compile',
+             '--allow-env',
+             '--allow-read',
+             '--allow-sys',
+             '--allow-write',
+             '--output', @out_path, src_path
+            )
+    end
+
+    def compile_node_exe(src_path, dir)
+      # Very new, experimental and complicated.
+      # See https://nodejs.org/api/single-executable-applications.html
+      Dir.chdir(dir) do
+        # 1. Create a JavaScript file - already done above
+        # 2. Create a configureation file
+        File.write('sea-config.json', "{\"main\":\"#{src_path}\",\"output\":\"sea-prep.blob\"}")
+        # 3. Generate the blob to be injected:
+        system('node', '--experimental-sea-config', 'sea-config.json')
+        # 4. Create a copy of the node executable
+        # What could possibly go wrong?
+        system('node', '-e', 'require("node:fs").copyFileSync(process.execPath, "node_copy.exe")')
+        # 4.1. Adjust file permissions
+        File.chmod(0o775, 'node_copy.exe')
+        # 5. Remove the signature of the binary
+        if OS.macos?
+          system('codesign --remove-signature node_copy.exe')
+        elsif OS.windows?
+          system('signtool remove /s node_copy.exe')
+        end
+        # 6. Inject the blob into the copied binary
+        if OS.macos?
+          system('npx', 'postject', 'node_copy.exe', 'NODE_SEA_BLOB', 'sea-prep.blob',
+                 '--sentinel-fuse', 'NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2',
+                 '--macho-segment-name', 'NODE_SEA' # Thats not a 'macho', thats Mach-O, the Mach Object File Format
+                )
+        else
+          system('npx', 'postject', 'node_copy.exe', 'NODE_SEA_BLOB', 'sea-prep.blob',
+                 '--sentinel-fuse', 'NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2'
+                )
+        end
+        # 7. Sign the binary
+        if OS.macos?
+          system('codesign --sign - node_copy.exe')
+        elsif OS.windows?
+          system('signtool sign /fd SHA256 node_copy.exe')
+        end
+      end
+      # 8. Copy binary to target
+      append_exe_to_out_path_on_windows
+      FileUtils.cp(File.join(dir, 'node_copy.exe'), @out_path)
+      true
+    end
+
+    def compile_osascript_exe(src_path, _dir)
+      @out_path << '.app' unless @out_path.end_with?('.app')
+      system('osacompile', '-l', 'JavaScript', '-o', @out_path, '-s', src_path)
+    end
+
+    def compile_quickjs_exe(src_path, _dir)
+      append_exe_to_out_path_on_windows
+      # '-flto', '-fbignum' might be useful options, depending on quickjs version/build
+      system('qjsc', '-o', @out_path, src_path)
+    end
+  end
+end


### PR DESCRIPTION
Ill expand on the example and docs after my platform work.
Also apps of type osa currently crash most probably, because osascript requires some platform work. Well, depends on what you do. The simple example should work.