### PR TITLE
Stop restating Ruby versions in HACKING.md

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -2,9 +2,11 @@
 
 ## Prerequisites
 
-- **Ruby.** The gemspec requires `>= 2.3`, and CI covers 3.0 through 4.0 plus JRuby.
-  CI's `DEFAULT_RUBY` is **3.4**, so that is the version to develop against if you
-  want the closest match to the reference build.
+- **Ruby.** The minimum is set by `required_ruby_version` in
+  [`opal.gemspec`](opal.gemspec). To match the reference build, develop against
+  the `DEFAULT_RUBY` named in
+  [`.github/workflows/build.yml`](.github/workflows/build.yml); the same file's
+  matrix lists every version CI covers, including JRuby.
 - **Node.js** with `npm`. Needed for the Node-based spec runners and for the JS
   linting step. There is no pinned version; CI uses whatever its runner image ships.
 - **A browser**, if you intend to run the full suite. See


### PR DESCRIPTION
Follow-up to the review on #2793: the Prerequisites section of `HACKING.md` restated version numbers that live elsewhere in the repo.

It named the minimum Ruby (`>= 2.3`), the range CI covers (3.0 through 4.0), and the value of `DEFAULT_RUBY` (3.4). All three were accurate as of writing — and all three are copies. The first belongs to `required_ruby_version` in `opal.gemspec`, the other two to the matrix in `.github/workflows/build.yml`. A copied version number goes wrong eventually and gives the reader no way to tell when it did.

Points at the two files instead, so a reader who wants the number follows one link to a value that cannot disagree with the build.

## Testing

```sh
bin/rake docs:check  # 40 files link-checked, 36 markdown-linted, 0 errors
```

---

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
