### PR TITLE
ci: update rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,8 @@ inherit_from:
   - .rubocop_todo.yml
   - .rubocop/todo.yml
 
-require: rubocop-performance
+plugins:
+  - rubocop-performance
 
 AllCops:
   TargetRubyVersion: 3.0
@@ -215,7 +216,7 @@ Naming/BinaryOperatorParameterName:
     - 'opal/**/*.rb'
     - 'stdlib/**/*.rb'
 
-Naming/PredicateName:
+Naming/PredicatePrefix:
   # Ruby has "has_key?" method
   ForbiddenPrefixes:
     - is_
@@ -391,6 +392,8 @@ Security/Eval:
   Exclude:
     # That's what parser does
     - 'stdlib/opal-parser.rb'
+    # Binding#eval necessarily uses eval
+    - 'opal/corelib/binding.rb'
 
 Naming/AccessorMethodName:
   Exclude:


### PR DESCRIPTION
## Summary
- modernize RuboCop configuration to use rubocop-performance plugin
- rename deprecated Naming/PredicateName cop and exclude Binding#eval from Security/Eval

## Testing
- `bin/rake lint`
- `bin/rake rspec`
- `bin/rake mspec_nodejs`
- `bin/rake minitest_nodejs`


------
https://chatgpt.com/codex/tasks/task_e_68b172ea92bc832a88ffaa632bade1a8