### PR TITLE
Don't rely on block.length alone for auto-splat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Changes are grouped as follows:
 - `Kernel#load` no longer adds the file to `$LOADED_FEATURES`, so a later `require` of the same path runs it again, like in MRI
 - `Kernel#format`: Keep the literal text preceding a `%%` escape ([#2796](https://github.com/opal/opal/pull/2796))
 - Resolve requires with a leading `./`, against `Builder#cwd` when set and through the load path otherwise. The CLI sets it to the working directory, as in MRI ([#778](https://github.com/opal/opal/issues/778))
+- Blocks no longer rely solely on the JS `length` of their function to decide whether a yielded array should be auto-splatted, which broke after minification dropped unused trailing parameters ([#2525](https://github.com/opal/opal/issues/2525))
 
 ### Internal
 

--- a/opal/runtime/proc.rb
+++ b/opal/runtime/proc.rb
@@ -41,6 +41,27 @@ module ::Opal
     }
   end
 
+  # Number of parameters a block declares, used to decide whether a single
+  # yielded array should be auto-splatted.
+  #
+  # NOTE: `block.length` is the accurate count, but a JS minifier may drop
+  # trailing unused parameters (as generated for a bare splat, `{ |x, *| }`),
+  # making it under-report. `$$arity` survives minification, so it is used as a
+  # lower bound. It cannot replace `length` outright: for a block taking only
+  # optional args, `{ |a=1, b=2| }` has an arity of -1 but declares 2 params.
+  def self.block_length(block)
+    %x{
+      var length = block.length;
+
+      if (typeof block.$$arity === 'number') {
+        var from_arity = Math.abs(block.$$arity);
+        if (from_arity > length) length = from_arity;
+      }
+
+      return length
+    }
+  end
+
   # handles yield calls for 1 yielded arg
   def self.yield1(block, arg)
     %x{
@@ -50,13 +71,16 @@ module ::Opal
 
       var has_mlhs = block.$$has_top_level_mlhs_arg,
           has_trailing_comma = block.$$has_trailing_comma_in_args,
-          is_returning_lambda = block.$$is_lambda && block.$$ret;
+          is_returning_lambda = block.$$is_lambda && block.$$ret,
+          // NOTE: $$arity is authoritative: a JS minifier is free to drop trailing
+          // unused parameters, which would silently shrink block.length.
+          length = Opal.block_length(block);
 
-      if (block.length > 1 || ((has_mlhs || has_trailing_comma) && block.length === 1)) {
+      if (length > 1 || ((has_mlhs || has_trailing_comma) && length === 1)) {
         arg = Opal.to_ary(arg);
       }
 
-      if ((block.length > 1 || (has_trailing_comma && block.length === 1)) && arg.$$is_array) {
+      if ((length > 1 || (has_trailing_comma && length === 1)) && arg.$$is_array) {
         if (is_returning_lambda) {
           return call_lambda(block.apply.bind(block, null), arg, block.$$ret);
         }
@@ -78,7 +102,7 @@ module ::Opal
         $raise(Opal.LocalJumpError, "no block given");
       }
 
-      if (block.length > 1 && args.length === 1) {
+      if (Opal.block_length(block) > 1 && args.length === 1) {
         if (args[0].$$is_array) {
           args = args[0];
         }

--- a/spec/opal/core/runtime/block_length_spec.rb
+++ b/spec/opal/core/runtime/block_length_spec.rb
@@ -1,0 +1,26 @@
+# backtick_javascript: true
+
+describe 'Opal.block_length' do
+  # A JS minifier is free to drop trailing unused parameters, which shrinks the
+  # function's `length`. `$$arity` survives that, so it is used as a lower bound.
+  it 'falls back to $$arity when the function length under-reports' do
+    block = proc { |x, *| x }
+    minified = `function(x) { return #{block}.apply(null, arguments) }`
+    `#{minified}.$$arity = #{block}.$$arity`
+
+    `Opal.block_length(#{minified})`.should == 2
+  end
+
+  it 'prefers the function length when it exceeds the absolute arity' do
+    # `{ |a=1, b=2| }` has an arity of -1 but declares two parameters.
+    `Opal.block_length(#{proc { |_a = 1, _b = 2| }})`.should == 2
+  end
+
+  it 'reports a single parameter for a lone splat' do
+    `Opal.block_length(#{proc { |*a| a }})`.should == 1
+  end
+
+  it 'auto-splats a yielded array for a block with a trailing bare splat' do
+    [[1, 2], [3, 4]].collect { |x, *| x }.should == [1, 3]
+  end
+end


### PR DESCRIPTION
Fixes #2525.

## What

`Opal.yield1` and `Opal.yieldX` used the JS `length` of a block's function to decide whether a single yielded array should be splatted into the block's parameters. A minifier is free to drop trailing unused parameters — such as the one generated for a bare splat in `{ |x, *| x }` — which shrinks `length` and silently disables the splat:

```ruby
[[1, 2], [3, 4]].collect { |x, *| x }
# MRI and unminified Opal => [1, 3]
# minified Opal           => [[1, 2], [3, 4]]
```

A new `Opal.block_length` helper takes the larger of `block.length` and `Math.abs(block.$$arity)`. `$$arity` survives minification, but it can't replace `length` outright: a block taking only optional arguments, `{ |a=1, b=2| }`, has an arity of `-1` while declaring two parameters.

Note the issue predates the current runtime and proposed `Math.abs(block.$$arity || block.length)`; that form regresses the all-optional case above, hence the max.

## Why

Reported in #2525 (2015). Still reproducible on `master` — `$$arity` is still set by `apply_blockopts`, and both yield helpers still read `block.length`.

## How to test

`bundle exec rake mspec_node` — green, with 4 new examples in `spec/opal/core/runtime/block_length_spec.rb`.

To see the original bug, compile a block with a bare splat and drop its unused trailing parameter, simulating a minifier:

```console
$ bundle exec bin/opal -c -e 'p [[1,2],[3,4]].collect { |x, *| x }' > t.js
$ ruby -e 'File.write("t2.js", File.read("t.js").sub(/function \$\$1\(x, \$a\)/, "function $$1(x)"))'
$ node t2.js
[1, 3]   # before this change: [[1, 2], [3, 4]]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)