### PR TITLE
Improve AGENTS instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,8 @@
 # AGENTS Instructions
 
-This file explains how automation and human contributors should operate in this
-repository.  Follow the steps below to get a working development environment,
-run the test suites and keep the repository in a healthy state.
+This file explains how automation and human contributors should work in this
+repository. Follow the steps below to set up the project, run tests and keep the
+codebase healthy.
 
 
 ## Setup
@@ -13,7 +13,7 @@ run the test suites and keep the repository in a healthy state.
 - `opal/` provides the runtime and Ruby core library. Its layout is:
   - `corelib/` contains Ruby's built-ins implemented in Ruby.
   - `runtime/` holds JS helpers required at execution time.
-  - `opal/` offers entry points like `base.rb`, `mini.rb`, and `full.rb` for
+  - `opal/` offers entry points like `base.rb`, `mini.rb` and `full.rb` for
     loading subsets of the runtime.
 - `stdlib/` contains Opal's standard library implementation.
 - `spec/` and `test/` host RSpec and Minitest suites.
@@ -41,5 +41,10 @@ run the test suites and keep the repository in a healthy state.
 - If an agent discovers information that required significant setup time, condense
   the result into a short bullet in this file so later agents can skip the same
   work.
+- Write commit messages in the `subsystem: summary` form so changes are easy to
+  track.
+- New features or bugfixes should come with tests. For compiler or builder
+  changes add RSpec specs; for runtime or stdlib consult the ruby/spec suite
+  first and add new specs under `spec/opal` if needed.
 - See `HACKING.md` and `CONTRIBUTING.md` for more detailed guides on
   collaborating on Opal.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,20 @@
 # AGENTS Instructions
 
+This file explains how automation and human contributors should operate in this
+repository.  Follow the steps below to get a working development environment,
+run the test suites and keep the repository in a healthy state.
+
+
 ## Setup
 - Run `bin/setup` once after cloning to install gems, yarn packages and git submodules.
+
+## Directory overview
+- `lib/` & `opal/` hold the compiler and runtime sources.
+- `stdlib/` contains Opal's standard library implementation.
+- `spec/` and `test/` host RSpec and Minitest suites.
+- `examples/` shows sample applications.
+- `docs/` provides documentation for contributors and users.
+- `tasks/` defines Rake tasks used by `bin/rake`.
 
 ## Running tests
 - Running `bin/rake` executes every suite on both Chrome and Node.js but is slow and requires a browser.
@@ -20,3 +33,8 @@
 ## Notes
 - The list of MSpec files is in `spec/ruby_specs` and filters live in `spec/filters`.
 - Tests depend on initialized submodules (`spec/mspec`, `spec/ruby`, `test/cruby`).
+- If an agent discovers information that required significant setup time, condense
+  the result into a short bullet in this file so later agents can skip the same
+  work.
+- See `HACKING.md` and `CONTRIBUTING.md` for more detailed guides on
+  collaborating on Opal.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,12 @@ run the test suites and keep the repository in a healthy state.
 - Run `bin/setup` once after cloning to install gems, yarn packages and git submodules.
 
 ## Directory overview
-- `lib/` & `opal/` hold the compiler and runtime sources.
+- `lib/` holds the compiler and CLI implementations.
+- `opal/` provides the runtime and Ruby core library. Its layout is:
+  - `corelib/` contains Ruby's built-ins implemented in Ruby.
+  - `runtime/` holds JS helpers required at execution time.
+  - `opal/` offers entry points like `base.rb`, `mini.rb`, and `full.rb` for
+    loading subsets of the runtime.
 - `stdlib/` contains Opal's standard library implementation.
 - `spec/` and `test/` host RSpec and Minitest suites.
 - `examples/` shows sample applications.


### PR DESCRIPTION
## Summary
- clarify the purpose of the AGENTS instructions file
- give an overview of project directories
- include instructions to store expensive discovery in AGENTS.md
- point contributors to further documentation

## Testing
- `bin/rake rspec`
- `bin/rake lint`


------
https://chatgpt.com/codex/tasks/task_e_68552a0f0210832aaaaf271586f38253