### PR TITLE
Fix lint issues

### DIFF
--- a/lib/opal/nodes/scope.rb
+++ b/lib/opal/nodes/scope.rb
@@ -101,9 +101,11 @@ module Opal
         iter? && @is_lambda
       end
 
-      def is_lambda! # rubocop:disable Naming/PredicateName
+      # rubocop:disable Naming/PredicatePrefix
+      def is_lambda!
         @is_lambda = true
       end
+      # rubocop:enable Naming/PredicatePrefix
 
       def defines_lambda
         @lambda_definition = true

--- a/opal/runtime/class.rb
+++ b/opal/runtime/class.rb
@@ -344,7 +344,7 @@ module ::Opal
     }
   end
 
-  # rubocop:disable Naming/PredicateName
+  # rubocop:disable Naming/PredicatePrefix
   def self.is_a(object, klass)
     %x{
       if (klass != null && object.$$meta === klass || object.$$class === klass) {
@@ -360,7 +360,7 @@ module ::Opal
       return ancestors.indexOf(klass) !== -1;
     }
   end
-  # rubocop:enable Naming/PredicateName
+  # rubocop:enable Naming/PredicatePrefix
 end
 
 ::Opal

--- a/opal/runtime/method.rb
+++ b/opal/runtime/method.rb
@@ -306,11 +306,11 @@ module ::Opal
   # Method iteration
   # ----------------
 
-  # rubocop:disable Naming/PredicateName
+  # rubocop:disable Naming/PredicatePrefix
   def self.is_method(prop)
     `prop[0] === '$' && prop[1] !== '$'`
   end
-  # rubocop:enable Naming/PredicateName
+  # rubocop:enable Naming/PredicatePrefix
 
   def self.instance_methods(mod)
     %x{


### PR DESCRIPTION
## Summary
- resolve Rubocop predicate lint errors by disabling `Naming/PredicatePrefix`

## Testing
- `bundle exec rubocop`
- `bundle exec rake` *(fails: Opal::Util::ExitStatusError)*

------
https://chatgpt.com/codex/tasks/task_e_68440f53eafc832ab40173c930682a0d