### PR TITLE
test: add ostruct for Ruby 4

### DIFF
--- a/opal.gemspec
+++ b/opal.gemspec
@@ -49,6 +49,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.50'
   spec.add_development_dependency 'rubocop-performance', '~> 1.1'
   spec.add_development_dependency 'rack', '~> 2.2'
+  spec.add_development_dependency 'ostruct'
   spec.add_development_dependency 'webrick'
   spec.add_development_dependency 'benchmark_driver', '0.15.17' # version taken from test/cruby/common.mk
 end


### PR DESCRIPTION
This fixes testing on Ruby 4.0.