### PR TITLE
corelib/unsupported: add Module#deprecate_constant

### DIFF
--- a/opal/corelib/unsupported.rb
+++ b/opal/corelib/unsupported.rb
@@ -37,6 +37,10 @@ class ::Module
   def private_constant(*)
   end
 
+  def deprecate_constant(*)
+    self
+  end
+
   alias nesting public
   alias private public
   alias protected public


### PR DESCRIPTION
This is so that certain software will not fail when this method is not present.