### PR TITLE
Fix Enumerable#first return value

### DIFF
--- a/opal/corelib/enumerable.rb
+++ b/opal/corelib/enumerable.rb
@@ -501,6 +501,7 @@ module ::Enumerable
       each do |value|
         return value
       end
+      nil
     else
       result = []
       number = `$coerce_to(number, #{::Integer}, 'to_int')`


### PR DESCRIPTION
## Summary
- ensure Enumerable#first returns `nil` for empty collections, matching MRI

------
https://chatgpt.com/codex/tasks/task_e_684539660058832a8f232b0f783ece8e