### PR TITLE
Add Ruby 3.4 tests and update specs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,14 +41,16 @@ jobs:
           # - name: head-ruby
           #   ruby: head
           #   permissive: true
-          - name: current-ruby
-            ruby: '3.3'
-          - name: previous-ruby
-            ruby: '3.2'
-          - name: older-ruby
-            ruby: '3.1'
-          - name: near-eol-ruby
+          - name: ruby-3.0
             ruby: '3.0'
+          - name: ruby-3.1
+            ruby: '3.1'
+          - name: ruby-3.2
+            ruby: '3.2'
+          - name: ruby-3.3
+            ruby: '3.3'
+          - name: ruby-3.4
+            ruby: '3.4'
           - name: jruby
             ruby: 'jruby'
           # truffleruby: disabled, does not finish on github actions

--- a/spec/lib/compiler_spec.rb
+++ b/spec/lib/compiler_spec.rb
@@ -650,9 +650,9 @@ RSpec.describe Opal::Compiler do
         end
 
         expect(error.backtrace[0]).to eq("#{File.basename(__FILE__)}/foobar.js.rb:in `BEGIN {}'")
-        expect(compiler_backtrace(error)[0]).to end_with(":in `error'")
-        expect(compiler_backtrace(error)[-3]).to end_with(":in `block in compile'")
-        expect(compiler_backtrace(error)[-1]).to end_with(":in `compile'")
+        expect(compiler_backtrace(error)[0]).to match(/:in [`'](?:Opal::Compiler#)?error[`']$/)
+        expect(compiler_backtrace(error)[-3]).to match(/:in [`']block in (?:Opal::Compiler#)?compile[`']$/)
+        expect(compiler_backtrace(error)[-1]).to match(/:in [`'](?:Opal::Compiler#)?compile[`']$/)
         expect(error.backtrace.size).to be > 1
       end
     end
@@ -667,7 +667,7 @@ RSpec.describe Opal::Compiler do
           error = syntax_error
         end
         expect(error.backtrace[0]).to eq("#{File.basename(__FILE__)}/foobar.js.rb:1:in `def foo'")
-        expect(compiler_backtrace(error)[0]).to end_with(":in `block in parse'")
+        expect(compiler_backtrace(error)[0]).to match(/:in [`']block in (?:Opal::Compiler#)?parse[`']$/)
         expect(error.backtrace.size).to be > 1
 
         expect($diagnostic_messages.flatten).to eq([


### PR DESCRIPTION
## Summary
- test against Ruby 3.4 in CI
- loosen backtrace matching for Ruby 3.4
- rename Ruby matrix entries to ruby-3.0..ruby-3.4 and sort

## Testing
- `bundle exec rspec spec/lib/compiler_spec.rb:644 spec/lib/compiler_spec.rb:661 --format doc --out /tmp/rspec.txt`


------
https://chatgpt.com/codex/tasks/task_e_684419b0c32c832ab6c19e911f4eb782