### PR TITLE
AGENTS.md: Add note about submodules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,3 +48,6 @@ codebase healthy.
   first and add new specs under `spec/opal` if needed.
 - See `HACKING.md` and `CONTRIBUTING.md` for more detailed guides on
   collaborating on Opal.
+- Do not commit changes to external submodules such as `spec/ruby` or
+  `spec/mspec`. Instead add new files under `spec/opal` so they remain within
+  the `opal` namespace.


### PR DESCRIPTION
## Summary
- mention that specs should not modify external submodule paths

## Testing
- `bin/rake lint`
- `bin/rake mspec_opal_nodejs`

------
https://chatgpt.com/codex/tasks/task_e_685aed86dc58832abbfd1328a10b1fcb