### PR TITLE
nodes/if: Require Thread shim

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -157,6 +157,10 @@ Lint/RedundantStringCoercion:
     # That's what MRI does
     - 'opal/corelib/error.rb'
 
+Lint/RedundantRequireStatement:
+  Exclude:
+    - 'lib/opal/nodes/if.rb'
+
 Lint/UnusedBlockArgument:
   Exclude:
     # Variable from Ruby can be accessed in JS, rubocop can't catch it (but JSHint can)

--- a/lib/opal/nodes/if.rb
+++ b/lib/opal/nodes/if.rb
@@ -2,6 +2,7 @@
 
 require 'opal/nodes/base'
 require 'opal/ast/matcher'
+require 'thread' if RUBY_ENGINE == 'opal'
 
 module Opal
   module Nodes


### PR DESCRIPTION
After introducing a threadsafe fix, opalopal users got a regression. Let's require `thread` for those users from now on.