### PR TITLE
Actions: Specify runner engine versions, least supported and latest, run on Edge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     env:
       DEFAULT_RUBY: '3.3'
     strategy:
-      max-parallel: 6
+      max-parallel: 8
       fail-fast: false
       matrix:
         combo:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,10 +98,8 @@ jobs:
             ruby: '3.0'
           - name: jruby
             ruby: jruby
-          # truffleruby: disabled, does not finish on github actions
-          # probably not enough memory
-          # - name: truffleruby
-          #   ruby: 'truffleruby'
+          - name: truffleruby
+            ruby: 'truffleruby'
           - name: windows
             command: bundle exec rake rspec
             os: windows-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,27 +17,74 @@ jobs:
     env:
       DEFAULT_RUBY: '3.3'
     strategy:
+      max-parallel: 6
       fail-fast: false
       matrix:
         combo:
-          - name: mspec-nodejs
+          - name: lint
+            command: bin/rake lint
+          - name: smoke-test-nodejs-18
+            node: lts/hydrogen
+            command: bin/rake smoke_test
+          - name: smoke-test
+            node: latest
+            command: bin/rake smoke_test
+          - name: mspec-nodejs-18
+            node: lts/hydrogen
             command: bin/rake mspec_nodejs
-          - name: mspec-chrome
+          - name: mspec-nodejs
+            node: latest
+            command: bin/rake mspec_nodejs
+          - name: mspec-nodejs-windows
+            node: latest
+            command: bundle exec rake mspec_nodejs
+            os: windows-latest
+          - name: mspec-chrome-115
+            chrome: '115'
             command: bin/rake mspec_chrome
-          - name: mspec-firefox
-            firefox: '106.0.4'
+          - name: mspec-chrome
+            chrome: stable
+            command: bin/rake mspec_chrome
+          - name: mspec-chrome-windows
+            chrome: stable
+            command: bundle exec rake mspec_chrome
+            os: windows-latest
+          - name: mspec-edge
+            edge: stable
+            command: bundle exec rake mspec_chrome
+            os: windows-latest
+          - name: mspec-firefox-115
+            firefox: '115.16.1esr'
             command: xvfb-run bin/rake mspec_firefox
+          - name: mspec-firefox
+            firefox: latest
+            command: xvfb-run bin/rake mspec_firefox
+          - name: mspec-safari
+            command: bundle exec rake mspec_safari
+            os: macos-latest
           - name: mspec-bun
-            bun: true
+            bun: '1.1.30'
             command: bin/rake mspec_bun
           - name: mspec-deno
-            deno: true
+            deno: 'vx.x.x'
             command: bin/rake mspec_deno
+          - name: mspec-osascript
+            command: bundle exec rake mspec_osascript
+            os: macos-latest
           - name: minitest
+            chrome: '115'
+            node: lts/hydrogen
             command: bin/rake minitest
           - name: minitest-strict-mode
+            chrome: stable
+            node: latest
             command: bin/rake minitest
             strict: 'true'
+          - name: minitest-windows
+            chrome: stable
+            node: lts/hydrogen
+            command: bundle exec rake minitest
+            os: windows-latest
           # - name: head-ruby
           #   ruby: head
           #   permissive: true
@@ -50,41 +97,22 @@ jobs:
           - name: near-eol-ruby
             ruby: '3.0'
           - name: jruby
-            ruby: 'jruby'
+            ruby: jruby
           # truffleruby: disabled, does not finish on github actions
           # probably not enough memory
           # - name: truffleruby
           #   ruby: 'truffleruby'
-          - name: smoke-test
-            command: bin/rake smoke_test
-          - name: windows-mspec-nodejs
-            command: bundle exec rake mspec_nodejs
-            os: windows-latest
-          - name: windows-mspec-chrome
-            command: bundle exec rake mspec_chrome
-            os: windows-latest
-          # - name: windows-mspec-firefox
-          #   firefox: '106.0.4'
-          #   command: bundle exec rake mspec_firefox
-          #   os: windows-latest
-          - name: macos-mspec-safari
-            command: bundle exec rake mspec_safari
-            os: 'macos-latest'
-          - name: windows-minitest
-            command: bundle exec rake minitest
-            os: windows-latest
           - name: windows
             command: bundle exec rake rspec
             os: windows-latest
           - name: macos
             command: bundle exec rake rspec
-            os: 'macos-latest'
-          - name: lint
-            command: bin/rake lint
+            os: macos-latest
           - name: timezone
             command: bin/rake mspec_nodejs TZ="Pacific/Fiji"
           - name: performance
-            bun: true
+            bun: '1.1.30'
+            node: latest
             permissive: true
             fetchdepth: '0'
             command: bin/rake performance:compare
@@ -96,14 +124,31 @@ jobs:
       - if: ${{ matrix.combo.bun }}
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.1.30
+          bun-version: ${{ matrix.combo.bun }}
       - if: ${{ matrix.combo.deno }}
         uses: denoland/setup-deno@v2
+        with:
+          deno-version: ${{ matrix.combo.deno }}
+      - if: ${{ matrix.combo.chrome }}
+        id: setup-chrome
+        uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: ${{ matrix.combo.chrome }}
+      - if: ${{ matrix.combo.edge }}
+        id: setup-edge
+        uses: browser-actions/setup-edge@v1
+        with:
+          edge-version: ${{ matrix.combo.edge }}
       - if: ${{ matrix.combo.firefox }}
         id: setup-firefox
-        uses: browser-actions/setup-firefox@latest
+        uses: browser-actions/setup-firefox@v1
         with:
           firefox-version: ${{ matrix.combo.firefox }}
+      - if: ${{ matrix.combo.node}}
+        id: setup-node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.combo.node }}
       - uses: actions/checkout@v4
         with:
           fetch-depth: ${{ fromJSON(matrix.combo.fetchdepth || '1') }}
@@ -142,6 +187,16 @@ jobs:
         if: ${{ matrix.combo.strict == 'true' }}
         run: |
           echo "USE_STRICT=true" >> $GITHUB_ENV
+      - name: set environment variables GOOGLE_CHROME_BINARY
+        if: ${{ matrix.combo.chrome }}
+        run: |
+          echo "GOOGLE_CHROME_BINARY=${{ steps.setup-chrome.outputs.chrome-path }}" >> $GITHUB_ENV
+      # steps.setup-edge.outputs.edge-path is not set when the specified version of Edge is already installed
+      # thats why the msedge.exe path is hardcoded below
+      - name: set environment variables GOOGLE_CHROME_BINARY
+        if: ${{ matrix.combo.edge }}
+        run: |
+          echo "GOOGLE_CHROME_BINARY='C:/Program Files (x86)/Microsoft/Edge/Application/msedge.exe'" >> $GITHUB_ENV
       - name: set environment variables MOZILLA_FIREFOX_BINARY
         if: ${{ matrix.combo.firefox }}
         run: |

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,6 +32,7 @@ end
 
 # To make MSpec happy
 require 'thread'
+require 'corelib/math'
 
 require 'mspec/utils/script' # Needed by DottedFormatter
 require 'mspec-opal/formatters'


### PR DESCRIPTION
JavaScript engines move fast, deprecating, removing or adding features. To ensure Opal works, we need to run tests on older engine versions and latest ones. This PR allows to specify exact versions for the engines and enables actions for:

Older engines:
- nodejs 18 (lts/hydrogen), supported until 2025
- Firefox 115 esr, supported until 2025
- Chrome 115, not supported

Newer engines:
- nodejs latest, currently 23.0
- Firefox latest, currently 131
- Chrome stable, currently 131
- Edge stable, currently 129
- Safari, depending on macos-latest provided by github actions
- OSAScript, depending on macos-latest provided by github actions (actually this engine is only partially newer)
- bun, currently fixed to 1.1.30, due to problems with latest 1.1.31
- deno latest stable, currently 2.0.2