### PR TITLE
Bundle files named by a load call

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,3 +56,15 @@ codebase healthy.
 - Do not commit changes to external submodules such as `spec/ruby` or
   `spec/mspec`. Instead add new files under `spec/opal` so they remain within
   the `opal` namespace.
+- Loading a file is a two-sided contract. The compiler decides what gets
+  *bundled*: only the specials in `lib/opal/nodes/call/require.rb` call
+  `compiler.track_require`, and a path that is never tracked is simply absent
+  from `Opal.modules`, so it fails at runtime no matter how reachable the file
+  was at build time. The runtime in `opal/runtime/boot.js` then decides what
+  gets *run*. A new loading method needs both halves.
+- `load` deliberately diverges from `require` in two ways, so don't "fix" them:
+  it ignores dynamic arguments whatever `dynamic_require_severity` says (it is
+  routinely given runtime-computed paths, and the file is often bundled by a
+  separate `require`), and it only tracks receivers that can reach
+  `Kernel#load`, because `YAML.load`/`Marshal.load`/`JSON.load` take arguments
+  that are not paths.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Changes are grouped as follows:
 
 - `String#{r,l,}strip`: Make them work like in MRI for non-breaking white-space ([#2612](https://github.com/opal/opal/pull/2612))
 - Compat regression fix: `Hash#to_n` should return a JS object ([#2613](https://github.com/opal/opal/pull/2613))
+- Bundle files named by `load`, so that `load` no longer needs a matching `require` to succeed ([#2629](https://github.com/opal/opal/issues/2629))
 
 ### Internal
 

--- a/lib/opal/nodes/call/require.rb
+++ b/lib/opal/nodes/call/require.rb
@@ -12,6 +12,26 @@ module Opal
         compile_default.call
       end
 
+      # Bundle the file named by a #load call, the same way #require does.
+      # Without this the module is never emitted, so #load fails at runtime even
+      # though the file was perfectly reachable at build time.
+      #
+      # Unlike #require, #load is a common method name on other receivers
+      # (YAML.load, Marshal.load, JSON.load, ...) whose argument is not a path,
+      # so only a call that can reach Kernel#load is tracked.
+      #
+      # A dynamic argument is always ignored, whatever #dynamic_require_severity
+      # says: #load is routinely given paths computed at runtime, and the file is
+      # often bundled by a separate #require, so warning here would fire on
+      # perfectly correct code.
+      add_special :load do |compile_default|
+        next compile_default.call unless kernel_receiver?
+
+        str = DependencyResolver.new(compiler, arglist.children[0], :ignore).resolve
+        compiler.track_require str unless str.nil?
+        compile_default.call
+      end
+
       add_special :require_relative do
         arg = arglist.children[0]
         file = compiler.file
@@ -51,6 +71,15 @@ module Opal
         end
         @arglist = arglist.updated(nil, [first_arg] + rest)
         compile_default.call
+      end
+
+      # Whether the call could be dispatched to Kernel, i.e. it has no explicit
+      # receiver, or one that is `self`, `Kernel` or `::Kernel`.
+      def kernel_receiver?
+        recvr.nil? ||
+          recvr == s(:self) ||
+          recvr == s(:const, nil, :Kernel) ||
+          recvr == s(:const, s(:cbase), :Kernel)
       end
 
       class DependencyResolver

--- a/spec/lib/builder_spec.rb
+++ b/spec/lib/builder_spec.rb
@@ -40,6 +40,10 @@ RSpec.describe Opal::Builder do
     expect(builder_with_paths.build('fixtures/require_tree_test').to_s).to include('Opal.modules["fixtures/required_tree_test/required_file1"]')
   end
 
+  it 'bundles files named by #load calls' do
+    expect(builder_with_paths.build('fixtures/load_test').to_s).to include('Opal.modules["fixtures/no_requires"]')
+  end
+
   describe ':stubs' do
     let(:options) { {stubs: ['foo']} }
 
@@ -133,6 +137,17 @@ RSpec.describe Opal::Builder do
         expect(builder.missing_require_severity).to eq(:error)
         expect(builder).not_to receive(:warn)
         expect{ builder.build_str("require 'non-existen-file'", 'foo.rb') }.to raise_error(described_class::MissingRequire)
+      end
+
+      it 'raises MissingRequire for a missing #load too' do
+        expect{ builder.build_str("load 'non-existen-file'", 'foo.rb') }.to raise_error(described_class::MissingRequire)
+      end
+    end
+
+    context 'when set to :ignore and the file is #load-ed' do
+      let(:options) { {missing_require_severity: :ignore} }
+      it 'does nothing' do
+        expect{ builder.build_str("load 'non-existen-file'", 'foo.rb') }.not_to raise_error
       end
     end
   end

--- a/spec/lib/compiler_spec.rb
+++ b/spec/lib/compiler_spec.rb
@@ -162,6 +162,41 @@ RSpec.describe Opal::Compiler do
       end
     end
 
+    describe '#load' do
+      it 'parses and resolve #load argument' do
+        compiler = compiler_for(%Q{load "#{__FILE__}"})
+        expect(compiler.requires).to eq([__FILE__])
+      end
+
+      it 'parses and resolve #load argument when called on Kernel' do
+        compiler = compiler_for(%Q{Kernel.load "#{__FILE__}"})
+        expect(compiler.requires).to eq([__FILE__])
+      end
+
+      it 'parses and resolve #load argument when called on ::Kernel' do
+        compiler = compiler_for(%Q{::Kernel.load "#{__FILE__}"})
+        expect(compiler.requires).to eq([__FILE__])
+      end
+
+      it 'does not track #load called on an unrelated receiver' do
+        compiler = compiler_for(%q{YAML.load("---\nfoo")})
+        expect(compiler.requires).to eq([])
+      end
+
+      it 'does not track #load called on an unrelated receiver with a safe navigation operator' do
+        compiler = compiler_for(%q{YAML&.load("---\nfoo")})
+        expect(compiler.requires).to eq([])
+      end
+
+      it 'does not report a dynamic #load argument as a dynamic require' do
+        expect_any_instance_of(Opal::Compiler).not_to receive(:error)
+        expect_any_instance_of(Opal::Compiler).not_to receive(:warning)
+
+        compiler = compiler_for('load some_path', dynamic_require_severity: :error)
+        expect(compiler.requires).to eq([])
+      end
+    end
+
     describe '#autoload' do
       it 'parses and resolve second #autoload arguments in top scope' do
         compiler = compiler_for(%Q{autoload :Whatever, "#{__FILE__}"})

--- a/spec/lib/fixtures/load_test.rb
+++ b/spec/lib/fixtures/load_test.rb
@@ -1,0 +1,1 @@
+load 'fixtures/no_requires'


### PR DESCRIPTION
Fixes #2629.

`load 'foo'` raised `LoadError: cannot load such file` unless the same path had also been `require`d somewhere in the build, forcing users to track which files they had already required and switch between `require` and `load` accordingly.

## Cause

The compiler tracks `require`, `require_relative`, `autoload` and `require_tree` as build-time dependencies — each calls `compiler.track_require`, which is what makes the Builder emit the file into `Opal.modules`. It never tracked `load`. So `load 'foo'` compiled to a runtime `Opal.load('foo')` against a module the build had never emitted.

The runtime was never at fault. `Opal.load` already skips the `require_table` guard so it re-executes; it only needed the module to be present.

## Fix

A new `add_special :load` in `lib/opal/nodes/call/require.rb` that tracks the path the same way `require` does. Two design points worth a reviewer's attention:

**Receiver guard.** Unlike `require`, `load` is a common method name on other objects whose argument is not a path — `YAML.load`, `Marshal.load`, `JSON.load`. The existing `require` special ignores the receiver entirely; copying that naively would make `YAML.load("---\nfoo")` resolve the YAML document itself as a dependency path and break the build. A new `kernel_receiver?` predicate therefore limits tracking to receivers that can actually reach `Kernel#load`: none, `self`, `Kernel` and `::Kernel`. This follows the `recvr.nil?` idiom already used by `add_special :binding` and `:eval` in `lib/opal/nodes/call/eval.rb`.

**Dynamic arguments are always ignored**, regardless of `dynamic_require_severity`. `load` is routinely given paths computed at runtime, and the file is often bundled by a separate `require`, so reporting them would fire on perfectly correct code. This is an intentional divergence from `require`; no default changes.

## How to test

```ruby
# lib/loadme.rb
puts "hello from loaded file"

# main.rb
load 'loadme.rb'
```

```console
$ bin/opal -I lib main.rb
```

Before: `LoadError: cannot load such file -- loadme`. After: prints the message.

Re-execution semantics match CRuby exactly — calling `load` twice runs the file twice — and a bundled-but-not-yet-loaded file does not execute at boot, since only `compiler.load?` emits a self-executing tail and the Builder passes `load: false`.

## Verification

- `spec/lib`: 375 examples, 0 failures
- `bin/rake lint`: 326 files, no offenses
- `mspec_opal_nodejs`: 684 examples, 0 failures
- `mspec_ruby_nodejs`: 14619 examples, 0 failures
- `minitest_nodejs`: 208 runs, 0 failures, 0 errors
- Build output is byte-identical to master for `opal`, `opal/full`, `optparse`, `yaml` and `date` — the change adds nothing to existing bundles.

## Known, out of scope

`Opal.load_normalized` calls `Opal.loaded()`, which marks the path in `require_table`. So `load 'x'` followed by `require 'x'` makes the `require` a no-op, whereas CRuby re-executes it (`load` does not populate `$LOADED_FEATURES`). That is a pre-existing runtime bug in `boot.js` rather than something introduced here, though this fix does make it reachable — `load`-first was impossible before. A follow-up PR will be stacked on this one.

---

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
