### PR TITLE
corelib/error: fix JS::Error deprecation to return Opal::Raw::Error

### DIFF
--- a/opal/corelib/error.rb
+++ b/opal/corelib/error.rb
@@ -348,7 +348,7 @@ module ::JS
       warn '[Opal] JS::Error class has been renamed to Opal::Raw::Error and will change semantics in Opal 2.1. ' \
            'To ensure forward compatibility, please update your rescue clauses.'
 
-      ::JS::Raw::Error
+      ::Opal::Raw::Error
     else
       super
     end


### PR DESCRIPTION
JS::Raw::Error was referenced but never defined; the class exists as Opal::Raw::Error. Update the const_missing handler to return the correct constant.