### PR TITLE
compiler: class/module nodes rework; tracepoint :end support

### DIFF
--- a/lib/opal/nodes/module.rb
+++ b/lib/opal/nodes/module.rb
@@ -18,17 +18,12 @@ module Opal
         end
 
         name, base = name_and_base
-        helper :module
+        helper :module_def
 
         if body.nil?
-          # Simplified compile for empty body
-          if stmt?
-            unshift '$module(', base, ", '#{name}')"
-          else
-            unshift '($module(', base, ", '#{name}'), nil)"
-          end
+          # Empty body: runtime $module_def without a callback returns nil
+          unshift '$module_def(', base, ", '#{name}')"
         else
-          line "  var self = $module($base, '#{name}');"
           in_scope do
             scope.name = name
             in_closure(Closure::MODULE | Closure::JS_FUNCTION) do
@@ -41,12 +36,11 @@ module Opal
             await_end = ')'
             async = 'async '
             parent.await_encountered = true
-          else
-            await_begin, await_end, async = '', '', ''
           end
 
-          unshift "#{await_begin}(#{async}function($base#{', $parent_nesting' if @define_nesting}) {"
-          line '})(', base, "#{', ' + scope.nesting if @define_nesting})#{await_end}"
+          # Emit a direct runtime call with an inline body function.
+          unshift "#{await_begin}$module_def(", base, ", '#{name}', #{async}function(self#{', $nesting' if @define_nesting}) {"
+          line "}#{", #{scope.nesting}" if @define_nesting})#{await_end}"
         end
       end
 
@@ -67,7 +61,8 @@ module Opal
         body_code = stmt(compiler.returns(body))
         empty_line
 
-        add_temp "$nesting = [self].concat($parent_nesting)" if @define_nesting
+        # $nesting is now provided as a parameter to the body callback by
+        # $klass_def/$module_def. Just setup relative access when needed.
         add_temp '$$ = Opal.$r($nesting)' if @define_relative_access
 
         line scope.to_vars

--- a/lib/opal/nodes/module.rb
+++ b/lib/opal/nodes/module.rb
@@ -50,11 +50,18 @@ module Opal
       def name_and_base
         base, name = cid.children
 
-        if base.nil?
-          [name, "#{scope.nesting}[0]"]
-        else
-          [name, expr(base)]
-        end
+        base = if base.nil?
+                 case scope
+                 when ModuleNode, ClassNode
+                   scope.self
+                 else
+                   "#{scope.nesting}[0]"
+                 end
+               else
+                 expr(base)
+               end
+
+        [name, base]
       end
 
       def compile_body

--- a/opal/corelib/trace_point.rb
+++ b/opal/corelib/trace_point.rb
@@ -2,7 +2,7 @@
 
 class ::TracePoint
   # partial implementation of TracePoint
-  # for the moment only supports the :class event
+  # supports :class and :end events
   def self.trace(event, &block)
     new(event, &block).enable
   end
@@ -10,7 +10,9 @@ class ::TracePoint
   attr_reader :event
 
   def initialize(event, &block)
-    ::Kernel.raise 'Only the :class event is supported' unless event == :class
+    unless event == :class || event == :end
+      ::Kernel.raise 'Only the :class and :end events are supported'
+    end
     @event = event
     @block = block
     @trace_object = nil
@@ -55,5 +57,13 @@ class ::TracePoint
 
   def self
     @trace_object
+  end
+
+  # Current path during callback
+  def path
+    # Use the Ruby-level caller to determine the current file path (first non-runtime frame)
+    loc = ::Kernel.caller(2, 1)
+    return nil unless loc
+    loc.split(':in `').first
   end
 end

--- a/opal/runtime/class.rb
+++ b/opal/runtime/class.rb
@@ -205,6 +205,30 @@ module ::Opal
     }
   end
 
+  # Class definition helper used by the compiler
+  #
+  # Defines or fetches a class (like `Opal.klass`) and, if a body callback is
+  # provided, evaluates the class body via that callback passing `self` and the
+  # updated `$nesting` array. The return value of the callback becomes the
+  # value of the class expression; when no callback is given the expression
+  # evaluates to `nil` (to match Ruby semantics for `class X; end`).
+  def self.klass_def(scope, superclass, name, body, parent_nesting)
+    %x{
+      var klass = Opal.klass(scope, superclass, name);
+
+      if (body != null) {
+        if (body.length == 1) {
+          return body(klass);
+        }
+        else {
+          return body(klass, [klass].concat(parent_nesting));
+        }
+      }
+
+      return nil;
+    }
+  end
+
   # Helper to set $$meta on klass, module or instance
   %x{
     function set_meta(obj, meta) {

--- a/opal/runtime/module.rb
+++ b/opal/runtime/module.rb
@@ -25,6 +25,30 @@ module ::Opal
     }
   end
 
+  # Module definition helper used by the compiler
+  #
+  # Defines or fetches a module (like `Opal.module`) and, if a body callback is
+  # provided, evaluates the module body via that callback passing `self` and the
+  # updated `$nesting` array. The return value of the callback becomes the
+  # value of the module expression; when no callback is given the expression
+  # evaluates to `nil`.
+  def self.module_def(scope, name, body, parent_nesting)
+    %x{
+      var module = Opal.module(scope, name);
+
+      if (body != null) {
+        if (body.length == 1) {
+          return body(module);
+        }
+        else {
+          return body(module, [module].concat(parent_nesting));
+        }
+      }
+
+      return nil;
+    }
+  end
+
   %x{
     function find_existing_module(scope, name) {
       var module = $const_get_name(scope, name);

--- a/tasks/testing.rake
+++ b/tasks/testing.rake
@@ -401,6 +401,7 @@ node_platforms.each do |platform|
       nodejs/test_opal_builder.rb
       nodejs/test_string.rb
       nodejs/test_await.rb
+      nodejs/test_tracepoint_end.rb
       nodejs/test_yaml.rb
     ]
 

--- a/test/nodejs/test_tracepoint_end.rb
+++ b/test/nodejs/test_tracepoint_end.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+# await: *await
+
+require "test/unit"
+require "corelib/trace_point"
+
+class TestTracePointEnd < Test::Unit::TestCase
+  HEADER = <<~RUBY
+    # await: true
+    require "await"
+  RUBY
+
+  def eval_and_await(code)
+    eval(code).__await__
+  end
+
+  def test_end_after_class_body_sync
+    code = <<~RUBY
+      #{HEADER}
+      $trace = []
+      tp = TracePoint.new(:end) { |tp| $trace << :end }
+      tp.enable
+      class TPESync
+        $trace << :in_body_before
+        $trace << :in_body_after
+      end
+      $trace << :after_class
+      tp.disable
+      $trace
+    RUBY
+
+    trace = eval_and_await(code)
+
+    assert_equal [:in_body_before, :in_body_after, :end, :after_class], trace
+  end
+
+  def test_end_after_class_body_async
+    code = <<~RUBY
+      #{HEADER}
+      $trace = []
+      tp = TracePoint.new(:end) { |tp| $trace << :end }
+      tp.enable
+      class TPEAsync
+        $trace << :in_body_before
+        sleep(0.001).__await__
+        $trace << :in_body_after
+      end
+      $trace << :after_class
+      tp.disable
+      $trace
+    RUBY
+
+    trace = eval_and_await(code)
+
+    assert_equal [:in_body_before, :in_body_after, :end, :after_class], trace
+  end
+
+  def test_end_after_module_body_sync
+    code = <<~RUBY
+      #{HEADER}
+      $trace = []
+      tp = TracePoint.new(:end) { |tp| $trace << :end }
+      tp.enable
+      module TPESyncMod
+        $trace << :in_body_before
+        $trace << :in_body_after
+      end
+      $trace << :after_module
+      tp.disable
+      $trace
+    RUBY
+
+    trace = eval_and_await(code)
+    assert_equal [:in_body_before, :in_body_after, :end, :after_module], trace
+  end
+
+  def test_end_after_module_body_async
+    code = <<~RUBY
+      #{HEADER}
+      $trace = []
+      tp = TracePoint.new(:end) { |tp| $trace << :end }
+      tp.enable
+      module TPEAsyncMod
+        $trace << :in_body_before
+        sleep(0.001).__await__
+        $trace << :in_body_after
+      end
+      $trace << :after_module
+      tp.disable
+      $trace
+    RUBY
+
+    trace = eval_and_await(code)
+    assert_equal [:in_body_before, :in_body_after, :end, :after_module], trace
+  end
+end
+


### PR DESCRIPTION
This PR wraps the class/module definition in a new $class_def/$module_def helpers. This allowed us to save a couple of lines of generated code and allowed us to introduce TracePoint :end support. Those events should fire when a class/module definition reaches its `end`, similarly to :class, which fires events when class/module definition begins.

This PR is sponsored by Ribose Inc.