### PR TITLE
ci: update default Ruby to 3.4 and add Ruby 4.0 testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
   rake:
     name: ${{ matrix.combo.name || matrix.combo.ruby }}
     env:
-      DEFAULT_RUBY: '3.3'
+      DEFAULT_RUBY: '3.4'
     strategy:
       fail-fast: false
       matrix:
@@ -51,6 +51,8 @@ jobs:
             ruby: '3.3'
           - name: ruby-3.4
             ruby: '3.4'
+          - name: ruby-4.0
+            ruby: '4.0'
           - name: jruby
             ruby: 'jruby'
           # truffleruby: disabled, does not finish on github actions


### PR DESCRIPTION
Updates the CI workflow to use Ruby 3.4 as the default version and adds Ruby 4.0 to the test matrix.