### PR TITLE
[WIP] Implement mutable ::String

### DIFF
--- a/opal/corelib/runtime.js
+++ b/opal/corelib/runtime.js
@@ -218,7 +218,7 @@
     if (method === 'to_int' && type === Opal.Integer && object.$$is_number)
       return object < 0 ? Math.ceil(object) : Math.floor(object);
 
-    if (method === 'to_str' && type === Opal.String && object.$$is_string)
+    if (method === 'to_str' && type.$$is_string_class && object.$$is_string)
       return object;
 
     if (Opal.is_a(object, type)) return object;
@@ -1429,7 +1429,9 @@
     //           - null
     //
     $prop(native_klass, '$$bridge', klass);
-    $set_proto(native_klass.prototype, (klass.$$super || Opal.Object).$$prototype);
+    if (!native_klass.prototype?.$$bridge_do_not_touch) {
+      $set_proto(native_klass.prototype, (klass.$$super || Opal.Object).$$prototype);
+    }
     $prop(klass, '$$prototype', native_klass.prototype);
 
     $prop(klass.$$prototype, '$$class', klass);
@@ -1763,6 +1765,11 @@
     if (object.$$is_number && klass.$$is_number_class) {
       return (klass.$$is_integer_class) ? (object % 1) === 0 : true;
     }
+
+    if (object.$$is_string && klass.$$is_string_class) return true;
+
+    if (klass === String) klass = Opal.String;
+    if (object === String) object = Opal.String;
 
     var ancestors = $ancestors(object.$$is_class ? Opal.get_singleton_class(object) : (object.$$meta || object.$$class));
 

--- a/opal/corelib/string/encoding.rb
+++ b/opal/corelib/string/encoding.rb
@@ -578,3 +578,5 @@ end
 
 `Opal.prop(String.prototype, 'encoding', #{::Encoding::UTF_8})`
 `Opal.prop(String.prototype, 'internal_encoding', #{::Encoding::UTF_8})`
+`Opal.prop(Opal.global.MutableString.prototype, 'encoding', #{::Encoding::UTF_8})`
+`Opal.prop(Opal.global.MutableString.prototype, 'internal_encoding', #{::Encoding::UTF_8})`

--- a/opal/corelib/unsupported.rb
+++ b/opal/corelib/unsupported.rb
@@ -5,7 +5,7 @@ class ::String
   `var ERROR = "String#%s not supported. Mutable String methods are not supported in Opal."`
 
   %i[
-    << capitalize! chomp! chop! downcase! gsub! lstrip! next! reverse!
+    capitalize! chomp! chop! downcase! gsub! lstrip! next! reverse!
     slice! squeeze! strip! sub! succ! swapcase! tr! tr_s! upcase! prepend
     []= clear encode! unicode_normalize!
   ].each do |method_name|

--- a/spec/filters/bugs/freeze.rb
+++ b/spec/filters/bugs/freeze.rb
@@ -29,10 +29,6 @@ opal_unsupported_filter "freezing" do
   fails "Regexp#initialize raises a FrozenError on a Regexp literal" # Expected FrozenError but no exception was raised (nil was returned)
   fails "String#-@ deduplicates frozen strings" # Expected "this string is frozen" not to be identical to "this string is frozen"
   fails "String#-@ returns a frozen copy if the String is not frozen" # Expected "foo".frozen? to be truthy but was false
-  fails "String#<< raises a FrozenError when self is frozen" # Expected FrozenError but got: NotImplementedError (String#<< not supported. Mutable String methods are not supported in Opal.)
-  fails "String#<< with Integer raises a FrozenError when self is frozen" # Expected FrozenError but got: NotImplementedError (String#<< not supported. Mutable String methods are not supported in Opal.)
-  fails "String#concat raises a FrozenError when self is frozen" # Expected FrozenError but got: NoMethodError (undefined method `concat' for "hello")
-  fails "String#concat with Integer raises a FrozenError when self is frozen" # Expected FrozenError but got: NoMethodError (undefined method `concat' for "hello")
   fails "String#initialize with an argument raises a FrozenError on a frozen instance that is modified" # Expected FrozenError but no exception was raised (nil was returned)
   fails "String#initialize with an argument raises a FrozenError on a frozen instance when self-replacing" # Expected FrozenError but no exception was raised (nil was returned)
   fails "String#next! raises a FrozenError if self is frozen" # Expected FrozenError but got: NotImplementedError (String#next! not supported. Mutable String methods are not supported in Opal.)

--- a/test.rb
+++ b/test.rb
@@ -1,0 +1,12 @@
+require 'opal'
+puts 'ready'
+
+t = String.new('bla')
+puts t
+puts t.size
+puts `t.length`
+
+t << 'haha'
+puts t
+puts t.size
+puts `t.length`


### PR DESCRIPTION
This demonstrates the concept. All is documented at the end of corelib/string.rb.

It implements at the moment String#<< and String#concat .

This has further implications though, to make it work for real. For example:
JS Strings are always considered frozen, even when boxed, so they are immutable.
::String.new strings are mutable  (until frozen).

Some compiler changes will be required to choose the correct one. Compiling to a literal/primitive will result in a frozen String, but that's not always wanted. In other cases it should compile to Opal.String.$new() or so.
Ruby 3.4 is also making some changes concerning frozen Strings.

@hmdne + @elia please check, see if this concept is ok for you. If you are ok with this concept i would then continue on that path.