### PR TITLE
stdlib: add Opal::JS interface

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,10 @@ Everything you need to know to install Opal and create your first application.
 
 Discover how to access JavaScript environment from Ruby code.
 
+#### [Opal::JS](opal_js.html)
+
+Use the modern `Opal::JS` interface to access JavaScript from Ruby and expose Ruby objects to JavaScript.
+
 #### [Async](async.html)
 
 Learn more about JavaScript `async`/`await` support in Opal and how you can use it to avoid explicit callbacks and promises.
@@ -129,4 +133,3 @@ This guide provides steps to be followed when you upgrade your applications to a
 #### [Releasing Instructions](releasing.html)
 
 (WIP) A step-by-step guide on who to release a new version of Opal.
-

--- a/docs/opal_js.md
+++ b/docs/opal_js.md
@@ -1,0 +1,252 @@
+# Opal::JS
+
+`Opal::JS` is the usual way for Ruby code compiled by Opal to work with the
+JavaScript world. Use it when you need to read browser or Node globals, call JS
+methods, pass callbacks, or wrap a JS class with a Ruby API.
+
+```ruby
+require 'opal/js'
+```
+
+Requiring `opal/js` defines `$js`, a wrapped JavaScript global object.
+
+## Ruby To JavaScript
+
+Use `$js` to read properties, assign properties, and call JavaScript methods.
+
+```ruby
+$js.document.title = 'Hello from Opal'
+
+element = $js.document.query_selector('#app')
+element[:textContent] = 'Loaded'
+```
+
+Dynamic Ruby method names try the exact JavaScript property first, then a
+camelCase translation. This means both forms can work:
+
+```ruby
+$js.document.querySelector('#app')
+$js.document.query_selector('#app')
+```
+
+Use bracket access for exact JavaScript property names. Bracket access never
+translates names.
+
+```ruby
+$js[:document][:body]
+$js.document[:querySelector].call('#app')
+```
+
+If bracket access returns a JavaScript function, the wrapper keeps the original
+receiver so `this` is preserved when calling it.
+
+## Conversion Rules
+
+Values passed from Ruby to JavaScript are made JavaScript-friendly:
+
+- `nil` becomes JavaScript `undefined`.
+- `Array` becomes a JavaScript array.
+- `Hash` becomes a plain JavaScript object.
+- `Proc` becomes a stable JavaScript function.
+- `Opal::JS` wrappers unwrap to their JavaScript value.
+
+Hash keys are not camelized during normal Ruby-to-JavaScript conversion.
+Unsupported keys raise `Opal::JS::ConversionError`. Use string, symbol, or
+numeric keys for plain JavaScript object conversion.
+
+JavaScript objects coming back to Ruby stay live by default. Call `to_h` or
+`to_a` only when you want a snapshot.
+
+```ruby
+config = Opal::JS.wrap(`{name: 'opal', nested: {ok: true}}`)
+config[:nested][:ok] # => true
+config.to_h         # => { 'name' => 'opal', 'nested' => { 'ok' => true } }
+```
+
+Snapshot conversion raises `Opal::JS::ConversionError` for cyclic object graphs.
+
+## Callbacks
+
+Ruby blocks and procs can be passed to JavaScript callbacks.
+
+```ruby
+callback = proc do
+  $js.console.log('later')
+end
+
+$js.set_timeout(callback, 100)
+```
+
+During a synchronous JavaScript callback, `Opal::JS.this` exposes the JavaScript
+receiver.
+
+```ruby
+$js.button.add_event_listener('click') do
+  Opal::JS.this[:disabled] = true
+end
+```
+
+The same Ruby callable maps to the same JavaScript function, so listener removal
+can use the same proc object.
+
+## Wrapper Classes
+
+Use `Opal::JS::Wrapper` to give a JavaScript class a Ruby API.
+
+```ruby
+class Document
+  include Opal::JS::Wrapper
+
+  js_object
+  js_register_wrapper $js.Document
+
+  js_method :query, 'querySelector'
+end
+
+$js.document.query_selector('#app') # dynamic access works directly
+
+doc = Document.wrap($js.document)
+doc.query('#app')                   # typed wrapper access
+```
+
+`.wrap` takes an existing JavaScript value, allocates the Ruby wrapper, and
+passes that value to `initialize_wrapped`. Override `initialize_wrapped` when a
+wrapper needs to initialize Ruby state for an existing JS object.
+
+You often do not need to call `.wrap` yourself. JavaScript values are
+automatically wrapped whenever they cross into Ruby through `Opal::JS` and a
+matching `js_register_wrapper` or `js_constructor` registration exists. Use
+`.wrap` when you explicitly want to project an existing value, such as
+`document`, an event target, or a value returned from another JS API, into a
+specific wrapper class. Use `.new` only when the wrapper has a `js_constructor`
+and should construct a new JavaScript object.
+
+`js_object` installs the dynamic object behavior: exact `[]`/`[]=`, `dig`,
+`to_h`, Ruby-style method dispatch, and setter support. It is recommended for
+most object wrappers so the wrapper still behaves like `$js.document` when you
+have not defined a more specific Ruby method.
+
+Use `js_array` for array-like JS values. It includes the object behavior plus
+`Enumerable`, `length`, `to_a`, `push`, `pop`, `shift`, and `unshift`.
+
+Use `js_constructor` when `.new` should construct a JavaScript object.
+
+```ruby
+class URL
+  include Opal::JS::Wrapper
+
+  js_object
+  js_constructor $js.URL
+end
+
+url = URL.new('https://opalrb.com')
+```
+
+`js_method` can reshape Ruby arguments for JavaScript APIs. The example below
+lets Ruby callers write `window.set_timeout(100) { ... }` while JS receives the
+callback first, as `setTimeout(callback, delay)` expects.
+
+```ruby
+module Timers
+  include Opal::JS::Wrapper
+
+  js_method :set_timeout, 'setTimeout', args: [:&, :*]
+end
+
+class Window
+  include Timers
+  include Opal::JS::Wrapper
+
+  js_object
+  js_register_wrapper $js.Window
+end
+
+window = Window.wrap($js)
+window.set_timeout(100) { $js.console.log('later') }
+```
+
+Without an `args:` option, `js_method` passes positional arguments first, then
+keyword options if present, then a block if present. Use `args:` only when the
+JavaScript API expects a different shape:
+
+```ruby
+js_method :append_child, 'appendChild'
+js_method :request_animation_frame, 'requestAnimationFrame', args: [:&]
+js_method :listen, 'addEventListener', args: [0, :&, :*]
+```
+
+Useful projection tokens are:
+
+- `:*` remaining positional arguments.
+- `:**` keyword/options object.
+- `:&` block.
+- integers such as `0`, `1`, or `-1` for specific positional arguments.
+
+Keyword keys are converted only when requested with `kwargs: :convert`.
+
+## JavaScript To Ruby: `Opal.$`
+
+`Opal.$` exposes Ruby constants and objects to JavaScript through a proxy facade.
+
+```javascript
+const Converter = Opal.$.MarkdownConverter;
+const converter = new Converter({format: 'html'});
+
+converter.inputText = 'text';       // Ruby: converter.input_text = 'text'
+converter.renderMarkdown();         // Ruby: converter.render_markdown
+converter.exportTo('clipboard');    // Ruby: converter.export_to('clipboard')
+```
+
+Unlike Ruby-to-JavaScript Hash conversion, `Opal.$` prepares the final plain JS
+object argument for Ruby keyword extraction. Use Ruby keyword names in that
+object unless the called Ruby API documents another shape.
+
+Property reads are callable on the JavaScript side. This is surprising but
+intentional: JavaScript `Proxy` cannot tell whether `obj.prop` is meant as a
+method call or as a value read. Use `converter.outputHtml()` to call the Ruby
+getter `output_html`, and `converter.outputHtml = value` to call `output_html=`.
+
+```javascript
+converter.outputHtml();              // Ruby: converter.output_html
+converter.outputHtml = '<p>ok</p>';  // Ruby: converter.output_html = '<p>ok</p>'
+```
+
+Uppercase names look up Ruby constants first:
+
+```javascript
+Opal.$.Asciidoctor.Converters.HTML
+```
+
+Use escape helpers when you need exact Ruby access independent of JavaScript
+property syntax:
+
+```javascript
+obj.__send__('empty?');
+obj.__const__('NestedName');
+```
+
+For exact method names that are valid JavaScript property keys, bracket member
+access can also call the method:
+
+```javascript
+obj['empty?']();
+```
+
+Use `__send_raw__` when you need explicit positional args, kwargs, and block
+shaping without the default final-function-as-block heuristic.
+
+```javascript
+obj.__send_raw__(
+  'method_name',
+  [arg1, arg2],
+  {kwarg: 123},
+  function () { return 'block'; }
+);
+
+obj.__send_raw__('method_name', function () { return 'block'; });
+obj.__send_raw__('method_name', {kwarg: 123});
+```
+
+`Object.keys`, `in`, and property descriptors expose JavaScript-facing names.
+For example, Ruby `my_property` appears as `myProperty`. Exact Ruby names remain
+available through `__send__`.

--- a/spec/opal/stdlib/opal_js_export_spec.rb
+++ b/spec/opal/stdlib/opal_js_export_spec.rb
@@ -1,0 +1,192 @@
+# frozen_string_literal: true
+
+# backtick_javascript: true
+
+# rubocop:disable Lint/Void,Performance/RedundantBlockCall,Style/TrivialAccessors,Lint/UselessAssignment
+
+require 'spec_helper'
+require 'opal/js'
+
+class OpalJSSpecExport
+  OPAL_JS_SPEC_CONST = 123
+
+  attr_accessor :my_property
+
+  def initialize(value = nil, options = nil, &block)
+    @value = value
+    @options = options
+    @block_value = block.call if block
+  end
+
+  def value
+    @value
+  end
+
+  def options
+    @options
+  end
+
+  def block_value
+    @block_value
+  end
+
+  def convert(text)
+    "converted #{text}"
+  end
+
+  def self.call(value)
+    "called #{value}"
+  end
+
+  def self.promise
+    PromiseV2.resolve({ abc: 123 })
+  end
+
+  def self.invoke(callable, value)
+    callable.call(value)
+  end
+
+  def self.invoke_with_default(callable)
+    callable.call('final member')
+  end
+
+  def self.same_object?(left, right)
+    left.equal?(right)
+  end
+
+  def self.raw_shape(*args, **kwargs, &block)
+    [args, kwargs, block&.call]
+  end
+
+  def self.empty?
+    true
+  end
+end
+
+class OpalJSSpecKwargsExport
+  def kwargs_value(**kwargs)
+    kwargs
+  end
+
+  def receive(value)
+    value
+  end
+end
+
+describe 'Opal.$' do
+  it 'exports Ruby constants, constructs classes, dispatches methods, and assigns setters' do
+    `Opal.global.__opal_export_spec = new Opal.$.OpalJSSpecExport(7, {argOne: 3}, function() { return 'block'; })`
+
+    `Opal.global.__opal_export_spec.value()`.should == 7
+    `Opal.global.__opal_export_spec.options().arg_one`.should == 3
+    `Opal.global.__opal_export_spec.blockValue()`.should == 'block'
+    `Opal.global.__opal_export_spec.convert('text')`.should == 'converted text'
+
+    `Opal.global.__opal_export_spec.myProperty = true`
+    `Opal.global.__opal_export_spec.myProperty()`.should == true
+
+    `delete Opal.global.__opal_export_spec`
+  end
+
+  it 'hides then on non-Promise facades' do
+    `Opal.$.OpalJSSpecExport.then === undefined`.should == true
+    `('then' in Opal.$.OpalJSSpecExport)`.should == false
+    `Object.keys(Opal.$.OpalJSSpecExport).indexOf('then')`.should == -1
+  end
+
+  it 'allows direct class facade call to fall back to Ruby call when supported' do
+    `Opal.$.OpalJSSpecExport('value')`.should == 'called value'
+  end
+
+  it 'passes final plain object arguments as keyword hashes' do
+    `Opal.global.__opal_export_spec = new Opal.$.OpalJSSpecKwargsExport()`
+    `Opal.global.__opal_export_spec.kwargsValue({argOne: 3}).arg_one`.should == 3
+    `delete Opal.global.__opal_export_spec`
+  end
+
+  it 'raises ConversionError for cyclic JS argument conversion' do
+    `Opal.global.__opal_export_spec = new Opal.$.OpalJSSpecKwargsExport()`
+    `Opal.global.__opal_export_cycle_object = {}; Opal.global.__opal_export_cycle_object.self = Opal.global.__opal_export_cycle_object`
+    `Opal.global.__opal_export_cycle_array = []; Opal.global.__opal_export_cycle_array[0] = Opal.global.__opal_export_cycle_array`
+
+    -> { `Opal.global.__opal_export_spec.receive(Opal.global.__opal_export_cycle_object)` }.should raise_error(Opal::JS::ConversionError)
+    -> { `Opal.global.__opal_export_spec.receive(Opal.global.__opal_export_cycle_array)` }.should raise_error(Opal::JS::ConversionError)
+
+    `delete Opal.global.__opal_export_cycle_object`
+    `delete Opal.global.__opal_export_cycle_array`
+    `delete Opal.global.__opal_export_spec`
+  end
+
+  it 'returns PromiseV2 values as JS promises resolving to JS-friendly values' do
+    `Opal.global.__opal_export_promise = Opal.$.OpalJSSpecExport.promise()`
+
+    `Opal.global.__opal_export_promise instanceof Promise`.should == true
+    `typeof Opal.global.__opal_export_promise.then`.should == 'function'
+
+    `delete Opal.global.__opal_export_promise`
+  end
+
+  it 'supports __send__ as the exact method escape' do
+    `Opal.$.OpalJSSpecExport.__send__('call', 'raw')`.should == 'called raw'
+  end
+
+  it 'supports __send_raw__ with explicit args, kwargs, and block' do
+    result = `Opal.$.OpalJSSpecExport.__send_raw__('raw_shape', [1, function() { return 'arg'; }], {kwarg: 123, kwargs3: 233}, function() { return 'block'; })`
+
+    `result[0][0]`.should == 1
+    `result[0][1].call()`.should == 'arg'
+    `result[1].kwarg`.should == 123
+    `result[1].kwargs3`.should == 233
+    `result[2]`.should == 'block'
+  end
+
+  it 'keeps JS function identity when converting explicit positional args to Ruby' do
+    `Opal.global.__opal_export_fn = function() { return 'same'; }`
+
+    `Opal.$.OpalJSSpecExport.__send_raw__('same_object?', [Opal.global.__opal_export_fn, Opal.global.__opal_export_fn])`.should == true
+
+    `delete Opal.global.__opal_export_fn`
+  end
+
+  it 'supports __send_raw__ with only an explicit block' do
+    result = `Opal.$.OpalJSSpecExport.__send_raw__('raw_shape', function() { return 'block'; })`
+
+    `result[0].length`.should == 0
+    `Object.keys(result[1]).length`.should == 0
+    `result[2]`.should == 'block'
+  end
+
+  it 'supports __send_raw__ with kwargs and no positional args' do
+    result = `Opal.$.OpalJSSpecExport.__send_raw__('raw_shape', {argOne: 1})`
+
+    `result[0].length`.should == 0
+    `result[1].arg_one`.should == 1
+    `result[2] === null || result[2] === undefined`.should == true
+  end
+
+  it 'converts exported member facades back to Ruby callable objects' do
+    `Opal.$.OpalJSSpecExport.invoke(Opal.$.OpalJSSpecExport.call, 'member')`.should == 'called member'
+    `Opal.$.OpalJSSpecExport.invokeWithDefault(Opal.$.OpalJSSpecExport.call)`.should == 'called final member'
+  end
+
+  it 'supports instanceof through Symbol.hasInstance' do
+    `Opal.global.__opal_export_spec = new Opal.$.OpalJSSpecExport()`
+    `Opal.global.__opal_export_spec instanceof Opal.$.OpalJSSpecExport`.should == true
+    `delete Opal.global.__opal_export_spec`
+  end
+
+  it 'enumerates JS-facing method names and constants without hiding punctuation methods' do
+    `Object.keys(Opal.$.OpalJSSpecExport).indexOf('call') >= 0`.should == true
+    `Object.keys(Opal.$.OpalJSSpecExport).indexOf('rawShape') >= 0`.should == true
+    `Object.keys(Opal.$.OpalJSSpecExport).indexOf('raw_shape')`.should == -1
+    `('rawShape' in Opal.$.OpalJSSpecExport)`.should == true
+    `('raw_shape' in Opal.$.OpalJSSpecExport)`.should == false
+    `Object.getOwnPropertyDescriptor(Opal.$.OpalJSSpecExport, 'rawShape') !== undefined`.should == true
+    `Object.getOwnPropertyDescriptor(Opal.$.OpalJSSpecExport, 'raw_shape') === undefined`.should == true
+    `Object.keys(Opal.$.OpalJSSpecExport).indexOf('empty?') >= 0`.should == true
+    `Object.keys(Opal.$.OpalJSSpecExport).indexOf('OPAL_JS_SPEC_CONST') >= 0`.should == true
+    `('OPAL_JS_SPEC_CONST' in Opal.$.OpalJSSpecExport)`.should == true
+  end
+end
+
+# rubocop:enable Lint/Void,Performance/RedundantBlockCall,Style/TrivialAccessors,Lint/UselessAssignment

--- a/spec/opal/stdlib/opal_js_export_spec.rb
+++ b/spec/opal/stdlib/opal_js_export_spec.rb
@@ -169,6 +169,11 @@ describe 'Opal.$' do
     `Opal.$.OpalJSSpecExport.invokeWithDefault(Opal.$.OpalJSSpecExport.call)`.should == 'called final member'
   end
 
+  it 'caches concrete member facades but not unresolved member misses' do
+    `Opal.$.OpalJSSpecExport.call === Opal.$.OpalJSSpecExport.call`.should == true
+    `Opal.$.OpalJSSpecExport.__missing_member__ === Opal.$.OpalJSSpecExport.__missing_member__`.should == false
+  end
+
   it 'supports instanceof through Symbol.hasInstance' do
     `Opal.global.__opal_export_spec = new Opal.$.OpalJSSpecExport()`
     `Opal.global.__opal_export_spec instanceof Opal.$.OpalJSSpecExport`.should == true

--- a/spec/opal/stdlib/opal_js_spec.rb
+++ b/spec/opal/stdlib/opal_js_spec.rb
@@ -1,0 +1,202 @@
+# frozen_string_literal: true
+
+# backtick_javascript: true
+
+# rubocop:disable Style/GlobalVars,Lint/Void,Style/NilComparison,Style/WordArray
+
+require 'spec_helper'
+require 'opal/js'
+
+describe 'Opal::JS' do
+  before do
+    `Opal.global.__opal_js_spec = {}`
+  end
+
+  after do
+    `delete Opal.global.__opal_js_spec`
+  end
+
+  it 'installs $js as the wrapped global object' do
+    $js.should be_kind_of(Opal::JS::Object)
+    `#{$js.instance_variable_get(:@native)} === Opal.global`.should == true
+  end
+
+  it 'wraps JS objects, arrays, and functions' do
+    Opal::JS.wrap(`{a: 1}`).should be_kind_of(Opal::JS::Object)
+    Opal::JS.wrap(`[1, 2]`).should be_kind_of(Opal::JS::Array)
+    Opal::JS.wrap(`function(){}`).should be_kind_of(Opal::JS::Function)
+  end
+
+  it 'exposes JS object/native predicate helpers' do
+    Opal::JS.object?(`{}`).should == true
+    Opal::JS.object?(Object.new).should == false
+
+    Opal::JS.native?(`{}`).should == true
+    Opal::JS.native?(nil).should == true
+    Opal::JS.native?(Object.new).should == false
+  end
+
+  it 'caches wrappers for repeated JS object and function wrapping' do
+    $js[:__opal_js_spec] = `{
+      fn: function() { return 1; }
+    }`
+
+    $js[:__opal_js_spec].equal?($js[:__opal_js_spec]).should == true
+    $js.__opal_js_spec[:fn].equal?($js.__opal_js_spec[:fn]).should == true
+  end
+
+  it 'caches wrappers for repeated JS promise wrapping' do
+    promise = `Promise.resolve(1)`
+
+    Opal::JS.wrap(promise).equal?(Opal::JS.wrap(promise)).should == true
+  end
+
+  it 'wraps typed array-like objects as live arrays' do
+    wrapper = Opal::JS.wrap(`new Uint8Array([1, 2])`)
+
+    wrapper.should be_kind_of(Opal::JS::Array)
+    wrapper.to_a.should == [1, 2]
+  end
+
+  it 'structurally wraps length-bearing JS objects as live arrays' do
+    wrapper = Opal::JS.wrap(`{0: 'a', 1: 'b', length: 2, name: 'box'}`)
+
+    wrapper.should be_kind_of(Opal::JS::Array)
+    wrapper.to_a.should == ['a', 'b']
+    wrapper[:name].should == 'box'
+  end
+
+  it 'deep-converts explicit JS object and array snapshots' do
+    object = Opal::JS.wrap(`{ nested: { value: 1 }, list: [2] }`)
+    array = Opal::JS.wrap(`[{ value: 3 }]`)
+
+    object.to_h.should == { 'nested' => { 'value' => 1 }, 'list' => [2] }
+    array.to_a.should == [{ 'value' => 3 }]
+  end
+
+  it 'uses exact bracket access without raising for missing properties' do
+    $js[:__opal_js_spec][:missing].should == nil
+  end
+
+  it 'returns nil for missing dynamic getters' do
+    $js.__opal_js_spec.missing.should == nil
+  end
+
+  it 'raises for missing dynamic calls with arguments' do
+    -> { $js.__opal_js_spec.missing(1) }.should raise_error(NoMethodError)
+  end
+
+  it 'creates new JS properties through dynamic setters' do
+    $js.__opal_js_spec.new_key = 42
+
+    $js[:__opal_js_spec][:newKey].should == 42
+    $js.__opal_js_spec.new_key.should == 42
+  end
+
+  it 'converts Ruby nil to JS undefined' do
+    $js[:__opal_js_spec][:value] = nil
+    `typeof Opal.global.__opal_js_spec.value`.should == 'undefined'
+  end
+
+  it 'converts Ruby hashes to plain JS objects without key translation' do
+    $js[:__opal_js_spec][:value] = { abc: 123, abc_def: 456, 7 => 8 }
+
+    `Opal.global.__opal_js_spec.value instanceof Map`.should == false
+    `Opal.global.__opal_js_spec.value.abc`.should == 123
+    `Opal.global.__opal_js_spec.value.abc_def`.should == 456
+    `Opal.global.__opal_js_spec.value[7]`.should == 8
+  end
+
+  it 'raises ConversionError for unsupported hash keys' do
+    -> { $js[:__opal_js_spec][:value] = { Object.new => 1 } }.should raise_error(Opal::JS::ConversionError)
+  end
+
+  it 'raises ConversionError for cyclic Ruby hash and array conversion' do
+    hash = {}
+    hash[:self] = hash
+
+    array = []
+    array << array
+
+    -> { $js[:__opal_js_spec][:value] = hash }.should raise_error(Opal::JS::ConversionError)
+    -> { $js[:__opal_js_spec][:value] = array }.should raise_error(Opal::JS::ConversionError)
+  end
+
+  it 'raises ConversionError for cyclic JS object and array snapshots' do
+    object = Opal::JS.wrap(`(function() { var object = {}; object.self = object; return object; })()`)
+    array = Opal::JS.wrap(`(function() { var array = []; array[0] = array; return array; })()`)
+
+    -> { object.to_h }.should raise_error(Opal::JS::ConversionError)
+    -> { array.to_a }.should raise_error(Opal::JS::ConversionError)
+  end
+
+  it 'prefers exact JS names and supports canonical snake_case translation' do
+    $js[:__opal_js_spec] = `{
+      querySelectorAll: function(selector) { return selector + ':translated'; },
+      query_selector_all: function(selector) { return selector + ':exact'; }
+    }`
+
+    $js.__opal_js_spec.query_selector_all('h1').should == 'h1:exact'
+    $js.__opal_js_spec.querySelectorAll('h2').should == 'h2:translated'
+
+    `delete Opal.global.__opal_js_spec.query_selector_all`
+    $js.__opal_js_spec.query_selector_all('h3').should == 'h3:translated'
+  end
+
+  it 'auto-calls zero-argument dynamic functions except constructor/prototype/uppercase names' do
+    $js[:__opal_js_spec] = `{
+      reload: function() { return 'reloaded'; },
+      constructor: function() { return 'constructed'; },
+      HTMLElement: function() { return 'element'; }
+    }`
+
+    $js.__opal_js_spec.reload.should == 'reloaded'
+    $js.__opal_js_spec.constructor.should be_kind_of(Opal::JS::Function)
+    $js.__opal_js_spec.HTMLElement.should be_kind_of(Opal::JS::Function)
+  end
+
+  it 'returns receiver-bound functions from bracket access' do
+    $js[:__opal_js_spec] = `{
+      value: 41,
+      add: function(amount) { return this.value + amount; }
+    }`
+
+    $js.__opal_js_spec[:add].call(1).should == 42
+  end
+
+  it 'exposes public call, new, and instanceof? helpers' do
+    $js[:__opal_js_spec] = `{
+      value: 41,
+      add: function(amount) { return this.value + amount; },
+      Klass: function(value) { this.value = value; }
+    }`
+
+    object = $js.__opal_js_spec
+    instance = Opal::JS.new(object.Klass, 42)
+
+    Opal::JS.call(object, :add, 1).should == 42
+    instance[:value].should == 42
+    Opal::JS.instanceof?(instance, object.Klass).should == true
+  end
+
+  it 'exposes JS this synchronously during callbacks while preserving Ruby block self' do
+    $js[:__opal_js_spec] = `{
+      value: 42,
+      callBlock: function(block) { return block.call(this); }
+    }`
+
+    ruby_self = self
+    seen_self = nil
+    seen_this = nil
+
+    $js.__opal_js_spec.call_block do
+      seen_self = self
+      seen_this = Opal::JS.this[:value]
+    end
+
+    seen_self.should == ruby_self
+    seen_this.should == 42
+  end
+end
+
+# rubocop:enable Style/GlobalVars,Lint/Void,Style/NilComparison,Style/WordArray

--- a/spec/opal/stdlib/opal_js_wrapper_spec.rb
+++ b/spec/opal/stdlib/opal_js_wrapper_spec.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+# backtick_javascript: true
+
+# rubocop:disable Style/GlobalVars,Lint/Void,Style/SymbolArray,Style/WordArray,Layout/MultilineMethodCallBraceLayout
+
+require 'spec_helper'
+require 'opal/js'
+
+`function OpalJSSpecAnimal(name) { this.name = name; }`
+`OpalJSSpecAnimal.prototype.kind = function() { return 'animal:' + this.name; }`
+`OpalJSSpecAnimal.prototype.describeArgs = function() { return Array.prototype.slice.call(arguments); }`
+`OpalJSSpecAnimal.prototype.configure = function(options) { return options; }`
+`OpalJSSpecAnimal.prototype.renamedValue = 'initial'`
+`Opal.global.OpalJSSpecAnimal = OpalJSSpecAnimal`
+
+`function OpalJSSpecDog(name) { OpalJSSpecAnimal.call(this, name); }`
+`OpalJSSpecDog.prototype = Object.create(OpalJSSpecAnimal.prototype)`
+`OpalJSSpecDog.prototype.constructor = OpalJSSpecDog`
+`Opal.global.OpalJSSpecDog = OpalJSSpecDog`
+
+`function OpalJSSpecBear(name) { OpalJSSpecAnimal.call(this, name); }`
+`OpalJSSpecBear.prototype = Object.create(OpalJSSpecAnimal.prototype)`
+`OpalJSSpecBear.prototype.constructor = OpalJSSpecBear`
+`Opal.global.OpalJSSpecBear = OpalJSSpecBear`
+
+`Opal.global.__opal_js_animal = new OpalJSSpecAnimal('a')`
+`Opal.global.__opal_js_dog = new OpalJSSpecDog('d')`
+`Opal.global.__opal_js_bear = new OpalJSSpecBear('b')`
+`Opal.global.__opal_js_entity = { name: 'e' }`
+
+module OpalJSSpecTimerEvents
+  include Opal::JS::Wrapper
+
+  js_method :set_timeout, 'setTimeout', args: [:&, :*]
+end
+
+class OpalJSSpecAnimalWrapper
+  include Opal::JS::Wrapper
+
+  js_object
+  js_constructor $js[:OpalJSSpecAnimal]
+  js_method :swap, 'describeArgs', args: [1, 0, 2]
+  js_method :last_first, 'describeArgs', args: [-1, :*]
+  js_method :remaining_then_last, 'describeArgs', args: [:*, -1]
+  js_method :remaining_then_first, 'describeArgs', args: [:*, 0]
+  js_method :configure_raw, 'configure', args: [:**]
+  js_method :configure_converted, 'configure', args: [:**], kwargs: :convert
+  js_accessor :renamed, 'renamedValue'
+end
+
+class OpalJSSpecDogWrapper < OpalJSSpecAnimalWrapper
+  js_constructor $js[:OpalJSSpecDog]
+end
+
+class OpalJSSpecRootWrapper
+  include OpalJSSpecTimerEvents
+  include Opal::JS::Wrapper
+
+  js_object
+end
+
+`function OpalJSSpecLate(value) { this.value = value; }`
+`Opal.global.OpalJSSpecLate = OpalJSSpecLate`
+
+class OpalJSSpecLateWrapper
+  include Opal::JS::Wrapper
+
+  js_object
+end
+
+describe 'Opal::JS::Wrapper DSL' do
+  it 'wraps existing values and constructs through js_constructor' do
+    animal = OpalJSSpecAnimalWrapper.wrap($js[:__opal_js_animal])
+    created = OpalJSSpecAnimalWrapper.new('created')
+
+    animal.kind.should == 'animal:a'
+    created.kind.should == 'animal:created'
+  end
+
+  it 'uses registered constructors to pick specific wrapper classes' do
+    $js[:__opal_js_entity].should be_kind_of(Opal::JS::Object)
+    $js[:__opal_js_animal].should be_kind_of(OpalJSSpecAnimalWrapper)
+    $js[:__opal_js_dog].should be_kind_of(OpalJSSpecDogWrapper)
+    $js[:__opal_js_bear].should be_kind_of(OpalJSSpecAnimalWrapper)
+  end
+
+  it 'keeps cached wrappers stable after late wrapper registration' do
+    raw_before = `new OpalJSSpecLate(1)`
+    raw_after = `new OpalJSSpecLate(2)`
+    before = Opal::JS.wrap(raw_before)
+
+    OpalJSSpecLateWrapper.js_register_wrapper $js[:OpalJSSpecLate]
+
+    Opal::JS.wrap(raw_before).should == before
+    Opal::JS.wrap(raw_before).should be_kind_of(Opal::JS::Object)
+    Opal::JS.wrap(raw_after).should be_kind_of(OpalJSSpecLateWrapper)
+  end
+
+  it 'does not validate explicit wrap class against the JS constructor' do
+    OpalJSSpecDogWrapper.wrap($js[:__opal_js_animal]).should be_kind_of(OpalJSSpecDogWrapper)
+  end
+
+  it 'rejects rebinding an initialized wrapper' do
+    wrapper = OpalJSSpecAnimalWrapper.wrap($js[:__opal_js_animal])
+
+    -> { wrapper.initialize_wrapped($js[:__opal_js_dog]) }.should raise_error(ArgumentError)
+  end
+
+  it 'supports js_method argument projection' do
+    wrapper = OpalJSSpecAnimalWrapper.wrap($js[:__opal_js_animal])
+
+    wrapper.swap('a', 'b', 'c').to_a.should == ['b', 'a', 'c']
+    wrapper.last_first('a', 'b', 'c').to_a.should == ['c', 'a', 'b']
+    wrapper.remaining_then_last('a', 'b', 'c').to_a.should == ['a', 'b', 'c']
+    wrapper.remaining_then_first('a', 'b', 'c').to_a.should == ['b', 'c', 'a']
+  end
+
+  it 'strictly requires args projection for blocks and kwargs' do
+    wrapper = OpalJSSpecAnimalWrapper.wrap($js[:__opal_js_animal])
+
+    -> { wrapper.swap('a') }.should raise_error(ArgumentError)
+    -> { wrapper.swap('a', 'b', 'c') {} }.should raise_error(ArgumentError)
+    -> { wrapper.swap('a', 'b', 'c', option: true) }.should raise_error(ArgumentError)
+  end
+
+  it 'positions kwargs and converts keys only when requested' do
+    wrapper = OpalJSSpecAnimalWrapper.wrap($js[:__opal_js_animal])
+
+    raw = wrapper.configure_raw(background_color: 'red')
+    converted = wrapper.configure_converted(background_color: 'blue')
+
+    raw[:background_color].should == 'red'
+    converted[:backgroundColor].should == 'blue'
+  end
+
+  it 'supports js_accessor aliases' do
+    wrapper = OpalJSSpecAnimalWrapper.wrap($js[:__opal_js_animal])
+
+    wrapper.renamed = 'changed'
+    wrapper.renamed.should == 'changed'
+  end
+
+  it 'supports wrapper DSL declarations from modules included before Wrapper' do
+    root = OpalJSSpecRootWrapper.wrap(`{
+      setTimeout: function(block, delay) { return block() + ':' + delay; }
+    }`)
+
+    root.set_timeout(10) { 'timer' }.should == 'timer:10'
+  end
+
+  it 'supports array-like mutators and exact dig' do
+    array = Opal::JS.wrap(`[1, 2]`)
+    object = Opal::JS.wrap(`{ nested: { value: 3 } }`)
+
+    array.push(3).should == array
+    array << 4
+    array.pop.should == 4
+    array.shift.should == 1
+    array.unshift(0).should == array
+    array.to_a.should == [0, 2, 3]
+    object.dig(:nested, :value).should == 3
+  end
+end
+
+# rubocop:enable Style/GlobalVars,Lint/Void,Style/SymbolArray,Style/WordArray,Layout/MultilineMethodCallBraceLayout

--- a/stdlib/opal/js.rb
+++ b/stdlib/opal/js.rb
@@ -1,0 +1,12 @@
+# backtick_javascript: true
+
+require 'opal/js/base'
+require 'opal/js/wrapper'
+require 'opal/js/wrapper_dsl'
+require 'opal/js/conversion'
+require 'opal/js/dispatch'
+require 'opal/js/export'
+
+# rubocop:disable Style/GlobalVars
+$js = ::Opal::JS.global
+# rubocop:enable Style/GlobalVars

--- a/stdlib/opal/js/base.rb
+++ b/stdlib/opal/js/base.rb
@@ -1,0 +1,12 @@
+# backtick_javascript: true
+
+require 'promise/v2'
+
+module ::Opal
+  module Export
+  end
+
+  module JS
+    class ConversionError < ::TypeError; end
+  end
+end

--- a/stdlib/opal/js/conversion.rb
+++ b/stdlib/opal/js/conversion.rb
@@ -1,0 +1,297 @@
+# backtick_javascript: true
+# helpers: hash_each, hash_put
+
+module ::Opal
+  module JS
+    class << self
+      def global
+        wrap(`Opal.global`)
+      end
+
+      def wrap(value)
+        from_js(value)
+      end
+
+      def unwrap(value)
+        to_js(value)
+      end
+
+      def from_js(value)
+        %x{
+          var wrapper, cache, klass;
+
+          if (value == null) return nil;
+
+          if (value.$$opal_js_wrapper) return value;
+
+          if (typeof Promise !== 'undefined' && value instanceof Promise) {
+            cache = Opal.JS.$$wrapper_cache;
+            if (cache && cache.has(value)) return cache.get(value);
+
+            wrapper = #{::PromiseV2.resolve(value).then { |resolved| from_js(resolved) }};
+            if (cache) cache.set(value, wrapper);
+            return wrapper;
+          }
+
+          if (typeof value === 'function') {
+            cache = Opal.JS.$$wrapper_cache;
+            if (cache && cache.has(value)) return cache.get(value);
+
+            klass = #{wrapper_class_for(value)};
+            wrapper = klass === nil ? #{::Opal::JS::Function.new(`value`)} : klass.$wrap(value);
+            if (cache) cache.set(value, wrapper);
+            return wrapper;
+          }
+
+          if (typeof value === 'object') {
+            cache = Opal.JS.$$wrapper_cache;
+            if (cache && cache.has(value)) return cache.get(value);
+
+            klass = #{wrapper_class_for(value)};
+            if (klass !== nil) {
+              wrapper = klass.$wrap(value);
+            }
+            else if (Array.isArray(value) || #{array_like?(value)}) {
+              wrapper = #{::Opal::JS::Array.new(`value`)};
+            }
+            else {
+              wrapper = #{::Opal::JS::Object.new(`value`)};
+            }
+
+            if (cache) cache.set(value, wrapper);
+            return wrapper;
+          }
+
+          return value;
+        }
+      end
+
+      def to_js(value, seen = nil)
+        %x{
+          if (value === nil) return undefined;
+
+          if (value != null && value.$$opal_js_wrapper) return value.$to_js();
+
+          if (value != null && value.$$opal_export_proxy) return value;
+
+          if (value != null && value.$$is_hash) return #{hash_to_js_object(value, seen)};
+
+          if (value != null && value.$$is_array) return #{array_to_js(value, seen)};
+
+          if (typeof value === 'function' && value.$$is_proc) return #{proc_to_js(value)};
+
+          if (value != null && Opal.respond_to(value, '$to_js', true)) return value.$to_js();
+
+          if (#{native_wrapper?(value)}) return value.$to_n();
+
+          if (typeof Promise !== 'undefined' && value instanceof Promise) {
+            return value.then(function(resolved) { return #{to_js(`resolved`, seen)}; });
+          }
+
+          if (value != null &&
+              (typeof value === 'object' || typeof value === 'function') &&
+              value.$$class && Opal.Export.$$proxy_for) {
+            return Opal.Export.$$proxy_for(value);
+          }
+
+          return value;
+        }
+      end
+
+      def native_wrapper?(value)
+        %x{
+          return value != null &&
+            typeof Opal.Native !== 'undefined' &&
+            typeof Opal.Native.Wrapper !== 'undefined' &&
+            Opal.is_a(value, Opal.Native.Wrapper);
+        }
+      end
+
+      def native?(value)
+        `#{value} === nil || #{value} == null || (typeof #{value} !== 'object' && typeof #{value} !== 'function') || !#{value}.$$class`
+      end
+
+      def object?(value)
+        `#{value} != null && (typeof #{value} === 'object' || typeof #{value} === 'function') && !#{value}.$$class`
+      end
+
+      def array_like?(value)
+        %x{
+          if (value == null || typeof value !== 'object') return false;
+          if (!('length' in value)) return false;
+
+          var length = value.length;
+          return typeof length === 'number' &&
+            length >= 0 &&
+            length <= Number.MAX_SAFE_INTEGER &&
+            Math.floor(length) === length;
+        }
+      end
+
+      def raise_unsupported_hash_key
+        raise ::Opal::JS::ConversionError, 'unsupported Hash key for JS object conversion'
+      end
+
+      def raise_cyclic_conversion
+        raise ::Opal::JS::ConversionError, 'cyclic object graph cannot be converted to plain JavaScript values'
+      end
+
+      def raise_not_callable(name)
+        raise ::NoMethodError, "JavaScript property `#{name}' is not callable"
+      end
+
+      def hash_to_js_object(hash, seen = nil)
+        %x{
+          var result = {};
+
+          seen = (seen === nil || seen == null) ? [] : seen;
+          if (seen.indexOf(hash) !== -1) #{raise_cyclic_conversion};
+          seen.push(hash);
+
+          try {
+            $hash_each(hash, false, function(key, value) {
+              var type = typeof key;
+
+              if (type !== 'string' && type !== 'number') {
+                #{raise_unsupported_hash_key};
+              }
+
+              result[key] = #{to_js(`value`, seen)};
+              return [false, false];
+            });
+          }
+          finally {
+            seen.pop();
+          }
+
+          return result;
+        }
+      end
+
+      def array_to_js(array, seen = nil)
+        %x{
+          var result = new Array(array.length);
+
+          seen = (seen === nil || seen == null) ? [] : seen;
+          if (seen.indexOf(array) !== -1) #{raise_cyclic_conversion};
+          seen.push(array);
+
+          try {
+            for (var i = 0; i < array.length; i++) {
+              result[i] = #{to_js(`array[i]`, seen)};
+            }
+          }
+          finally {
+            seen.pop();
+          }
+
+          return result;
+        }
+      end
+
+      def proc_to_js(proc)
+        %x{
+          if (proc.$$opal_js_function) return proc.$$opal_js_function;
+
+          var fn = function() {
+            var previous = Opal.JS.$$this, args = new Array(arguments.length);
+
+            Opal.JS.$$this = this;
+
+            try {
+              for (var i = 0; i < arguments.length; i++) {
+                args[i] = #{from_js(`arguments[i]`)};
+              }
+
+              return #{to_js(`proc.apply(proc.$$s, args)`)};
+            }
+            finally {
+              Opal.JS.$$this = previous;
+            }
+          };
+
+          proc.$$opal_js_function = fn;
+          return fn;
+        }
+      end
+
+      def this
+        # Exposes JavaScript `this` only while a Ruby callback is synchronously
+        # executing from a JS call. Outside that callback boundary it is nil.
+        from_js(`Opal.JS.$$this`)
+      end
+
+      def call(receiver, name, *args, &block)
+        property = property_name_for(to_js(receiver), name)
+
+        if property.nil?
+          raise ::NoMethodError, "undefined JavaScript property or method `#{name}'"
+        end
+
+        `var fn = #{to_js(receiver)}[property]`
+        raise_not_callable(name) unless `typeof fn === 'function'`
+
+        call_function(`fn`, to_js(receiver), args, block)
+      end
+
+      def new(constructor, *args, &block)
+        construct(to_js(constructor), args, block)
+      end
+
+      def instanceof?(value, constructor)
+        `#{to_js(value)} instanceof #{to_js(constructor)}`
+      end
+
+      def object_to_hash(object)
+        %x{
+          return #{snapshot_js_value(object, `[]`)};
+        }
+      end
+
+      def array_to_ruby(array)
+        %x{
+          return #{snapshot_js_value(array, `[]`)};
+        }
+      end
+
+      # rubocop:disable Style/EmptyLiteral
+      def snapshot_js_value(value, seen)
+        %x{
+          var hash, array, keys;
+
+          if (value == null) return nil;
+
+          if (typeof value === 'object') {
+            if (seen.indexOf(value) !== -1) #{raise_cyclic_conversion};
+            seen.push(value);
+
+            try {
+              if (Array.isArray(value) || #{array_like?(value)}) {
+                array = [];
+                for (var i = 0, length = value.length; i < length; i++) {
+                  array.push(#{snapshot_js_value(`value[i]`, seen)});
+                }
+                return array;
+              }
+
+              hash = #{::Hash.new};
+              keys = Object.keys(value);
+
+              for (var j = 0; j < keys.length; j++) {
+                $hash_put(hash, keys[j], #{snapshot_js_value(`value[keys[j]]`, seen)});
+              }
+
+              return hash;
+            }
+            finally {
+              seen.pop();
+            }
+          }
+
+          return #{from_js(value)};
+        }
+      end
+      # rubocop:enable Style/EmptyLiteral
+    end
+  end
+end

--- a/stdlib/opal/js/dispatch.rb
+++ b/stdlib/opal/js/dispatch.rb
@@ -1,0 +1,118 @@
+# backtick_javascript: true
+
+module ::Opal
+  module JS
+    class << self
+      def read(receiver, name)
+        %x{
+          var value = receiver[name], cache, receiverCache, wrapper;
+
+          if (typeof value === 'function') {
+            cache = Opal.JS.$$bound_function_cache;
+            if (cache) {
+              receiverCache = cache.get(receiver);
+              if (!receiverCache) cache.set(receiver, receiverCache = new WeakMap());
+              if (receiverCache.has(value)) return receiverCache.get(value);
+            }
+
+            wrapper = #{::Opal::JS::Function.new(`value`, receiver)};
+            if (receiverCache) receiverCache.set(value, wrapper);
+            return wrapper;
+          }
+
+          return #{from_js(`value`)};
+        }
+      end
+
+      def property_name_for(receiver, ruby_name)
+        name = ruby_name.to_s
+        name = name[0...-1] if name.end_with?('=')
+
+        %x{
+          if (name in receiver) return name;
+
+          var translated = #{camelize(name)};
+          if (translated in receiver) return translated;
+
+          return nil;
+        }
+      end
+
+      def dispatch(receiver, ruby_name, args, block)
+        setter = ruby_name.to_s.end_with?('=')
+        property = property_name_for(receiver, ruby_name)
+
+        if setter
+          value = args[0]
+          property = camelize(ruby_name.to_s[0...-1]) if property.nil?
+          `receiver[property] = #{to_js(value)}`
+          return value
+        end
+
+        if property.nil?
+          if !args.empty? || (!block.nil? && `block != null`)
+            raise ::NoMethodError, "undefined JavaScript property or method `#{ruby_name}'"
+          end
+
+          return nil
+        end
+
+        %x{
+          var value = receiver[property];
+
+          if (typeof value === 'function') {
+            if (args.length === 0 && (block === nil || block == null) && property !== 'constructor' && property !== 'prototype' && !/^[A-Z]/.test(property)) {
+              return #{from_js(`value.apply(receiver, [])`)};
+            }
+
+            if (args.length === 0 && (block === nil || block == null)) {
+              return #{::Opal::JS::Function.new(`value`, receiver)};
+            }
+
+            return #{call_function(`value`, receiver, args, block)};
+          }
+
+          if (args.length > 0 || (block !== nil && block != null)) {
+            #{raise_not_callable(ruby_name)};
+          }
+
+          return #{from_js(`value`)};
+        }
+      end
+
+      def call_function(fn, receiver, args, block)
+        %x{
+          var has_block = !(block === nil || block == null);
+          var js_args = new Array(args.length + (has_block ? 1 : 0));
+
+          for (var i = 0; i < args.length; i++) {
+            js_args[i] = #{to_js(`args[i]`)};
+          }
+
+          if (has_block) js_args[args.length] = #{proc_to_js(block)};
+
+          return #{from_js(`fn.apply(receiver == null ? undefined : receiver, js_args)`)};
+        }
+      end
+
+      def construct(fn, args, block)
+        %x{
+          var has_block = !(block === nil || block == null);
+          var js_args = new Array(args.length + (has_block ? 1 : 0));
+
+          for (var i = 0; i < args.length; i++) {
+            js_args[i] = #{to_js(`args[i]`)};
+          }
+
+          if (has_block) js_args[args.length] = #{proc_to_js(block)};
+
+          return #{from_js(`new (Function.prototype.bind.apply(fn, [null].concat(js_args)))()`)};
+        }
+      end
+
+      def camelize(name)
+        `#{name}.replace(/_([a-zA-Z0-9])/g, function(_, chr) { return chr.toUpperCase(); })`
+      end
+    end
+  end
+end

--- a/stdlib/opal/js/export.rb
+++ b/stdlib/opal/js/export.rb
@@ -1,0 +1,4 @@
+# backtick_javascript: true
+
+require 'opal/js/export_conversion'
+require 'opal/js/export_proxy'

--- a/stdlib/opal/js/export_conversion.rb
+++ b/stdlib/opal/js/export_conversion.rb
@@ -1,0 +1,157 @@
+# backtick_javascript: true
+
+%x{
+  (function() {
+    if (Opal.Export.$$conversion) return;
+
+    var functionCache = typeof WeakMap === 'undefined' ? null : new WeakMap();
+
+    function camelToSnake(name) {
+      return name.replace(/([A-Z])/g, function(chr) { return '_' + chr.toLowerCase(); });
+    }
+
+    function snakeToCamel(name) {
+      return name.replace(/_([a-zA-Z0-9])/g, function(_match, chr) { return chr.toUpperCase(); });
+    }
+
+    function isSnakeName(name) {
+      return name.indexOf('_') !== -1;
+    }
+
+    function isUpperName(name) {
+      return /^[A-Z]/.test(name);
+    }
+
+    function isPlainObject(value) {
+      if (value == null || typeof value !== 'object') return false;
+      var proto = Object.getPrototypeOf(value);
+      return proto === Object.prototype || proto === null;
+    }
+
+    function raiseConversionError() {
+      throw Opal.JS.ConversionError.$new('cyclic object graph cannot be converted to plain JavaScript values');
+    }
+
+    function toRuby(value, seen) {
+      seen = seen || [];
+
+      if (value == null) return nil;
+      if (value.$$is_hash) return value;
+      if (value.$$opal_export_member) return memberToRuby(value);
+      if (value.$$opal_export_proxy) return value.$$opal_export_value;
+      if (value.$$opal_js_wrapper) return value;
+
+      if (Array.isArray(value)) {
+        if (seen.indexOf(value) !== -1) raiseConversionError();
+        seen.push(value);
+        try {
+          return value.map(function(item) { return toRuby(item, seen); });
+        }
+        finally {
+          seen.pop();
+        }
+      }
+
+      if (typeof value === 'function') return functionToRuby(value);
+      if (isPlainObject(value)) return objectToHash(value, seen);
+      return Opal.JS.$from_js(value);
+    }
+
+    function functionToRuby(value) {
+      var wrapper;
+
+      if (functionCache && functionCache.has(value)) return functionCache.get(value);
+
+      wrapper = function() {
+        var args = new Array(arguments.length);
+        for (var i = 0; i < arguments.length; i++) args[i] = Opal.JS.$to_js(arguments[i]);
+        return Opal.JS.$from_js(value.apply(this, args));
+      };
+
+      if (functionCache) functionCache.set(value, wrapper);
+      return wrapper;
+    }
+
+    function memberToRuby(member) {
+      var receiver = member.$$opal_export_receiver, name = member.$$opal_export_name;
+
+      try {
+        return Opal.send(receiver, 'method', [name], nil);
+      }
+      catch (error) {
+        return function() {
+          var converted = argsToRuby(arguments);
+          return Opal.send(receiver, name, converted.args, converted.block);
+        };
+      }
+    }
+
+    function objectToHash(object, seen) {
+      var hash = Opal.Hash.$new(), keys = Object.keys(object);
+
+      if (seen.indexOf(object) !== -1) raiseConversionError();
+      seen.push(object);
+
+      try {
+        for (var i = 0; i < keys.length; i++) Opal.hash_put(hash, camelToSnake(keys[i]), toRuby(object[keys[i]], seen));
+        return hash;
+      }
+      finally {
+        seen.pop();
+      }
+    }
+
+    function functionToBlock(fn) {
+      return function() {
+        var blockArgs = new Array(arguments.length);
+        for (var i = 0; i < arguments.length; i++) blockArgs[i] = Opal.JS.$to_js(arguments[i]);
+        return Opal.JS.$from_js(fn.apply(this, blockArgs));
+      };
+    }
+
+    function argsToRuby(args) {
+      var result = Array.prototype.slice.call(args), block = nil;
+
+      if (result.length > 0 && typeof result[result.length - 1] === 'function' && !result[result.length - 1].$$opal_export_member) {
+        var fn = result.pop();
+        block = functionToBlock(fn);
+      }
+
+      if (result.length > 0 && isPlainObject(result[result.length - 1])) {
+        result[result.length - 1] = objectToHash(result[result.length - 1], []);
+      }
+
+      for (var j = 0; j < result.length; j++) result[j] = toRuby(result[j], []);
+
+      return { args: result, block: block };
+    }
+
+    function rawArgsToRuby(args) {
+      var input = Array.prototype.slice.call(args), result = [], block = nil, positional, kwargs, callback;
+
+      if (input.length > 0 && Array.isArray(input[0])) positional = input.shift();
+      else positional = [];
+
+      if (input.length > 0 && isPlainObject(input[0])) kwargs = input.shift();
+      if (input.length > 0 && typeof input[0] === 'function') callback = input.shift();
+
+      if (input.length > 0) throw new TypeError('invalid __send_raw__ argument shape');
+
+      for (var i = 0; i < positional.length; i++) result.push(toRuby(positional[i], []));
+      if (kwargs !== undefined) result.push(objectToHash(kwargs, []));
+      if (callback !== undefined) block = functionToBlock(callback);
+
+      return { args: result, block: block };
+    }
+
+    Opal.Export.$$conversion = {
+      argsToRuby: argsToRuby,
+      rawArgsToRuby: rawArgsToRuby,
+      camelToSnake: camelToSnake,
+      snakeToCamel: snakeToCamel,
+      isSnakeName: isSnakeName,
+      isPlainObject: isPlainObject,
+      isUpperName: isUpperName
+    };
+  })();
+}

--- a/stdlib/opal/js/export_proxy.rb
+++ b/stdlib/opal/js/export_proxy.rb
@@ -58,9 +58,9 @@
     }
 
     function memberFor(receiver, rubyName) {
-      var receiverCache, proxy;
+      var cacheable = typeof receiver['$' + rubyName] === 'function', receiverCache, proxy;
 
-      if (memberCache) {
+      if (cacheable && memberCache) {
         receiverCache = memberCache.get(receiver);
         if (!receiverCache) memberCache.set(receiver, receiverCache = Object.create(null));
         if (receiverCache[rubyName]) return receiverCache[rubyName];

--- a/stdlib/opal/js/export_proxy.rb
+++ b/stdlib/opal/js/export_proxy.rb
@@ -1,0 +1,181 @@
+# backtick_javascript: true
+
+%x{
+  (function() {
+    if (Opal.$$export_proxy_initialized) return;
+    Opal.$$export_proxy_initialized = true;
+
+    var proxyCache = typeof WeakMap === 'undefined' ? null : new WeakMap();
+    var memberCache = typeof WeakMap === 'undefined' ? null : new WeakMap();
+    var conversion = Opal.Export.$$conversion;
+
+    function constantsFor(value) {
+      if (value && (value.$$is_class || value.$$is_module)) return Opal.constants(value, true);
+      if (value && value.$$class) return Opal.constants(value.$$class, true);
+      return [];
+    }
+
+    function methodsFor(value) {
+      var names = {}, seen = typeof WeakSet === 'undefined' ? null : new WeakSet();
+
+      function collect(proto) {
+        while (proto != null) {
+          if (seen) {
+            if (seen.has(proto)) return;
+            seen.add(proto);
+          }
+
+          Object.getOwnPropertyNames(proto).forEach(function(name) {
+            if (name[0] === '$' && name[1] !== '$' && name !== '$then') names[conversion.snakeToCamel(name.slice(1))] = true;
+          });
+          proto = Object.getPrototypeOf(proto);
+        }
+      }
+
+      collect(value);
+
+      if (value && (value.$$is_class || value.$$is_module)) {
+        collect(value.$$prototype || value);
+      }
+
+      return Object.keys(names);
+    }
+
+    function proxyFor(value) {
+      if (value == null) return value;
+      if (value.$$is_hash || value.$$is_array) return Opal.JS.$to_js(value);
+      if (typeof value !== 'object' && typeof value !== 'function') return Opal.JS.$to_js(value);
+      if (value.$$opal_export_proxy) return value;
+      if (typeof Promise !== 'undefined' && value instanceof Promise) {
+        return value.then(function(resolved) { return proxyFor(resolved); });
+      }
+
+      if (proxyCache && proxyCache.has(value)) return proxyCache.get(value);
+
+      var proxy = new Proxy(function() {}, handlerFor(value));
+      if (proxyCache) proxyCache.set(value, proxy);
+      return proxy;
+    }
+
+    function memberFor(receiver, rubyName) {
+      var receiverCache, proxy;
+
+      if (memberCache) {
+        receiverCache = memberCache.get(receiver);
+        if (!receiverCache) memberCache.set(receiver, receiverCache = Object.create(null));
+        if (receiverCache[rubyName]) return receiverCache[rubyName];
+      }
+
+      proxy = new Proxy(function() {}, {
+        apply: function(_target, _thisArg, args) {
+          var converted = conversion.argsToRuby(args);
+          return proxyFor(Opal.send(receiver, rubyName, converted.args, converted.block));
+        },
+        get: function(_target, prop) {
+          if (prop === '$$opal_export_member') return true;
+          if (prop === '$$opal_export_value') return function() { return Opal.send(receiver, rubyName, [], nil); };
+          if (prop === '$$opal_export_receiver') return receiver;
+          if (prop === '$$opal_export_name') return rubyName;
+          if (prop === 'then') return undefined;
+          return undefined;
+        }
+      });
+
+      if (receiverCache) receiverCache[rubyName] = proxy;
+      return proxy;
+    }
+
+    function getConstant(receiver, name) {
+      if (receiver && (receiver.$$is_class || receiver.$$is_module)) return Opal.$$$ (receiver, name, true);
+      if (receiver === Opal.Object) return Opal.$$$ (Opal.Object, name, true);
+      return null;
+    }
+
+    function handlerFor(value) {
+      return {
+        apply: function(_target, _thisArg, args) {
+          var converted;
+          if (Opal.respond_to(value, '$call', true)) {
+            converted = conversion.argsToRuby(args);
+            return proxyFor(Opal.send(value, 'call', converted.args, converted.block));
+          }
+          throw new TypeError('Opal.$ facade is not directly callable');
+        },
+
+        construct: function(_target, args) {
+          var converted = conversion.argsToRuby(args);
+          return proxyFor(Opal.send(value, 'new', converted.args, converted.block));
+        },
+
+        get: function(_target, prop) {
+          var constant, rubyName;
+
+          if (prop === '$$opal_export_proxy') return true;
+          if (prop === '$$opal_export_value') return value;
+          if (prop === '__send__') return function(method) {
+            var converted = conversion.argsToRuby(Array.prototype.slice.call(arguments, 1));
+            return proxyFor(Opal.send(value, method, converted.args, converted.block));
+          };
+          if (prop === '__send_raw__') return function(method) {
+            var converted = conversion.rawArgsToRuby(Array.prototype.slice.call(arguments, 1));
+            return proxyFor(Opal.send(value, method, converted.args, converted.block));
+          };
+          if (prop === '__const__') return function(name) { return proxyFor(Opal.$$$ (value, name, false)); };
+          if (prop === Symbol.hasInstance) return function(object) {
+            return !!(object && object.$$opal_export_proxy && Opal.is_a(object.$$opal_export_value, value));
+          };
+          if (prop === 'then') return undefined;
+          if (typeof prop !== 'string') return undefined;
+
+          if (conversion.isUpperName(prop)) {
+            constant = getConstant(value, prop);
+            if (constant != null) return proxyFor(constant);
+          }
+
+          rubyName = conversion.camelToSnake(prop);
+          return memberFor(value, rubyName);
+        },
+
+        set: function(_target, prop, assigned) {
+          var rubyName = conversion.camelToSnake(String(prop)) + '=', converted = conversion.argsToRuby([assigned]);
+          Opal.send(value, rubyName, converted.args, converted.block);
+          return true;
+        },
+
+        has: function(_target, prop) {
+          if (typeof prop !== 'string') return false;
+          if (prop === 'then') return false;
+          if (conversion.isUpperName(prop) && getConstant(value, prop) != null) return true;
+          if (conversion.isSnakeName(prop)) return false;
+          return Opal.respond_to(value, '$' + conversion.camelToSnake(prop), true);
+        },
+
+        ownKeys: function(_target) {
+          var keys = {}, out = [];
+
+          Reflect.ownKeys(_target).concat(constantsFor(value), methodsFor(value)).forEach(function(key) {
+            if (!keys[key]) {
+              keys[key] = true;
+              out.push(key);
+            }
+          });
+
+          return out;
+        },
+
+        getOwnPropertyDescriptor: function(_target, prop) {
+          var descriptor = Object.getOwnPropertyDescriptor(_target, prop);
+          if (descriptor) return descriptor;
+          if (this.has(_target, prop)) return { configurable: true, enumerable: true };
+        }
+      };
+    }
+
+    Object.defineProperty(Opal, '$', {
+      configurable: true,
+      get: function() { return proxyFor(Opal.Object); }
+    });
+
+    Opal.Export.$$proxy_for = proxyFor;
+  })();
+}

--- a/stdlib/opal/js/wrapper.rb
+++ b/stdlib/opal/js/wrapper.rb
@@ -1,0 +1,54 @@
+# backtick_javascript: true
+
+require 'opal/js/wrapper_access'
+
+module ::Opal
+  module JS
+    module Wrapper
+      def initialize(native)
+        @native = native
+      end
+
+      def to_js
+        @native
+      end
+    end
+
+    class Object
+      include Wrapper
+      include DynamicObjectAccess
+
+      def ==(other)
+        `#{@native} === #{::Opal::JS.to_js(other)}`
+      end
+    end
+
+    class Array < Object
+      include ArrayAccess
+    end
+
+    class Function < Object
+      def initialize(native, receiver = nil)
+        super(native)
+        @receiver = receiver
+      end
+
+      def call(*args, &block)
+        ::Opal::JS.call_function(@native, @receiver, args, block)
+      end
+
+      def new(*args, &block)
+        ::Opal::JS.construct(@native, args, block)
+      end
+    end
+  end
+end
+
+%x{
+  Opal.JS.$$this = undefined;
+  Opal.JS.$$wrapper_cache = typeof WeakMap === 'undefined' ? null : new WeakMap();
+  Opal.JS.$$bound_function_cache = typeof WeakMap === 'undefined' ? null : new WeakMap();
+  Opal.JS.Object.$$prototype.$$opal_js_wrapper = true;
+  Opal.JS.Array.$$prototype.$$opal_js_wrapper = true;
+  Opal.JS.Function.$$prototype.$$opal_js_wrapper = true;
+}

--- a/stdlib/opal/js/wrapper_access.rb
+++ b/stdlib/opal/js/wrapper_access.rb
@@ -1,0 +1,91 @@
+# backtick_javascript: true
+
+module ::Opal
+  module JS
+    module DynamicObjectAccess
+      def [](name)
+        ::Opal::JS.read(@native, name)
+      end
+
+      def []=(name, value)
+        `#{@native}[#{name}] = #{::Opal::JS.to_js(value)}`
+      end
+
+      def dig(key, *keys)
+        value = self[key]
+        return value if keys.empty? || value.nil?
+
+        value.dig(*keys)
+      end
+
+      def constructor
+        self[:constructor]
+      end
+
+      def prototype
+        self[:prototype]
+      end
+
+      def respond_to_missing?(name, include_all = false)
+        !::Opal::JS.property_name_for(@native, name).nil? || super
+      end
+
+      def method_missing(name, *args, &block)
+        ::Opal::JS.dispatch(@native, name, args, block)
+      end
+
+      def to_h
+        ::Opal::JS.object_to_hash(@native)
+      end
+    end
+
+    module ArrayAccess
+      include ::Enumerable
+
+      def length
+        `#{@native}.length`
+      end
+
+      alias size length
+
+      def each(&block)
+        return enum_for :each unless block
+
+        %x{
+          for (var i = 0, length = #{@native}.length; i < length; i++) {
+            block(#{::Opal::JS.from_js(`#{@native}[i]`)});
+          }
+        }
+
+        self
+      end
+
+      def to_a
+        ::Opal::JS.array_to_ruby(@native)
+      end
+
+      def <<(value)
+        push(value)
+        self
+      end
+
+      def push(*values)
+        values.each { |value| ::Opal::JS.array_push(@native, value) }
+        self
+      end
+
+      def pop
+        ::Opal::JS.array_pop(@native)
+      end
+
+      def shift
+        ::Opal::JS.array_shift(@native)
+      end
+
+      def unshift(*values)
+        values.reverse_each { |value| ::Opal::JS.array_unshift(@native, value) }
+        self
+      end
+    end
+  end
+end

--- a/stdlib/opal/js/wrapper_arguments.rb
+++ b/stdlib/opal/js/wrapper_arguments.rb
@@ -1,0 +1,80 @@
+# backtick_javascript: true
+# helpers: hash_each
+
+module ::Opal
+  module JS
+    class << self
+      def project_args(args, block, spec, kwargs_mode, name)
+        if spec.nil?
+          return args if block.nil? || `block == null`
+
+          return args + [block]
+        end
+
+        has_block = !block.nil? && `block != null`
+        positional = args.dup
+        kwargs = nil
+
+        if positional.last.is_a?(::Hash)
+          kwargs = positional.pop
+        end
+
+        if !kwargs.nil? && !spec.include?(:**)
+          raise ::ArgumentError, "keyword arguments are not projected for JS method `#{name}'"
+        end
+
+        if has_block && !spec.include?(:&)
+          raise ::ArgumentError, "block is not projected for JS method `#{name}'"
+        end
+
+        consumed = []
+        result = []
+
+        # Integer tokens must be reserved before :* expands remaining arguments.
+        spec.each do |token|
+          next unless token.is_a?(::Integer)
+
+          index = token < 0 ? positional.length + token : token
+          if index < 0 || index >= positional.length
+            raise ::ArgumentError, "missing argument index #{token} for JS method `#{name}'"
+          end
+
+          consumed << index
+        end
+
+        spec.each do |token| # rubocop:disable Style/CombinableLoops
+          case token
+          when :*
+            positional.each_with_index do |value, index|
+              result << value unless consumed.include?(index)
+            end
+          when :**
+            result << convert_kwargs(kwargs || {}, kwargs_mode)
+          when :&
+            result << block if has_block
+          when ::Integer
+            index = token < 0 ? positional.length + token : token
+            result << positional[index]
+          else
+            raise ::ArgumentError, "unsupported JS argument projection token `#{token.inspect}'"
+          end
+        end
+
+        result
+      end
+
+      def convert_kwargs(hash, mode)
+        return hash unless mode == :convert
+
+        %x{
+          var result = {}, source = hash;
+          $hash_each(source, false, function(key, value) {
+            result[#{camelize(`key`)}] = #{to_js(`value`)};
+            return [false, false];
+          });
+          return #{from_js(`result`)};
+        }
+      end
+    end
+  end
+end

--- a/stdlib/opal/js/wrapper_array.rb
+++ b/stdlib/opal/js/wrapper_array.rb
@@ -1,0 +1,51 @@
+# backtick_javascript: true
+
+module ::Opal
+  module JS
+    class << self
+      def array_push(native, value)
+        %x{
+          if (typeof #{native}.push === 'function') return #{native}.push(#{to_js(value)});
+          #{native}[#{native}.length] = #{to_js(value)};
+          #{native}.length += 1;
+          return #{native}.length;
+        }
+      end
+
+      def array_pop(native)
+        %x{
+          var value;
+          if (typeof #{native}.pop === 'function') return #{from_js(`#{native}.pop()`)};
+          if (#{native}.length <= 0) return nil;
+          value = #{native}[#{native}.length - 1];
+          delete #{native}[#{native}.length - 1];
+          #{native}.length -= 1;
+          return #{from_js(`value`)};
+        }
+      end
+
+      def array_shift(native)
+        %x{
+          var value;
+          if (typeof #{native}.shift === 'function') return #{from_js(`#{native}.shift()`)};
+          if (#{native}.length <= 0) return nil;
+          value = #{native}[0];
+          for (var i = 1; i < #{native}.length; i++) #{native}[i - 1] = #{native}[i];
+          delete #{native}[#{native}.length - 1];
+          #{native}.length -= 1;
+          return #{from_js(`value`)};
+        }
+      end
+
+      def array_unshift(native, value)
+        %x{
+          if (typeof #{native}.unshift === 'function') return #{native}.unshift(#{to_js(value)});
+          for (var i = #{native}.length; i > 0; i--) #{native}[i] = #{native}[i - 1];
+          #{native}[0] = #{to_js(value)};
+          #{native}.length += 1;
+          return #{native}.length;
+        }
+      end
+    end
+  end
+end

--- a/stdlib/opal/js/wrapper_dsl.rb
+++ b/stdlib/opal/js/wrapper_dsl.rb
@@ -1,0 +1,86 @@
+# backtick_javascript: true
+
+require 'opal/js/wrapper_access'
+require 'opal/js/wrapper_registry'
+require 'opal/js/wrapper_arguments'
+require 'opal/js/wrapper_array'
+
+module ::Opal
+  module JS
+    module Wrapper
+      def self.included(base)
+        base.extend ClassMethods
+        `base.$$prototype && (base.$$prototype.$$opal_js_wrapper = true)`
+      end
+
+      module ClassMethods
+        def wrap(value)
+          wrapper = allocate
+          wrapper.initialize_wrapped(value)
+          wrapper
+        end
+
+        def js_object
+          include ::Opal::JS::DynamicObjectAccess
+        end
+
+        def js_array
+          include ::Opal::JS::DynamicObjectAccess
+          include ::Opal::JS::ArrayAccess
+        end
+
+        def js_register_wrapper(constructor = nil, priority: 0, &block)
+          ::Opal::JS.register_wrapper(self, constructor, priority, block)
+        end
+
+        def js_constructor(constructor, args: nil, kwargs: nil)
+          ::Opal::JS.register_wrapper(self, constructor, 0, nil)
+          ::Opal::JS.register_constructor(self, constructor)
+
+          define_method(:initialize) do |*ruby_args, &block|
+            js_args = ::Opal::JS.project_args(ruby_args, block, args, kwargs, self.class.name)
+            initialize_wrapped(::Opal::JS.construct(::Opal::JS.to_js(constructor), js_args, nil))
+          end
+        end
+
+        def js_method(ruby_name, js_name = ruby_name, args: nil, kwargs: nil)
+          define_method(ruby_name) do |*ruby_args, &block|
+            js_args = ::Opal::JS.project_args(ruby_args, block, args, kwargs, ruby_name)
+            ::Opal::JS.call(self, js_name, *js_args)
+          end
+        end
+
+        def js_reader(ruby_name, js_name = ruby_name)
+          define_method(ruby_name) { self[js_name] }
+        end
+
+        def js_writer(ruby_name, js_name = ruby_name)
+          method_name = ruby_name.to_s.end_with?('=') ? ruby_name : "#{ruby_name}="
+          define_method(method_name) do |value|
+            self[js_name] = value
+          end
+        end
+
+        def js_accessor(ruby_name, js_name = ruby_name)
+          js_reader(ruby_name, js_name)
+          js_writer(ruby_name, js_name)
+        end
+      end
+
+      def initialize(native = nil)
+        initialize_wrapped(native) unless `#{native} === nil || #{native} == null`
+      end
+
+      def initialize_wrapped(value)
+        raise ::ArgumentError, 'wrapper is already initialized' if instance_variable_defined?(:@native)
+
+        @native = `#{value} != null && #{value}.$$opal_js_wrapper ? #{value}.$to_js() : #{value}`
+        self
+      end
+
+      def to_js
+        @native
+      end
+    end
+  end
+end

--- a/stdlib/opal/js/wrapper_registry.rb
+++ b/stdlib/opal/js/wrapper_registry.rb
@@ -1,0 +1,54 @@
+# backtick_javascript: true
+
+module ::Opal
+  module JS
+    class << self
+      def register_wrapper(klass, constructor = nil, priority = 0, block = nil)
+        %x{
+          Opal.JS.$$wrapper_registry.push({
+            klass: klass,
+            constructor: constructor == nil || constructor == null ? null : #{to_js(constructor)},
+            priority: priority,
+            block: block,
+            order: Opal.JS.$$wrapper_registry.length
+          });
+        }
+      end
+
+      def register_constructor(klass, constructor)
+        `klass.$$opal_js_constructor = #{to_js(constructor)}`
+      end
+
+      def wrapper_class_for(value)
+        %x{
+          var entries = Opal.JS.$$wrapper_registry, best = null;
+
+          for (var i = 0; i < entries.length; i++) {
+            var entry = entries[i], ctor = entry.constructor;
+            if (ctor == null) continue;
+            if (typeof ctor !== 'function') continue;
+            if (!(value instanceof ctor)) continue;
+
+            if (!best || entry.priority > best.priority || (entry.priority === best.priority && entry.order > best.order)) best = entry;
+          }
+
+          if (best) return best.klass;
+
+          for (var j = 0; j < entries.length; j++) {
+            var predicate = entries[j];
+            if (predicate.block === nil || predicate.block == null) continue;
+            if (predicate.block(value)) {
+              if (!best || predicate.priority > best.priority || (predicate.priority === best.priority && predicate.order > best.order)) best = predicate;
+            }
+          }
+
+          return best ? best.klass : nil;
+        }
+      end
+    end
+  end
+end
+
+%x{
+  Opal.JS.$$wrapper_registry = Opal.JS.$$wrapper_registry || []
+}


### PR DESCRIPTION
Introduce Opal::JS as the opt-in Ruby-facing interface for working with JavaScript values. The new stdlib entrypoint provides the $js global wrapper, live Object/Array/Function wrappers, explicit Ruby-to-JS and JS-to-Ruby boundary conversion, callback handling, stable wrapper/function identity, and conversion errors for unsupported or cyclic projections.
    
Add the Opal::JS::Wrapper DSL for typed JavaScript wrappers, including js_object, js_array, js_constructor, wrapper registration, js_method/js_accessor helpers, and argument projection for APIs that expect callbacks, rest args, and keyword option objects in a different order.
    
Expose Ruby values back to JavaScript through Opal.$ using a Proxy facade. The export side supports constant lookup, construction, method/setter dispatch, JS-facing reflection names, exact escapes through __send__/__const__, raw argument shaping through __send_raw__, callable member conversion back to Ruby, and Promise-friendly projection without exposing Ruby internals.
    
Document the beginner-facing Opal::JS workflow, wrapper patterns, and Opal.$ usage, and cover the new behavior with focused Opal stdlib specs plus stress cases for conversion cycles, reflection, wrapper registration, and argument shaping.
