### PR TITLE
Keep load out of $LOADED_FEATURES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Changes are grouped as follows:
 - `String#{r,l,}strip`: Make them work like in MRI for non-breaking white-space ([#2612](https://github.com/opal/opal/pull/2612))
 - Compat regression fix: `Hash#to_n` should return a JS object ([#2613](https://github.com/opal/opal/pull/2613))
 - Bundle files named by `load`, so that `load` no longer needs a matching `require` to succeed ([#2629](https://github.com/opal/opal/issues/2629))
+- `Kernel#load` no longer adds the file to `$LOADED_FEATURES`, so a later `require` of the same path runs it again, like in MRI
 
 ### Internal
 

--- a/opal/runtime/boot.js
+++ b/opal/runtime/boot.js
@@ -439,8 +439,10 @@
     }
   };
 
-  Opal.load_normalized = function(path) {
-    Opal.loaded([path]);
+  // `mark_as_loaded` defaults to true: every caller but Kernel#load wants the
+  // path recorded in $LOADED_FEATURES, so that a later #require is a no-op.
+  Opal.load_normalized = function(path, mark_as_loaded) {
+    if (mark_as_loaded !== false) Opal.loaded([path]);
 
     var module = Opal.modules[path];
 
@@ -467,10 +469,12 @@
     return true;
   };
 
+  // Kernel#load runs the file every time and, unlike #require, does not add it
+  // to $LOADED_FEATURES, so a later #require still executes it.
   Opal.load = function(path) {
     path = Opal.normalize(path);
 
-    return Opal.load_normalized(path);
+    return Opal.load_normalized(path, false);
   };
 
   Opal.require = function(path) {

--- a/spec/opal/core/runtime/load_spec.rb
+++ b/spec/opal/core/runtime/load_spec.rb
@@ -1,0 +1,48 @@
+# backtick_javascript: true
+
+describe 'Opal.load' do
+  before do
+    @path = 'opal/spec/fake_loaded_module'
+    `Opal.global.OPAL_SPEC_LOAD_RUNS = 0`
+    `Opal.modules[#{@path}] = function(Opal) { Opal.global.OPAL_SPEC_LOAD_RUNS++ }`
+  end
+
+  after do
+    `delete Opal.modules[#{@path}]`
+    `delete Opal.require_table[#{@path}]`
+    `delete Opal.global.OPAL_SPEC_LOAD_RUNS`
+    index = `Opal.loaded_features.indexOf(#{@path})`
+    `Opal.loaded_features.splice(#{index}, 1)` if index >= 0
+  end
+
+  def runs
+    `Opal.global.OPAL_SPEC_LOAD_RUNS`
+  end
+
+  it 'runs the module every time it is called' do
+    `Opal.load(#{@path})`
+    runs.should == 1
+
+    `Opal.load(#{@path})`
+    runs.should == 2
+  end
+
+  it 'does not mark the file as required' do
+    `Opal.load(#{@path})`
+    `(Opal.require_table[#{@path}] == null)`.should == true
+  end
+
+  it 'leaves a later Opal.require free to run the module again' do
+    `Opal.load(#{@path})`
+    `Opal.require(#{@path})`
+    runs.should == 2
+  end
+
+  it 'marks the file as required once Opal.require has run it' do
+    `Opal.require(#{@path})`
+    `(Opal.require_table[#{@path}] === true)`.should == true
+
+    `Opal.require(#{@path})`
+    runs.should == 1
+  end
+end


### PR DESCRIPTION
Stacked on #2797 — review that one first; this PR's diff is the last commit only.

`Kernel#load` marked the file as required, so a later `require` of the same path became a no-op. MRI does the opposite: `load` never populates `$LOADED_FEATURES`, so the `require` still runs the file.

```ruby
load 'side.rb'
puts "in $\": #{$LOADED_FEATURES.grep(/side/).any?}"
require 'side'
```

| | MRI | Opal before | Opal after |
|---|---|---|---|
| in `$"` after `load` | `false` | `true` | `false` |
| later `require` runs the file | yes | no | yes |

## Cause

`Opal.load_normalized` unconditionally called `Opal.loaded([path])`, which records the path in `require_table` and `loaded_features`. Both `Opal.load` and `Opal.require` go through it, so `load` inherited `require`'s bookkeeping.

## Fix

`load_normalized` takes an opt-out, and only `Opal.load` passes it. The argument defaults to marking the path, so the other three call sites — `Opal.require` and the CLI `-r` / runtime-mode tails emitted by `top.rb` — keep deduplicating exactly as before. Verified that `-r side` combined with an explicit `require "side"` still runs the file once.

This was pre-existing, but only became reachable once #2797 let a `load`-first path be bundled at all.

## Verification

- `mspec_opal_nodejs`: 688 examples, 0 failures (4 new; 2 of them fail without this change)
- `mspec_ruby_nodejs`: 14619 examples, 0 failures
- `minitest_nodejs`: 208 runs, 0 failures, 0 errors
- `spec/lib`: 467 examples, 0 failures
- `bin/rake lint`: 326 files, no offenses

---

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
