### PR TITLE
builder: add postprocessor subsystem

### DIFF
--- a/lib/opal/builder.rb
+++ b/lib/opal/builder.rb
@@ -7,6 +7,7 @@ require 'opal/cache'
 require 'opal/builder/scheduler'
 require 'opal/project'
 require 'opal/builder/directory'
+require 'opal/builder/post_processor'
 require 'set'
 
 module Opal
@@ -127,11 +128,11 @@ module Opal
     end
 
     def to_s
-      processed.map(&:to_s).join("\n")
+      postprocessed.map(&:to_s).join("\n")
     end
 
     def source_map
-      ::Opal::SourceMap::Index.new(processed.map(&:source_map), join: "\n")
+      ::Opal::SourceMap::Index.new(postprocessed.map(&:source_map), join: "\n")
     end
 
     def append_paths(*paths)
@@ -174,6 +175,10 @@ module Opal
     include Builder::Directory
 
     attr_reader :processed
+
+    def postprocessed
+      @postprocessed ||= PostProcessor.call(processed, self)
+    end
 
     attr_accessor :processors, :path_reader, :stubs,
       :compiler_options, :missing_require_severity, :cache, :scheduler

--- a/lib/opal/builder/directory.rb
+++ b/lib/opal/builder/directory.rb
@@ -21,7 +21,7 @@ module Opal
         catch(:file) do
           index = []
 
-          processed.each do |file|
+          postprocessed.each do |file|
             module_name = Compiler.module_name(file.filename)
             last_segment_name = File.basename(module_name)
             depth = module_name.split('/').length - 1

--- a/lib/opal/builder/post_processor.rb
+++ b/lib/opal/builder/post_processor.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module Opal
+  class Builder
+    class PostProcessor
+      @postprocessors = []
+      def self.register(klass)
+        @postprocessors << klass
+      end
+
+      def self.call(processed, builder)
+        @postprocessors.each do |postprocessor|
+          processed = postprocessor.new(processed, builder).call
+        end
+
+        processed
+      end
+
+      def self.postprocessing_enabled?(builder)
+        @postprocessors.any? do |postprocessor|
+          postprocessor.enabled?(builder)
+        end
+      end
+
+      # For spec use
+      def self.with_postprocessors(postprocessors)
+        prev_postprocessors = @postprocessors
+        @postprocessors = Array(postprocessors)
+        result = yield
+        @postprocessors = prev_postprocessors
+        result
+      end
+
+      # If any postprocessor is enabled, we need to cache fragments
+      # and source.
+      def self.enabled?(_builder)
+        true
+      end
+
+      def initialize(processed, builder)
+        @processed = processed
+        @builder = builder
+      end
+
+      attr_reader :processed, :builder
+
+      # descendants override
+
+      def call
+        processed
+      end
+
+      class Directive
+        attr_accessor :name, :params
+
+        def initialize(name, **params)
+          @name = name
+          @params = params
+        end
+
+        # Unhandled post-processor directive
+        def code
+          ''
+        end
+      end
+
+      module NodeSupport
+        def post_processor_directive(name, **kwargs)
+          Directive.new(name, **kwargs)
+        end
+      end
+    end
+  end
+end

--- a/lib/opal/fragment.rb
+++ b/lib/opal/fragment.rb
@@ -13,6 +13,8 @@ module Opal
     # @return [String]
     attr_reader :code
 
+    attr_reader :scope, :sexp
+
     # Create fragment with javascript code and optional original [Opal::Sexp].
     #
     # @param code [String] javascript code

--- a/lib/opal/nodes/base.rb
+++ b/lib/opal/nodes/base.rb
@@ -2,12 +2,14 @@
 
 require 'opal/nodes/helpers'
 require 'opal/nodes/closure'
+require 'opal/builder/post_processor'
 
 module Opal
   module Nodes
     class Base
       include Helpers
       include Closure::NodeSupport
+      include Builder::PostProcessor::NodeSupport
 
       def self.handlers
         @handlers ||= {}

--- a/spec/lib/builder/post_processor_spec.rb
+++ b/spec/lib/builder/post_processor_spec.rb
@@ -1,0 +1,71 @@
+require 'lib/spec_helper'
+require 'opal/os'
+require 'opal/builder'
+require 'opal/builder/scheduler/sequential'
+require 'opal/builder/scheduler/threaded'
+require 'opal/fragment'
+require 'tmpdir'
+
+RSpec.describe Opal::Builder::PostProcessor do
+  subject(:builder) { Opal::Builder.new(options) }
+  let(:options) { {compiler_options: {cache_fragments: true}} }
+  let(:postprocessors) {
+    body = postprocessor_body
+    Class.new(described_class) { define_method(:call, &body) }
+  }
+
+  around(:example) do |example|
+    described_class.with_postprocessors(postprocessors, &example)
+  end
+
+  context "with a capturing postprocessor" do
+    scratchpad = nil
+    let(:postprocessor_body) {-> {
+      scratchpad << [processed, builder]
+      processed
+    }}
+
+    it "has an access to both processed and builder" do
+      scratchpad = []
+      builder.build_str("require 'opal'", "(sample)").to_s
+      scratchpad.length.should be 1
+      first = scratchpad.first
+      first[0].should be_a Array
+      first[1].should be builder
+      first[0].each { |i| i.should be_a Opal::Builder::Processor }
+    end
+  end
+
+  context "with a replacing postprocessor" do
+    let(:postprocessor_body) {-> {
+      [
+        Opal::Builder::Processor::JsProcessor.new("Replaced!", "replaced.js")
+      ]
+    }}
+
+    it "replaces everything in all result and source map" do
+      b = builder.build_str("require 'opal'", "(sample)")
+      b.to_s.should start_with "Replaced!"
+      b.source_map.to_s.should include "Replaced!"
+    end
+  end
+
+  context "with a fragment replacing postprocessor" do
+    let(:postprocessor_body) {-> {
+      processed.each do |file|
+        if file.respond_to? :compiled
+          compiler = file.compiled
+          compiler.fragments = compiler.fragments.map do |frag|
+            Opal::Fragment.new("Badger", frag.scope, frag.sexp)
+          end
+        end
+      end
+    }}
+
+    it "replaces fragments correctly" do
+      b = builder.build_str("require 'opal'", "(sample)")
+      b.to_s.should include "Badger" * 1000
+      # TODO: Test the source map integrity?
+    end
+  end
+end

--- a/spec/lib/compiler_spec.rb
+++ b/spec/lib/compiler_spec.rb
@@ -651,7 +651,7 @@ RSpec.describe Opal::Compiler do
 
         expect(error.backtrace[0]).to eq("#{File.basename(__FILE__)}/foobar.js.rb:in `BEGIN {}'")
         expect(compiler_backtrace(error)[0]).to match(/:in [`'](?:Opal::Compiler#)?error[`']$/)
-        expect(compiler_backtrace(error)[-3]).to match(/:in [`']block in (?:Opal::Compiler#)?compile[`']$/)
+        expect(compiler_backtrace(error)[-4]).to match(/:in [`']block in (?:Opal::Compiler#)?fragments[`']$/)
         expect(compiler_backtrace(error)[-1]).to match(/:in [`'](?:Opal::Compiler#)?compile[`']$/)
         expect(error.backtrace.size).to be > 1
       end


### PR DESCRIPTION
## Summary
- add `Builder::PostProcessor` and wire builder output through postprocessors
- expose fragment caching in the compiler to support postprocessing
- test postprocessor capture, replacement, and fragment rewriting

## Testing
- `bin/rake rspec`
- `bin/rake mspec_nodejs`
- `bin/rake minitest_nodejs`
- `bin/rake lint`


------
https://chatgpt.com/codex/tasks/task_e_68c3ce6f53f4832aa2f15fd6faf76fee