### PR TITLE
builder: fix JRuby 10.1 rspec

### DIFF
--- a/lib/opal/builder/scheduler/threaded.rb
+++ b/lib/opal/builder/scheduler/threaded.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'etc'
+
 module Opal
   class Builder
     class Scheduler

--- a/lib/opal/config.rb
+++ b/lib/opal/config.rb
@@ -56,6 +56,8 @@ module Opal
       compiler_options = {}
       config_options.each do |name, options|
         compiler_option_name = options.fetch(:compiler)
+        next unless compiler_option_name
+
         compiler_options[compiler_option_name] = config.fetch(name)
       end
       compiler_options


### PR DESCRIPTION
This is really weird... Somehow during an upgrade of JRuby from 10.0 to 10.1 the CI stopped working, with JRuby actually messing up our compiler cache (replacing the output with a source map).

As of now, I know it's related to 3 components: `{ nil => Set[] )` being added to our compiler options (or any other key, but with a Set value) hash and marshaling.

The fix has been found by my agent (removing this useless nil key from compiler options hash), but it is unable yet to produce a minimal reproduction.

For now, this PR fixes JRuby CI.