### PR TITLE
Fix MissingRequire reporting in the threaded scheduler

### DIFF
--- a/lib/opal/builder/scheduler/threaded.rb
+++ b/lib/opal/builder/scheduler/threaded.rb
@@ -75,7 +75,11 @@ module Opal
                 args[:queue_mutex].synchronize do
                   exe[:continue] = false
                   exe[:busy] = 0
-                  args[:exception] = Builder::MissingRequire.new "A file required by #{rel_path.inspect} wasn't found.\n#{error.message}", error.backtrace
+                  # NOTE: `LoadError#initialize` only takes a message, so the
+                  # backtrace has to be assigned separately.
+                  args[:exception] = Builder::MissingRequire
+                                     .new("A file required by #{rel_path.inspect} wasn't found.\n#{error.message}")
+                                     .tap { |e| e.set_backtrace(error.backtrace) }
                 end
               rescue => error
                 args[:queue_mutex].synchronize do

--- a/spec/lib/builder_spec.rb
+++ b/spec/lib/builder_spec.rb
@@ -197,6 +197,31 @@ RSpec.describe Opal::Builder do
     end
   end
 
+  # Each scheduler builds its own MissingRequire, so they all have to report
+  # which file was missing. The threaded scheduler is only the default on JRuby
+  # and TruffleRuby, but it runs fine on CRuby, so these are not skipped there:
+  # that is the only way CI covers the branch at all.
+  describe 'reporting a missing require' do
+    def expect_missing_require_naming_the_file
+      expect { builder_with_paths.build('fixtures/missing_require_test') }
+        .to raise_error(Opal::Builder::MissingRequire, /this_file_does_not_exist/)
+    end
+
+    it 'names the missing file with a sequential scheduler' do
+      temporarily_with_sequential_scheduler { expect_missing_require_naming_the_file }
+    end
+
+    it 'names the missing file with a threaded scheduler' do
+      temporarily_with_threaded_scheduler { expect_missing_require_naming_the_file }
+    end
+
+    it 'names the missing file with a prefork scheduler' do
+      skip "Scheduler::Prefork not available for #{RUBY_ENGINE}" if %w[jruby truffleruby].include?(RUBY_ENGINE)
+      skip 'Scheduler::Prefork not available on Windows' if Opal::OS.windows?
+      temporarily_with_prefork_scheduler { expect_missing_require_naming_the_file }
+    end
+  end
+
   describe 'directory mode' do
     shared_examples 'directory mode' do
       let(:options) { {compiler_options: {directory: true, esm: esm?}}}

--- a/spec/lib/fixtures/missing_require_test.rb
+++ b/spec/lib/fixtures/missing_require_test.rb
@@ -1,0 +1,1 @@
+require 'this_file_does_not_exist'


### PR DESCRIPTION
On JRuby and TruffleRuby, a missing require reported `MissingRequire` with no message at all, hiding which file was actually missing.

## The bug

When a require fails, the threaded scheduler wraps the error to say which file pulled it in:

```ruby
Builder::MissingRequire.new "A file required by #{rel_path.inspect} wasn't found.\n#{error.message}", error.backtrace
```

`MissingRequire` inherits from `LoadError`, whose initializer takes only a message. Passing the backtrace as a second argument raises `ArgumentError: wrong number of arguments (given 2, expected 0..1)` — from *inside* the rescue block. The wrapped exception is never assigned to `args[:exception]`, and the build eventually surfaces a `MissingRequire` with an empty message instead.

So the diagnostic meant to name the missing file was the very thing that erased it.

Fixed by building the exception with the message alone and calling `set_backtrace` separately.

## Why it went unnoticed

Two things had to line up:

- The threaded scheduler is the default only on JRuby and TruffleRuby; CRuby uses prefork, so it never runs this file.
- No spec had ever made a require *fail* under threading. The existing scheduler specs all use requires that succeed, so this rescue branch had no coverage since it was added in cac026b52.

## A note on the specs

The new specs assert that every scheduler names the missing file. The threaded one deliberately does **not** skip on CRuby, unlike the existing `output order` spec above it. The scheduler runs correctly on CRuby — it is just not the default there — and skipping would leave the branch uncovered on the platform CI exercises by default, which is exactly how this survived.

The spec fails on master with `got #<ArgumentError: wrong number of arguments (given 2, expected 0..1)>` and passes with the fix.

## How to test

```sh
bundle exec rspec spec/lib/builder_spec.rb -e 'reporting a missing require'
```

---

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
