### PR TITLE
Keep literal text preceding a %% escape in format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Changes are grouped as follows:
 
 - `String#{r,l,}strip`: Make them work like in MRI for non-breaking white-space ([#2612](https://github.com/opal/opal/pull/2612))
 - Compat regression fix: `Hash#to_n` should return a JS object ([#2613](https://github.com/opal/opal/pull/2613))
+- `Kernel#format`: Keep the literal text preceding a `%%` escape ([#2796](https://github.com/opal/opal/pull/2796))
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Changes are grouped as follows:
 - Compat regression fix: `Hash#to_n` should return a JS object ([#2613](https://github.com/opal/opal/pull/2613))
 - Bundle files named by `load`, so that `load` no longer needs a matching `require` to succeed ([#2629](https://github.com/opal/opal/issues/2629))
 - `Kernel#load` no longer adds the file to `$LOADED_FEATURES`, so a later `require` of the same path runs it again, like in MRI
+- `Kernel#format`: Keep the literal text preceding a `%%` escape ([#2796](https://github.com/opal/opal/pull/2796))
 
 ### Internal
 

--- a/opal/corelib/kernel/format.rb
+++ b/opal/corelib/kernel/format.rb
@@ -135,6 +135,11 @@ module ::Kernel
 
         switch (format_string.charAt(i)) {
         case '%':
+          // `begin_slice = i` points at the second `%`, so the next flush
+          // re-emits it as literal text. The run preceding the first `%` has
+          // not been flushed yet though, so it must be emitted here or moving
+          // `begin_slice` past it would discard it.
+          result += format_string.slice(begin_slice, end_slice);
           begin_slice = i;
           // no-break
         case '':

--- a/spec/opal/core/kernel/format_spec.rb
+++ b/spec/opal/core/kernel/format_spec.rb
@@ -1,0 +1,10 @@
+describe "Kernel#format" do
+  # https://github.com/opal/opal/issues/2758
+  it "keeps the literal text preceding a %% escape" do
+    format("foo %% %d", 100).should == "foo % 100"
+    format("foo %%").should == "foo %"
+    format("a%%b%%c").should == "a%b%c"
+    format("%%%%").should == "%%"
+    format("a%%%%%%b%dc", 3).should == "a%%%b3c"
+  end
+end


### PR DESCRIPTION
Fixes `Kernel#format` dropping the literal text that precedes a `%%` escape.

```ruby
format('foo %% %d', 100)  # => "% 100", MRI returns "foo % 100"
```

## Cause

`format` builds its result by accumulating slices of the format string, flushing the pending literal run whenever a directive is handled. The `%%` branch moves `begin_slice` forward to the second `%` so that it gets re-emitted as literal text — but it did so while `begin_slice` still pointed at a run that had not been flushed yet, discarding everything since the previous flush.

The neighbouring fallthrough branches also `continue` without flushing; they are harmless only because they leave `begin_slice` untouched, so a later flush still picks the pending run up.

## Scope

The damage scaled with the amount of text preceding an escape, so it reached further than the report suggests — consecutive escapes collapsed too, with `'%%%%'` returning `'%'` rather than `'%%'`.

Checked against MRI 3.4 over 25 format strings covering escapes at the start, in the middle and at the end of the string, consecutive escapes, and escapes combined with directives: 13 diverged before this change and none do after. The one remaining divergence, `format('%')` returning `'%'` where MRI raises `ArgumentError`, is unrelated and already tracked by a filter in `spec/filters/bugs/kernel.rb`.

`String#%` and `sprintf` reach the same implementation, so both are fixed as well.

## Notes

@janbiedermann pointed out in #2758 that this is already fixed by #2746, which is correct — that PR rewrites `format` as a port of MRI's `sprintf.c` and is structurally immune. The fix there is not separable from the rewrite though, so this is a self-contained fix for the current implementation, useful should a release land before #2746 merges. Happy to close it if you would rather just wait for 2.0.

## Test plan

- [x] New regression spec in `spec/opal/core/kernel/format_spec.rb`, verified red before the change and green after
- [x] `rake mspec_ruby_node` — 14619 examples, 0 failures, unchanged from master
- [x] `rake mspec_opal_node` — 685 examples, 0 failures
- [x] Upstream `kernel/{sprintf,format}_spec.rb` counts unchanged, nothing became unfiltered

---

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
