### PR TITLE
Enable async Opal startup and REPL, use correct REPL runner

### DIFF
--- a/lib/opal/cli.rb
+++ b/lib/opal/cli.rb
@@ -114,7 +114,7 @@ module Opal
     def run_repl
       require 'opal/repl'
 
-      repl = REPL.new
+      repl = REPL.new(@runner_type)
       repl.run(argv)
     end
 
@@ -197,6 +197,7 @@ module Opal
         parse_comments
         esm
         directory
+        await
       ]
     end
 

--- a/lib/opal/cli_options.rb
+++ b/lib/opal/cli_options.rb
@@ -196,6 +196,10 @@ module Opal
         options[:irb] = true
       end
 
+      on('--await', 'Enable async/await support') do
+        options[:await] = true
+      end
+
       on('-M', '--no-method-missing', 'Disable method missing') do
         options[:method_missing] = false
       end

--- a/lib/opal/nodes/top.rb
+++ b/lib/opal/nodes/top.rb
@@ -88,7 +88,7 @@ module Opal
 
         if compiler.requirable?
           unshift "#{async_prefix}function(Opal) {"
-        elsif compiler.eval?
+        elsif compiler.eval? || compiler.irb?
           unshift "(#{async_prefix}function(Opal, self) {"
         else
           unshift "Opal.queue(#{async_prefix}function(Opal) {"
@@ -104,9 +104,9 @@ module Opal
             # require absolute paths from CLI. For other cases
             # we can expect the module names to be normalized
             # already.
-            line "Opal.load_normalized(#{module_name.inspect});"
+            line "Opal.queue(()=>{ Opal.load_normalized(#{module_name.inspect}) });"
           end
-        elsif compiler.eval?
+        elsif compiler.eval? || compiler.irb?
           line "})(Opal, self);"
         else
           line "});\n"

--- a/lib/opal/repl.rb
+++ b/lib/opal/repl.rb
@@ -12,9 +12,10 @@ module Opal
 
     attr_accessor :colorize
 
-    def initialize
+    def initialize(runner_type = nil)
       @argv = []
       @colorize = true
+      @runner_type = runner_type || :nodejs
 
       begin
         require 'readline'
@@ -44,6 +45,7 @@ module Opal
 
     def load_opal
       runner = @argv.reject { |i| i == '--repl' }
+      runner += ['-R', @runner_type.to_s, '--await']
       runner += ['-e', 'require "opal/repl_js"']
       runner = [RbConfig.ruby, "#{__dir__}/../../exe/opal"] + runner
 
@@ -94,7 +96,7 @@ module Opal
 
       begin
         silencer.silence do
-          builder.build_str(eval_code, '(irb)', irb: true, const_missing: true)
+          builder.build_str(eval_code, '(irb)', irb: true, const_missing: true, await: true)
         end
         @incomplete = nil
       rescue Opal::SyntaxError => e

--- a/stdlib/opal-parser.rb
+++ b/stdlib/opal-parser.rb
@@ -57,6 +57,8 @@ end
   };
 
   Opal['eval'] = function(str, options) {
+    if (!options) { options = new Map(); }
+    options.set('eval', true);
     return eval(Opal.compile(str, options));
   };
 

--- a/stdlib/opal-replutils.rb
+++ b/stdlib/opal-replutils.rb
@@ -1,5 +1,7 @@
 # backtick_javascript: true
+# await: true
 
+require 'await'
 require 'pp'
 require 'stringio'
 
@@ -95,6 +97,7 @@ module REPLUtils
         }
       }
     }
+    nil.__await__ # bogus call to make this method async
   rescue Exception => e # rubocop:disable Lint/RescueException
     e.full_message(highlight: true)
   end
@@ -103,7 +106,7 @@ module REPLUtils
     while (line = gets)
       input = JSON.parse(line)
 
-      out = eval_and_print(input[:code], input[:mode], input[:colors])
+      out = eval_and_print(input[:code], input[:mode], input[:colors]).__await__
       puts out if out
       puts '<<<ready>>>'
     end


### PR DESCRIPTION
Taken from my platform work.
Use case: Conditional dynamic import() of platform specific modules directly after runtime.js and before corelib ruby parts.
Lets see what specs say ...
